### PR TITLE
Redirect Flask redirects back to custom domain.

### DIFF
--- a/.platform/nginx/conf.d/redirects.conf
+++ b/.platform/nginx/conf.d/redirects.conf
@@ -1,0 +1,4 @@
+server {
+    server_name .elasticbeanstalk.com;
+    return 301 https://earthmaps.io$request_uri;
+}


### PR DESCRIPTION
Related to #21.

Yesterday, I moved the data-api Elastic Beanstalk instance behind a CloudFront distribution to set up HTTPS, and changed Route 53 to point to the CloudFront distribution instead of directly to the Elastic Beanstalk instance. So, the server infrastructure changed from this:

Route 53 → Elastic Beanstalk

To this:

Route 53 → CloudFront → Elastic Beanstalk

Almost everything is working as intended, but whenever there is a case where the data-api Flask application needs to perform a redirect, it is redirecting to the Elastic Beanstalk domain (testing.eba-hkca5w5b.us-west-2.elasticbeanstalk.com instead of the custom (eathmaps.io) domain.

Currently the Flask application is set to force routes to have a trailing slash. So, for example, this URL loads just fine and retains the custom (earthmaps.io) domain in the browser address bar:

https://earthmaps.io/permafrost/

But if you access the same URL without a trailing slash, the wrong domain shows up in the address bar (you may need to use a different browser or private window to test this since browsers are pretty aggressive about caching things like this):

https://earthmaps.io/permafrost

It looks like the way to fix this is to override Amazon Linux 2's default NGINX behavior, which is what this PR is doing. It's hard to test this without merging & deploying this to the Elastic Beanstalk instance, so I suggest we do that.

More information about overriding Amazon Linux 2's default NGINX configuration can be found here:

https://stackoverflow.com/a/63801963
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/platforms-linux-extend.html