### PR TITLE
Increases the Elastic Beanstalk timeout to 300 seconds

### DIFF
--- a/.platform/nginx/conf.d/timeouts.conf
+++ b/.platform/nginx/conf.d/timeouts.conf
@@ -1,0 +1,3 @@
+proxy_connect_timeout 600s;
+proxy_send_timeout 600s; 
+proxy_read_timeout 600s;


### PR DESCRIPTION
This allows for the Nginx configuration that hosts the API to have a timeout of 300 seconds to allow for many 502 / 504 errors to be eliminated. Without this configuration change, we get a lot of timeouts (502s / 504s) when querying larger protected areas and HUCs.