### PR TITLE
expand eastern bounding box

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,4 +8,4 @@ RAS_BASE_URL = (
     os.getenv("API_RAS_BASE_URL") or "http://zeus.snap.uaf.edu:8080/rasdaman/"
 )
 WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
-EAST_BBOX = [179.7607, 51.3492, 180, 71.3694]
+EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]


### PR DESCRIPTION
This PR is a slight modification of the bounding box used to validate queries and should prevent queries for Attu, Shemya, Eareckson, etc. from throwing out-of-bounds errors.

Closes #75 