### PR TITLE
Add new vegetation type (aka veg_type) endpoint that returns each vegetation type as a percentage

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -181,6 +181,10 @@ async def fetch_bbox_netcdf_list(urls):
     """
     start_time = time.time()
     netcdf_bytes_list = await fetch_data(urls)
+
+    if not isinstance(netcdf_bytes_list, list):
+        netcdf_bytes_list = [netcdf_bytes_list]
+
     app.logger.info(
         f"Fetched BBOX data from Rasdaman, elapsed time {round(time.time() - start_time)}s"
     )

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -484,7 +484,7 @@ def csv_metadata(place_name, place_id, place_type, lat=None, lon=None):
     Creates metadata string to add to beginning of CSV file.
 
     Args:
-        place_name (str): Name of the place, None of just lat/lon
+        place_name (str): Name of the place, None if just lat/lon
         place_id (str): place identifier (e.g., AK124)
         place_type (str): point or area
         lat: latitude for points or None for polygons
@@ -496,6 +496,9 @@ def csv_metadata(place_name, place_id, place_type, lat=None, lon=None):
     metadata = "# Location: "
     if place_name is None:
         metadata += lat + " " + lon + "\n"
+        # if lat and lon and type huc12, then it's a local / point-to-huc query
+        if place_type == "huc12":
+            metadata += "# Corresponding HUC12 code: " + place_id + "\n"
     elif place_type == "communities":
         metadata += place_name + "\n"
     else:

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -495,7 +495,7 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
 
     metadata = csv_metadata(place_name, place_id, place_type, lat, lon)
 
-    if var_ep in "flammability":
+    if var_ep == "flammability":
         metadata += "# rf is relative flammability in number of pixels burned\n"
         metadata += "# mean is the mean of of annual means\n"
     elif var_ep == "veg_change":

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -202,7 +202,8 @@ def package_ar5_alf_point_data(point_data, varname):
                         veg_type = veg_type.lower()
                         veg_type = veg_type.replace(" ", "_")
                         veg_type = veg_type.replace("/", "_")
-                        point_data_pkg[era][model][scenario][veg_type] = {varname: value}
+                        percent = round(value * 100, 2)
+                        point_data_pkg[era][model][scenario][veg_type] = {varname: percent}
 
     if varname == "vt":
         eras = list(dim_encodings["era"].values())
@@ -420,10 +421,14 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
         CSV response object
     """
     varname = var_ep_lu[var_ep]["varname"]
+    if var_ep == "flammability":
+        fieldnames = flammability_fieldnames
+    elif var_ep == "veg_type":
+        fieldnames = veg_type_fieldnames
     csv_dicts = build_csv_dicts(
         data_pkg,
-        flammability_fieldnames,
-        {"variable": varname, "stat": "mean"},
+        fieldnames,
+        {"variable": varname, "stat": "percent"},
     )
 
     place_name, place_type = place_name_and_type(place_id)
@@ -442,7 +447,7 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
     else:
         filename = var_label_lu[var_ep] + " for " + lat + ", " + lon + ".csv"
 
-    return write_csv(csv_dicts, flammability_fieldnames, filename, metadata)
+    return write_csv(csv_dicts, fieldnames, filename, metadata)
 
 
 @routes.route("/alfresco/")
@@ -505,14 +510,14 @@ def run_fetch_alf_point_data(var_ep, lat, lon):
 
     if var_ep in var_ep_lu.keys():
         cov_id_str = var_ep_lu[var_ep]["cov_id_str"]
-        try:
-            point_data_list = asyncio.run(fetch_alf_point_data(x, y, cov_id_str))
-        except Exception as exc:
-            if hasattr(exc, "status") and exc.status == 404:
-                return render_template("404/no_data.html"), 404
-            return render_template("500/server_error.html"), 500
-    else:
-        return render_template("400/bad_request.html"), 400
+        #try:
+        point_data_list = asyncio.run(fetch_alf_point_data(x, y, cov_id_str))
+        # except Exception as exc:
+        #     if hasattr(exc, "status") and exc.status == 404:
+        #         return render_template("404/no_data.html"), 404
+        #     return render_template("500/server_error.html"), 500
+    # else:
+    #     return render_template("400/bad_request.html"), 400
 
     varname = var_ep_lu[var_ep]["varname"]
     if var_ep == "flammability":

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -467,10 +467,9 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
 
     if var_ep == "flammability":
         metadata += "# rf is relative flammability in number of pixels burned\n"
