### PR TITLE
Preserve keys for null values if any sibling contains data in pruned response

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -258,7 +258,7 @@ def run_point_fetch_all_permafrost(lat, lon):
         "obupfx": package_obu_vector(gs_results[2]),
     }
 
-    return postprocess(data, "permafrost", titles, 2)
+    return postprocess(data, "permafrost", titles)
 
 
 @routes.route("/permafrost/huc/<huc_id>")


### PR DESCRIPTION
Closes #120.

This PR changes the way that our response pruning algorithm works. In the current main branch, the pruning function allows us to set the minimum pruning depth so that certain keys are preserved even if they have a null value. Keeping certain keys intact makes it easier to handle the data on the client-side without inspecting the structure of the entire JSON object.

For example, we want the "gipl" key (and "jorg" and "obupfx" keys) to be preserved in the following response even though they have null values:

https://earthmaps.io/permafrost/point/52.9025/172.909444

The downside to this approach is that the pruning algorithm is too aggressive at higher nesting depths. For example, we want the "alt" key to be preserved in this response even though the alt values are null:

https://earthmaps.io/permafrost/point/61.0628/-147.1627

Since there is no obvious way to set two separate pruning depths simultaneously, a different approach is needed. Fortunately, a pattern is emerging here: We want to preserve JSON keys for null values if any of the sibling keys have non-null data. This PR implements this functionality and removes the unnecessary minimum-prune-depth feature to simplify the code considerably.

Testing:

The following URL should have keys for gipl, jorg, and obupfx even though they have null values:
https://earthmaps.io/permafrost/point/52.9025/172.909444
http://localhost:5000/permafrost/point/52.9025/172.909444

The following URL should have gipl "alt" keys even though they are all set to null:
https://earthmaps.io/permafrost/point/59.24/-135.51
http://localhost:5000/permafrost/point/59.24/-135.51

All other API URLs should continue to work as before!