### PR TITLE
Support partial nodata pruning and remove deeply nested nulls from permafrost output

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -258,7 +258,7 @@ def run_point_fetch_all_permafrost(lat, lon):
         "obupfx": package_obu_vector(gs_results[2]),
     }
 
-    return postprocess(data, "permafrost", titles)
+    return postprocess(data, "permafrost", titles, 2)
 
 
 @routes.route("/permafrost/huc/<huc_id>")

--- a/validate_data.py
+++ b/validate_data.py
@@ -9,7 +9,7 @@ nodata_values = {
     "mean_annual_precip": [-9999],
     "permafrost": [-9999, -9999.0],
     "physiography": [],
-    "taspr": [-9999, -9.223372e+18, -9.223372036854776e+18],
+    "taspr": [-9999, -9.223372e18, -9.223372036854776e18],
 }
 
 


### PR DESCRIPTION
Closes #88.

This PR allows us to partially prune data responses. Without this PR, we are using the `prune_nodata` function to detect when a response object is missing data entirely (in which case we return a 404). But if the response object is a hybrid of data & nodata, as is common with permafrost queries, we respond with a hybrid object where the nodata fields are set to `null`. However, this approach has the problem of returning responses like this, where the GIPL data is `nulled`ed out while retaining a deeply nested structure:

https://earthmaps.io/permafrost/point/64.5011/-165.406

This creates needless complexity for the web app code to decipher.

This PR allows us to partially prune the data response object to a specified prune depth, so we get this:

```
{
  "gipl": null,
  "jorg": {
    "ice": "Variable",
    "pfx": "Discontinuous",
    "title": "Jorgenson et al. (2008) Permafrost Extent and Ground Ice Volume"
  },
  "obu_magt": {
    "depth": "Top of Permafrost",
    "temp": 0.7,
    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (°C)",
    "year": "2000-2016"
  },
  "obupfx": {
    "pfx": "Sporadic",
    "title": "Obu et al. (2018) Permafrost Extent"
  }
}
```

Instead of this:

```
{
  "gipl": {
    "1995": {
      "cruts31": {
        "historical": {
          "alt": null,
          "magt": null
        }
      }
    },
    "2025": {
      "gfdlcm3": {
        "rcp45": {
          "alt": null,
          "magt": null
        },
        "rcp85": {
          "alt": null,
          "magt": null
        }
      },
      "gisse2r": {
        "rcp45": {
          "alt": null,
          "magt": null
        },
        "rcp85": {
          "alt": null,
          "magt": null
        },
      ...
    ...
  }
  "jorg": {
    "ice": "Variable",
    "pfx": "Discontinuous",
    "title": "Jorgenson et al. (2008) Permafrost Extent and Ground Ice Volume"
  },
  "obu_magt": {
    "depth": "Top of Permafrost",
    "temp": 0.7,
    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (°C)",
    "year": "2000-2016"
  },
  "obupfx": {
    "pfx": "Sporadic",
    "title": "Obu et al. (2018) Permafrost Extent"
  }
}
```

To test this PR, try loading the local version of the same URL to make sure it matches the expected output above:

http://localhost:5000/permafrost/point/64.5011/-165.406