+        metadata += "# mean is the mean of of annual means\n"
     elif var_ep == "veg_type":
-        metadata += "# rvc is relative vegetation change in number of pixels that changed dominant vegetation type\n"
-
-    metadata += "# mean is the mean of of annual means\n"
+        metadata += "# vt is dominant vegetation type as a percentage of coverage\n"
 
     if place_name is not None:
         filename = var_label_lu[var_ep] + " for " + quote(place_name) + ".csv"

--- a/templates/alfresco/abstract.html
+++ b/templates/alfresco/abstract.html
@@ -26,6 +26,12 @@
     <td>Relative Vegetation Change</td>
     <td>These data are derived from the vegetation class data, the principal phenomena being modeled by ALFRESCO. They are computed as the average number of year-to-year transitions of any vegetation class for a pixel, across all reps for all years of the summary year span. Pixels are 1km x 1km.</td>
   </tr>
+  <tr>
+    <td>veg_type</td>
+    <td>vt</td>
+    <td>Vegetation Type</td>
+    <td>These data are derived from the vegetation class data, the principal phenomena being modeled by ALFRESCO. They are computed as the average percentage of each vegetation type for a pixel, across all reps for all years of the summary year span. Pixels are 1km x 1km.</td>
+  </tr>
 </tbody>
 </table>
 

--- a/templates/alfresco/area.html
+++ b/templates/alfresco/area.html
@@ -6,6 +6,7 @@
 <ul>
     <li>Relative flammability: <a href="/alfresco/flammability/area/19080309">/alfresco/flammability/area/19080309</a></li>
     <li>Relative vegetation change: <a href="/alfresco/veg_change/area/19080309">/alfresco/veg_change/area/19080309</a></li>
+    <li>Vegetation type: <a href="/alfresco/veg_type/area/19080309">/alfresco/veg_type/area/19080309</a></li>
 </ul>
 <h4>CSV Export</h4>
 <p>To export the aggregated HUC data in a CSV file, append <code>?format=csv</code>.</p>

--- a/templates/alfresco/local.html
+++ b/templates/alfresco/local.html
@@ -6,6 +6,7 @@
 <ul>
     <li>Relative flammability: <a href="/alfresco/flammability/local/65.4844/-145.4036">/alfresco/flammability/local/65.4844/-145.4036</a></li>
     <li>Relative vegetation change: <a href="/alfresco/veg_change/local/65.4844/-145.4036">/alfresco/veg_change/local/65.4844/-145.4036</a></li>
+    <li>Vegetation type: <a href="/alfresco/veg_type/local/65.4844/-145.4036">/alfresco/veg_type/local/65.4844/-145.4036</a></li>
 </ul>
 <h4>CSV Export</h4>
 <p>To export the local data in a CSV file, append <code>?format=csv</code>.</p>

--- a/templates/alfresco/point.html
+++ b/templates/alfresco/point.html
@@ -6,6 +6,7 @@
 <ul>
     <li>Relative flammability: <a href="/alfresco/flammability/point/65.0628/-146.1627">/alfresco/flammability/point/65.0628/-146.1627</a></li>
     <li>Relative vegetation change: <a href="/alfresco/veg_change/point/65.0628/-146.1627">/alfresco/veg_change/point/65.0628/-146.1627</a></li>
+    <li>Vegetation type: <a href="/alfresco/veg_type/point/65.0628/-146.1627">/alfresco/veg_type/point/65.0628/-146.1627</a></li>
 </ul>
 <h4>CSV Export</h4>
 <p>To export the  data in a CSV file, append <code>?format=csv</code>.</p>

--- a/validate_data.py
+++ b/validate_data.py
@@ -1,5 +1,6 @@
 """A module to validate fetched data values."""
 import json
+import re
 from flask import render_template
 from luts import json_types
 
@@ -179,6 +180,10 @@ def place_name_and_type(place_id):
 
     if place_id is None:
         return None, None
+
+    # HUC12s, not getting names from them below
+    if (not re.search("[^0-9]", place_id)) and (len(place_id) == 12):
+        return None, "huc12"
 
     place_types = list(json_types.keys())
     place_types.remove("hucs")


### PR DESCRIPTION
To test, use the new `veg_type` endpoint for any lat/lon or area query that works for the existing ALFRESCO endpoints (`flammability` and `veg_change`):

http://localhost:5000/alfresco/veg_type/

This new endpoint can use some better documentation and example output. This has been captured in #154.