### PR TITLE
Fix HUC DEM errors and remove HUC class fragment from HUC endpoint

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -100,6 +100,8 @@ async def make_get_request(url, session):
         data = await resp.json()
     elif "application/netcdf" in url:
         data = await resp.read()
+    elif "GeoTIFF" in url:
+        data = await resp.read()
     elif "DescribeCoverage" in url:
         # DescribeCoverage in URL ==> XML coming back
         data = await resp.text()

--- a/routes/boundary.py
+++ b/routes/boundary.py
@@ -50,12 +50,7 @@ def protectedarea_about():
 @routes.route("/boundary/huc/")
 @routes.route("/boundary/huc/abstract/")
 def huc_about():
-    return render_template("boundary/huc/abstract.html")
-
-
-@routes.route("/boundary/huc/huc8/")
-def huc8_about():
-    return render_template("boundary/huc/huc8.html")
+    return render_template("boundary/huc.html")
 
 
 @routes.route("/boundary/climatedivision/<cd_id>")
@@ -150,24 +145,24 @@ def run_fetch_firemanagement_poly(fire_id):
     return poly_geojson
 
 
-@routes.route("/boundary/huc/huc8/<huc8_id>")
-def run_fetch_huc_poly(huc8_id):
+@routes.route("/boundary/huc/<huc_id>")
+def run_fetch_huc_poly(huc_id):
     """Run the async requesting for a HUC polygon and return the GeoJSON.
 
     Args:
-        huc8_id (int): HUC-8 ID
+        huc_id (int): The HUC ID, only HUC-8 ID supported for now
 
     Returns:
-        GeoJSON of the HUC-8 polygon
+        GeoJSON of the HUC polygon
 
     Notes:
-        example: http://localhost:5000/boundary/huc/huc8/19070506
+        example: http://localhost:5000/boundary/huc/19070506
     """
-    validation = validate_polyid(huc8_id)
+    validation = validate_polyid(huc_id)
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     try:
-        poly = huc8_gdf.loc[[huc8_id]].to_crs(4326)
+        poly = huc8_gdf.loc[[huc_id]].to_crs(4326)
     except:
         return render_template("422/invalid_huc.html"), 422
     poly_geojson = poly.to_json()

--- a/templates/boundary/huc.html
+++ b/templates/boundary/huc.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>HUC data</h3>
+<p>This endpoint returns a GeoJSON of the HUC boundaries used across SNAP tools and data. Currently, only HUC-8 codes are available. </p>
+<h4>Service Endpoint</h4>
+The endpoint is <code>boundary/huc/&lthuc_id></code> for all available HUC codes.
+<ul>
+    <li>Example HUC-8 query: <a href="/boundary/huc/19070506">/boundary/huc/19070506</a></li>
+</ul>
+{% endblock %}

--- a/templates/boundary/huc/abstract.html
+++ b/templates/boundary/huc/abstract.html
@@ -1,9 +1,0 @@
-{% extends 'base.html' %}
-{% block content %}
-<h3>HUC data</h3>
-<p>These data are intended for exposing the HUC boundaries used across SNAP tools and data.</p>
-<h4>Service Endpoints</h4>
-<ul>
-    <li><a href="/boundary/huc/huc8">HUC-8 Polygon</a>: HUC-8 polygon of Alaska, as GeoJSON</li>
-</ul>
-{% endblock %}

--- a/templates/boundary/huc/huc8.html
+++ b/templates/boundary/huc/huc8.html
@@ -1,6 +1,0 @@
-{% extends 'base.html' %}
-{% block content %}
-<h3>HUC-8 Polygon Query</h3>
-<p>Query the HUC-8 polygons of Alaska and return a GeoJSON string of the polygon.</p>
-<p>Example: <a href="/boundary/huc/huc8/19070506">/boundary/huc8/19070506</a></p>
-{% endblock %}


### PR DESCRIPTION
This PR makes a small change to fix an error with the `elevation/huc` endpoint that was caused by failure to account for a new format returned through a WCS request: GeoTIFF!

To test, try some of the following endpoints that return an internal server error on the live API:

[http://localhost:5000/elevation/huc/19010208](http://localhost:5000/elevation/huc/19010208)
[http://localhost:5000/elevation/huc/19070506](http://localhost:5000/elevation/huc/19070506)
[http://localhost:5000/elevation/protectedarea/NPS7](http://localhost:5000/elevation/protectedarea/NPS7)
[http://localhost:5000/elevation/protectedarea/NPS5](http://localhost:5000/elevation/protectedarea/NPS5)

This PR also makes a change to remove the HUC class fragment from the HUC boundary endpoint, e.g. the `/huc8/` in `/boundary/huc/huc8/`. To test, try some of the HUC boundary endpoints:

[http://localhost:5000/boundary/huc/19010208](http://localhost:5000/boundary/huc/19010208)
[http://localhost:5000/boundary/huc/19070506](http://localhost:5000/boundary/huc/19070506)

Closes #106 #107 