### PR TITLE
Convert elevation nodata to null in JSON response

### DIFF
--- a/routes/elevation.py
+++ b/routes/elevation.py
@@ -15,7 +15,7 @@ from validate_request import (
     validate_huc,
     validate_akpa,
 )
-from validate_data import get_poly_3338_bbox
+from validate_data import get_poly_3338_bbox, postprocess
 from config import GS_BASE_URL, WEST_BBOX, EAST_BBOX
 from luts import huc_gdf, akpa_gdf
 from . import routes
@@ -111,7 +111,7 @@ def run_fetch_elevation(lat, lon):
         return render_template("500/server_error.html"), 500
 
     elevation = package_astergdem(results)
-    return elevation
+    return postprocess(elevation, "elevation")
 
 
 @routes.route("/elevation/huc/<huc_id>")
@@ -145,7 +145,7 @@ def run_huc_fetch_all_elevation(huc_id):
     with rio.open(asyncio.run(fetch_bbox_geotiff_from_gs([url]))) as src:
         huc_pkg = package_zonal_stats(src, poly)
 
-    return huc_pkg
+    return postprocess(huc_pkg, "elevation")
 
 
 @routes.route("/elevation/protectedarea/<akpa_id>")
@@ -180,4 +180,4 @@ def run_protectedarea_fetch_all_elevation(akpa_id):
     with rio.open(asyncio.run(fetch_bbox_geotiff_from_gs([url]))) as src:
         pa_pkg = package_zonal_stats(src, poly)
 
-    return pa_pkg
+    return postprocess(pa_pkg, "elevation")

--- a/validate_data.py
+++ b/validate_data.py
@@ -2,6 +2,8 @@
 from flask import render_template
 
 nodata_values = {
+    "alfresco": [-9999],
+    "elevation": [-9999],
     "fire": [-9999],
     "forest": [65535],
     "geology": [],
@@ -10,7 +12,6 @@ nodata_values = {
     "permafrost": [-9999, -9999.0],
     "physiography": [],
     "taspr": [-9999, -9.223372e18, -9.223372036854776e18],
-    "alfresco": [-9999],
 }
 
 


### PR DESCRIPTION
Closes #125.

This PR is dependent on #133, so I'm setting this PR as a draft until #133 is merged.

To test, compare this URL between production and the `elevation_nodata` branch running locally:

https://earthmaps.io/elevation/point/68.55/-174.88
http://localhost:5000/elevation/point/68.55/-174.88

Instead of this:

```
{
  "max": -9999,
  "mean": -9999,
  "min": -9999,
  "res": "1 kilometer",
  "title": "ASTER Global Digital Elevation Model",
  "units": "meters difference from sea level"
}
```

You should see this:

```
{
  "max": null,
  "mean": null,
  "min": null,
  "res": "1 kilometer",
  "title": "ASTER Global Digital Elevation Model",
  "units": "meters difference from sea level"
}
```
