### PR TITLE
Use new flammability coverage with precomputed eras, streamline ALFRESCO output, and fix polygon mask shape mismatches

### DIFF
--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -37,36 +37,24 @@ from . import routes
 alfresco_api = Blueprint("alfresco_api", __name__)
 
 
-# These are the encoded coordinate values for the "era" axis of the
-# rasdaman coverages being queried here. Each tuple contains the first
-# and last coordinate for creating WCPS query to average over them.
-# E.g., (3,5) computes average across 2040-2049, 2050-2059, and 2060-2069.
-summary_era_coords = [(3, 5), (6, 8)]
-
 # create encodings for coverages (currently all coverages share encodings)
-flammability_future_dim_encodings = asyncio.run(
-    get_dim_encodings("relative_flammability_future")
+flammability_dim_encodings = asyncio.run(
+    get_dim_encodings("alfresco_relative_flammability_30yr")
 )
-flammability_historical_dim_encodings = asyncio.run(
-    get_dim_encodings("relative_flammability_historical")
-)
-
-veg_change_future_dim_encodings = flammability_future_dim_encodings
-veg_change_historical_dim_encodings = flammability_historical_dim_encodings
 
 veg_type_dim_encodings = asyncio.run(
     get_dim_encodings("alfresco_vegetation_type_percentage")
 )
 
 var_ep_lu = {
-    "flammability": {"cov_id_str": "relative_flammability", "varname": "rf",},
-    "veg_change": {"cov_id_str": "relative_vegetation_change", "varname": "rvc",},
-    "veg_type": {"cov_id_str": "alfresco_vegetation_type_percentage", "varname": "vt",},
+    "flammability": {"cov_id_str": "alfresco_relative_flammability_30yr"},
+    "veg_type": {
+        "cov_id_str": "alfresco_vegetation_type_percentage",
+    },
 }
 
 var_label_lu = {
     "flammability": "Flammability",
-    "veg_change": "Vegetation Change",
     "veg_type": "Vegetation Type",
 }
 
@@ -75,17 +63,15 @@ flammability_fieldnames = [
     "date_range",
     "model",
     "scenario",
-    "variable",
     "stat",
     "value",
 ]
-veg_change_fieldnames = flammability_fieldnames
+
 veg_type_fieldnames = [
     "date_range",
     "model",
     "scenario",
     "veg_type",
-    "variable",
     "stat",
     "value",
 ]
@@ -93,7 +79,7 @@ veg_type_fieldnames = [
 
 async def fetch_alf_point_data(x, y, cov_id_str):
     """Make the async request for the data at the specified point for
-    a specific varname.
+    a specific coverage
 
     Args:
         x (float): lower x-coordinate bound
@@ -105,22 +91,7 @@ async def fetch_alf_point_data(x, y, cov_id_str):
     """
     # set up WCS request strings
     request_strs = []
-    if cov_id_str in ["relative_flammability", "relative_vegetation_change"]:
-        # historical data request string
-        request_strs.append(generate_wcs_getcov_str(x, y, f"{cov_id_str}_historical"))
-
-        # generate both future average requests (averages over decades)
-        for coords in summary_era_coords:
-            request_strs.append(
-                generate_average_wcps_str(x, y, f"{cov_id_str}_future", "era", coords)
-            )
-
-        # future non-average request str
-        request_strs.append(generate_wcs_getcov_str(x, y, f"{cov_id_str}_future"))
-    elif cov_id_str == "alfresco_vegetation_type_percentage":
-        # historical and projected are combined into the same coverage
-        # averages have already been precomputed before Rasdaman ingest
-        request_strs.append(generate_wcs_getcov_str(x, y, f"{cov_id_str}"))
+    request_strs.append(generate_wcs_getcov_str(x, y, cov_id_str))
     urls = [generate_wcs_query_url(request_str) for request_str in request_strs]
     point_data_list = await fetch_data(urls)
     return point_data_list
@@ -128,7 +99,7 @@ async def fetch_alf_point_data(x, y, cov_id_str):
 
 async def fetch_alf_bbox_data(bbox_bounds, cov_id_str):
     """Make the async request for the data at the specified point for
-    a specific varname.
+    a specific coverage
 
     Args:
         bbox_bounds (tuple): 4-tuple of x,y lower/upper bounds: (<xmin>,<ymin>,<xmax>,<ymax>)
@@ -139,72 +110,28 @@ async def fetch_alf_bbox_data(bbox_bounds, cov_id_str):
     """
     # set up WCS request strings
     request_strs = []
-
-    if cov_id_str in ["relative_flammability", "relative_vegetation_change"]:
-        # historical data request string
-        request_strs.append(
-            generate_netcdf_wcs_getcov_str(bbox_bounds, f"{cov_id_str}_historical")
-        )
-        # generate both future average requests (averages over decades)
-        for coords in summary_era_coords:
-            # kwargs to pass to function in generate_netcdf_average_wcps_str
-            kwargs = {
-                "cov_id": f"{cov_id_str}_future",
-                "axis_name": "era",
-                "axis_coords": coords,
-                "encoding": "netcdf",
-            }
-            request_strs.append(generate_netcdf_average_wcps_str(bbox_bounds, kwargs))
-        # future non-average request str
-        request_strs.append(
-            generate_netcdf_wcs_getcov_str(bbox_bounds, f"{cov_id_str}_future")
-        )
-    elif cov_id_str == "alfresco_vegetation_type_percentage":
-        # averages for vegetation type were precomputed before Rasdaman ingest
-        request_strs.append(
-            generate_netcdf_wcs_getcov_str(bbox_bounds, f"{cov_id_str}")
-        )
+    request_strs.append(generate_netcdf_wcs_getcov_str(bbox_bounds, cov_id_str))
     urls = [generate_wcs_query_url(request_str) for request_str in request_strs]
     bbox_ds_list = await fetch_bbox_netcdf_list(urls)
     return bbox_ds_list
 
 
-def package_historical_alf_point_data(point_data, varname):
-    """Add dim names to JSON response from point query
-    for the historical coverages
-
-    Args:
-        point_data (list): nested list containing JSON
-            results of historical alfresco point query
-        varname (str): variable name
-
-    Returns:
-        JSON-like dict of query results
-    """
-    point_data_pkg = {}
-    # hard-code summary period for CRU
-    for ei, value in enumerate(point_data):  # (nested list with value at dim 0)
-        era = flammability_historical_dim_encodings["era"][ei]
-        point_data_pkg[era] = {"CRU-TS40": {"CRU_historical": {varname: value}}}
-    return point_data_pkg
-
-
-def package_ar5_alf_point_data(point_data, varname):
+def package_ar5_alf_point_data(point_data, var_ep):
     """Add dim names to JSON response from typical AR5 point query
 
     Args:
         point_data (list): nested list containing JSON
             results of AR5 WCPS query
-        varname (str): variable name
+        var_ep (str): variable name
 
     Returns:
         JSON-like dict of query results
     """
     point_data_pkg = {}
 
-    if varname in ["rf", "rvc"]:
-        dim_encodings = flammability_future_dim_encodings
-    elif varname == "vt":
+    if var_ep == "flammability":
+        dim_encodings = flammability_dim_encodings
+    elif var_ep == "veg_type":
         dim_encodings = veg_type_dim_encodings
 
     # AR5 data:
@@ -217,32 +144,29 @@ def package_ar5_alf_point_data(point_data, varname):
             point_data_pkg[era][model] = {}
             for si, value in enumerate(s_li):
                 scenario = dim_encodings["scenario"][si]
-                if varname in ["rf", "rvc"]:
-                    point_data_pkg[era][model][scenario] = {varname: value}
-                elif varname == "vt":
+                if var_ep == "flammability":
+                    point_data_pkg[era][model][scenario] = value
+                elif var_ep == "veg_type":
                     point_data_pkg[era][model][scenario] = {}
                     v_li = value
                     for vi, value in enumerate(v_li):
                         veg_type = dim_encodings["veg_type"][vi]
                         percent = round(value * 100, 2)
-                        point_data_pkg[era][model][scenario][veg_type] = {
-                            varname: percent
-                        }
+                        point_data_pkg[era][model][scenario][veg_type] = percent
 
-    if varname == "vt":
-        point_data_pkg = remove_invalid_dim_combos(point_data_pkg)
+    point_data_pkg = remove_invalid_dim_combos(var_ep, point_data_pkg)
 
     return point_data_pkg
 
 
-def package_ar5_alf_averaged_point_data(point_data, varname):
+def package_ar5_alf_averaged_point_data(point_data, var_ep):
     """Add dim names to JSON response from WCPS point query
     for the AR5/CMIP5 coverages
 
     Args:
         point_data (list): nested list containing JSON
             results of AR5 WCPS query
-        varname (str): variable name
+        var_ep (str): variable name
 
     Returns:
         JSON-like dict of query results
@@ -255,15 +179,13 @@ def package_ar5_alf_averaged_point_data(point_data, varname):
         point_data_pkg[model] = {}
         for si, value in enumerate(s_li):
             scenario = flammability_future_dim_encodings["scenario"][si]
-            if varname in ["rf", "rvc"]:
-                point_data_pkg[model][scenario] = {varname: round(value, 4)}
-            elif varname == "vt":
+            if var_ep == "flammability":
+                point_data_pkg[model][scenario] = round(value, 4)
+            elif var_ep == "veg_type":
                 point_data_pkg[model][scenario] = {}
                 for vi, value in enumerate(v_li):
                     veg_type = future_dim_encodings["veg_type"][vi]
-                    point_data_pkg[model][scenario][veg_type] = {
-                        varname: round(value, 4)
-                    }
+                    point_data_pkg[model][scenario][veg_type] = round(value, 4)
     return point_data_pkg
 
 
@@ -278,8 +200,8 @@ def get_poly_mask_arr(ds, poly, bandname):
         bandname (str): name of the DataArray containing the data
 
     Returns:
-        poly_mask_arr (numpy.ma.core.MaskedArra): a masked array masking the cells intersecting
-            the polygon of interest
+        cropped_poly_mask (numpy.ma.core.MaskedArra): a masked array masking the cells
+            intersecting the polygon of interest, cropped to the right shape
     """
     # need a data layer of same x/y shape just for running a zonal stats
     xy_shape = ds[bandname].values.shape[-2:]
@@ -295,11 +217,12 @@ def get_poly_mask_arr(ds, poly, bandname):
         stats=["mean"],
         raster_out=True,
     )[0]["mini_raster_array"]
-    return poly_mask_arr
+    cropped_poly_mask = poly_mask_arr[0 : xy_shape[1], 0 : xy_shape[0]]
+    return cropped_poly_mask
 
 
 def summarize_within_poly_marr(
-    ds, poly_mask_arr, dim_encodings, bandname="Gray", varname="Gray"
+    ds, poly_mask_arr, dim_encodings, bandname="Gray", var_ep="Gray"
 ):
     """Summarize a single Data Variable of a xarray.DataSet within a polygon.
     Return the results as a nested dict.
@@ -317,7 +240,7 @@ def summarize_within_poly_marr(
             data and map integer data coordinates to models, scenarios, variables, etc.
         bandname (str): name of variable in ds, defaults to "Gray" for rasdaman coverages where
             the name is not given at ingest
-        varname (str): standard variable name used for storing results
+        var_ep (str): variable (flammability or veg_type)
 
     Returns:
         Nested dict of results for all non-X/Y axis combinations,
@@ -357,11 +280,12 @@ def summarize_within_poly_marr(
 
     for map_list, result in zip(dim_combos, results):
         if len(map_list) > 1:
-            if varname in ["rf", "rvc"]:
+            data = get_from_dict(aggr_results, map_list[:-1])
+            if var_ep == "flammability":
                 result = round(result, 4)
-            elif varname == "vt":
+            elif var_ep == "veg_type":
                 result = round(result * 100, 2)
-            get_from_dict(aggr_results, map_list[:-1])[map_list[-1]] = {varname: result}
+            data[map_list[-1]] = result
         else:
             aggr_results[map_list[0]] = round(result, 4)
     return aggr_results
@@ -385,8 +309,6 @@ def run_aggregate_var_polygon(var_ep, poly_gdf, poly_id):
             validating polygon IDs in `validate_data` or `lat_lon` module.
     """
     poly = get_poly_3338_bbox(poly_gdf, poly_id)
-    # mapping between coordinate values (ints) and variable names (strs)
-    varname = var_ep_lu[var_ep]["varname"]
     cov_id_str = var_ep_lu[var_ep]["cov_id_str"]
     ds_list = asyncio.run(fetch_alf_bbox_data(poly.bounds, cov_id_str))
 
@@ -396,47 +318,22 @@ def run_aggregate_var_polygon(var_ep, poly_gdf, poly_id):
     poly_mask_arr = get_poly_mask_arr(ds_list[0], poly, bandname)
     # average over the following decades / time periods
     aggr_results = {}
-    if cov_id_str in ["relative_flammability", "relative_vegetation_change"]:
-        historical_results = summarize_within_poly_marr(
-            ds_list[0],
-            poly_mask_arr,
-            flammability_historical_dim_encodings,
-            bandname,
-            varname,
-        )
-        #  add the model, scenario, and varname levels for CRU
-        for era in historical_results:
-            aggr_results[era] = {
-                "CRU-TS40": {"CRU_historical": {varname: historical_results[era]}}
-            }
-        # run regular future
+    if var_ep == "flammability":
         ar5_results = summarize_within_poly_marr(
-            ds_list[-1],
-            poly_mask_arr,
-            flammability_future_dim_encodings,
-            bandname,
-            varname,
+            ds_list[-1], poly_mask_arr, flammability_dim_encodings, bandname, var_ep
         )
-        for era, summaries in ar5_results.items():
-            aggr_results[era] = summaries
-        # run summary eras for future
-        summary_eras = ["2040-2069", "2070-2099"]
-        for ds, era in zip(ds_list[1:3], summary_eras):
-            aggr_results[era] = summarize_within_poly_marr(
-                ds, poly_mask_arr, flammability_future_dim_encodings, bandname, varname
-            )
-    elif cov_id_str == "alfresco_vegetation_type_percentage":
+    elif var_ep == "veg_type":
         ar5_results = summarize_within_poly_marr(
-            ds_list[-1], poly_mask_arr, veg_type_dim_encodings, bandname, varname
+            ds_list[-1], poly_mask_arr, veg_type_dim_encodings, bandname, var_ep
         )
-        for era, summaries in ar5_results.items():
-            aggr_results[era] = summaries
-        aggr_results = remove_invalid_dim_combos(aggr_results)
+    for era, summaries in ar5_results.items():
+        aggr_results[era] = summaries
+    aggr_results = remove_invalid_dim_combos(var_ep, aggr_results)
 
     return aggr_results
 
 
-def remove_invalid_dim_combos(results):
+def remove_invalid_dim_combos(var_ep, results):
     """Remove data from invalid era/model/scenario dimension combinations
 
     Args:
@@ -445,15 +342,20 @@ def remove_invalid_dim_combos(results):
     Returns:
         results (dict): point or area results data with invalid combos removed
     """
-    eras = list(veg_type_dim_encodings["era"].values())
-    models = list(veg_type_dim_encodings["model"].values())
-    scenarios = list(veg_type_dim_encodings["scenario"].values())
+    if var_ep == "flammability":
+        dim_encodings = flammability_dim_encodings
+    elif var_ep == "veg_type":
+        dim_encodings = veg_type_dim_encodings
+
+    eras = list(dim_encodings["era"].values())
+    models = list(dim_encodings["model"].values())
+    scenarios = list(dim_encodings["scenario"].values())
     # Remove empty data from invalid combos of era/model/scenario.
     for era in eras:
         for model in models:
             # Remove non-CRU-TS models and non-historical era from historical data.
-            if era == "1950-2008":
-                if model != "CRU-TS":
+            if era in ["1950-2008", "1950-1979", "1980-2008"]:
+                if model not in ["CRU-TS", "MODEL-SPINUP"]:
                     results[era].pop(model, None)
                     continue
                 for scenario in scenarios:
@@ -463,8 +365,9 @@ def remove_invalid_dim_combos(results):
             else:
                 results[era][model].pop("historical", None)
         # Remove CRU-TS "model" from projected data.
-        if era != "1950-2008":
+        if era not in ["1950-2008", "1950-1979", "1980-2008"]:
             results[era].pop("CRU-TS", None)
+            results[era].pop("MODEL-SPINUP", None)
 
     return results
 
@@ -480,15 +383,16 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
     Returns:
         CSV response object
     """
-    varname = var_ep_lu[var_ep]["varname"]
-    if var_ep in ["flammability", "veg_change"]:
+    if var_ep == "flammability":
         fieldnames = flammability_fieldnames
-        stat = "mean"
+        extra_columns = {"stat": "mean"}
     elif var_ep == "veg_type":
         fieldnames = veg_type_fieldnames
-        stat = "percent"
+        extra_columns = {"stat": "percent"}
     csv_dicts = build_csv_dicts(
-        data_pkg, fieldnames, {"variable": varname, "stat": stat},
+        data_pkg,
+        fieldnames,
+        extra_columns,
     )
 
     place_name, place_type = place_name_and_type(place_id)
@@ -496,13 +400,7 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
     metadata = csv_metadata(place_name, place_id, place_type, lat, lon)
 
     if var_ep == "flammability":
-        metadata += "# rf is relative flammability in number of pixels burned\n"
         metadata += "# mean is the mean of of annual means\n"
-    elif var_ep == "veg_change":
-        metadata += "# rvc is relative vegetation change in number of pixels that changed dominant vegetation type\n"
-        metadata += "# mean is the mean of of annual means\n"
-    elif var_ep == "veg_type":
-        metadata += "# vt is dominant vegetation type as a percentage of coverage\n"
 
     if place_name is not None:
         filename = var_label_lu[var_ep] + " for " + quote(place_name) + ".csv"
@@ -515,14 +413,12 @@ def create_csv(data_pkg, var_ep, place_id=None, lat=None, lon=None):
 @routes.route("/alfresco/")
 @routes.route("/alfresco/abstract/")
 @routes.route("/alfresco/flammability/")
-@routes.route("/alfresco/veg_change/")
 @routes.route("/alfresco/veg_type/")
 def alfresco_about():
     return render_template("alfresco/abstract.html")
 
 
 @routes.route("/alfresco/flammability/point/")
-@routes.route("/alfresco/veg_change/point/")
 @routes.route("/alfresco/veg_type/point/")
 @routes.route("/alfresco/point/")
 def alfresco_about_point():
@@ -530,7 +426,6 @@ def alfresco_about_point():
 
 
 @routes.route("/alfresco/flammability/area/")
-@routes.route("/alfresco/veg_change/area/")
 @routes.route("/alfresco/veg_type/area/")
 @routes.route("/alfresco/area/")
 def alfresco_about_huc():
@@ -538,7 +433,6 @@ def alfresco_about_huc():
 
 
 @routes.route("/alfresco/flammability/local/")
-@routes.route("/alfresco/veg_change/local/")
 @routes.route("/alfresco/veg_type/local/")
 @routes.route("/alfresco/local/")
 def alfresco_about_local():
@@ -551,7 +445,7 @@ def run_fetch_alf_point_data(var_ep, lat, lon):
     specified lat/lon and return JSON-like dict.
 
     Args:
-        var_ep (str): variable endpoint. Flammability, veg change, or veg_type
+        var_ep (str): variable endpoint. Flammability or veg_type
         lat (float): latitude
         lon (float): longitude
 
@@ -585,22 +479,7 @@ def run_fetch_alf_point_data(var_ep, lat, lon):
     else:
         return render_template("400/bad_request.html"), 400
 
-    varname = var_ep_lu[var_ep]["varname"]
-    if var_ep in ["flammability", "veg_change"]:
-        point_pkg = package_historical_alf_point_data(point_data_list[0], varname)
-        # package AR5 data and fold into data pakage
-        ar5_point_pkg = package_ar5_alf_point_data(point_data_list[3], varname)
-        for era, summaries in ar5_point_pkg.items():
-            point_pkg[era] = summaries
-        # package summary future eras in
-        point_pkg["2040-2069"] = package_ar5_alf_averaged_point_data(
-            point_data_list[1], varname
-        )
-        point_pkg["2070-2099"] = package_ar5_alf_averaged_point_data(
-            point_data_list[2], varname
-        )
-    elif var_ep == "veg_type":
-        point_pkg = package_ar5_alf_point_data(point_data_list, varname)
+    point_pkg = package_ar5_alf_point_data(point_data_list, var_ep)
 
     if request.args.get("format") == "csv":
         point_pkg = nullify_and_prune(point_pkg, "alfresco")
@@ -618,7 +497,7 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
     the request lat/lon and returns a summary of data within that HUC
 
     Args:
-        var_ep (str): variable endpoint. Flammability, veg_change, or veg_type
+        var_ep (str): variable endpoint. Flammability or veg_type
         lat (float): latitude
         lon (float): longitude
 

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -36,8 +36,6 @@ from . import routes
 
 alfresco_api = Blueprint("alfresco_api", __name__)
 
-
-# create encodings for coverages (currently all coverages share encodings)
 flammability_dim_encodings = asyncio.run(
     get_dim_encodings("alfresco_relative_flammability_30yr")
 )

--- a/templates/alfresco/abstract.html
+++ b/templates/alfresco/abstract.html
@@ -1,141 +1,263 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>Post-processed 1km ALFRESCO Data</h3>
-<p>The endpoints here provide access to data products derived from outputs from ALFRESCO simulations done using future (AR5/CMIP5) scenarios and historical (CRU TS 4.0) data completed for the Integrated Ecosystem Model (IEM) project. The current endpoints are described in the "Service Endpoints" section below, and are available for the following datasets:</p>
+<p>
+  The endpoints here provide access to data products derived from outputs from
+  ALFRESCO simulations done using future (AR5/CMIP5) scenarios and historical
+  (CRU TS 4.0) data completed for the Integrated Ecosystem Model (IEM) project.
+  The current endpoints are described in the "Service Endpoints" section below,
+  and are available for the following datasets:
+</p>
 
 <h4>Datasets</h4>
 <table>
-<thead>
-  <tr>
-    <th>Endpoint Name</th>
-    <th>Variable Name</th>
-    <th>Data Layer</th>
-    <th>Description</th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td>flammability</td>
-    <td>rf</td>
-    <td>Relative Flammability</td>
-    <td>These data are derived from the fire scar outputs and are computed as the average number of times a pixel burned across all reps for all years of the summary year span. Pixels are 1km x 1km.</td>
-  </tr>
-  <tr>
-    <td>veg_change</td>
-    <td>rvc</td>
-    <td>Relative Vegetation Change</td>
-    <td>These data are derived from the vegetation class data, the principal phenomena being modeled by ALFRESCO. They are computed as the average number of year-to-year transitions of any vegetation class for a pixel, across all reps for all years of the summary year span. Pixels are 1km x 1km.</td>
-  </tr>
-  <tr>
-    <td>veg_type</td>
-    <td>vt</td>
-    <td>Vegetation Type</td>
-    <td>These data are derived from the vegetation class data, the principal phenomena being modeled by ALFRESCO. They are computed as the average percentage of each vegetation type for a pixel, across all reps for all years of the summary year span. Pixels are 1km x 1km.</td>
-  </tr>
-</tbody>
+  <thead>
+    <tr>
+      <th>Endpoint Name</th>
+      <th>Data Layer</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>flammability</td>
+      <td>Flammability</td>
+      <td>
+        These data are derived from the fire scar outputs and are computed as
+        the average number of times a pixel burned across all reps for all years
+        of the summary year span. Pixels are 1km x 1km.
+      </td>
+    </tr>
+    <tr>
+      <td>veg_type</td>
+      <td>Vegetation Type</td>
+      <td>
+        These data are derived from the vegetation class data, the principal
+        phenomena being modeled by ALFRESCO. They are computed as the average
+        percentage of each vegetation type for a pixel, across all reps for all
+        years of the summary year span. Pixels are 1km x 1km.
+      </td>
+    </tr>
+  </tbody>
 </table>
 
 <h4>Service endpoints</h4>
 <p>Here are the existing endpoints for the above datasets.</p>
 <ul>
-    <li><a href="/alfresco/point">Point query</a></li>
-    <li><a href="/alfresco/local">Point-based aggregation of local area (HUC-12)</a></li>
-    <li><a href="/alfresco/area">Aggregate by AOI polygon ID</a></li>
+  <li><a href="/alfresco/point">Point query</a></li>
+  <li>
+    <a href="/alfresco/local">Point-based aggregation of local area (HUC-12)</a>
+  </li>
+  <li><a href="/alfresco/area">Aggregate by AOI polygon ID</a></li>
 </ul>
 
-<h4>Results from queries to the above endpoints will look like this:</h4>
+<h3>Flammability</h3>
+
+<p>Results from flammability endpoints will look like this:</p>
 
 <pre>
-{
-  "1950-1959": {
-    "CRU-TS40": {
-      "CRU_historical": {
-        "rf": 0.0009
+  {
+    "1950-1979": {
+      "MODEL-SPINUP": {
+        "historical": 0.0065
       }
-    }
+    },
+    ...
+    "2010-2039": {
+      "5modelAvg": {
+        "rcp45": 0.0014,
+        "rcp60": 0.0007,
+        "rcp85": 0.0007
+      },
+      ...
+    },
+    ...
   }
-...
-  "2010-2019": {
-    "5modelAvg": {
-      "rcp45": {
-        "rf": 0.0017
-      }
-    }
-  }
-...
-}
 </pre>
 
-The above output is structured as such:
+<p>The above output is structured as such:</p>
 
 <pre>
 {
   &ltera>: {
     &ltmodel>: {
-      &ltscenario>: {
-        &ltvarname>: &ltvalue>
-      }
+      &ltscenario>: &ltvalue>
     }
-  } 
+  }
   ...
 }
 </pre>
 
 <h4>Dimensions:</h4>
 <ul>
-    <li><strong><code>era</code></strong>: Sumary era:</li>
-        <ul>
-            <li>1950-1959</li>
-            <li>1950-2008</li>
-            <li>1960-1969</li>
-            <li>1970-1979</li>
-            <li>1980-1989</li>
-            <li>1990-1999</li>
-            <li>2000-2008</li>
-            <li>2040_2069</li>
-            <li>2070_2099</li>
-            <li>2010_2019</li>
-            <li>2020_2029</li>
-            <li>2030_2039</li>
-            <li>2040_2049</li>
-            <li>2050_2059</li>
-            <li>2060_2069</li>
-            <li>2070_2079</li>
-            <li>2080_2089</li>
-            <li>2090_2099</li>
-        </ul>
-    <li><strong><code>model</code></strong>: AR5 model source, or CRU TS:</li>
-        <ul>
-            <li>NCAR-CCSM4</li>
-            <li>MRI-CGCM3</li>
-            <li>IPSL-CM5A-LR</li>
-            <li>GFDL-CM3</li>
-            <li>GISS-E2-R</li>
-            <li>5modelAvg: the average of the above 5 models</li>
-        </ul>
-    <li><strong><code>scenario</code></strong>: RCP scenario for AR5, or "CRU_historical" for historical</li>
-        <ul>
-            <li>rcp45</li>
-            <li>rcp60</li>
-            <li>rcp85</li>
-            <li>CRU_historical</li>
-        </ul>
+  <li>
+    <strong><code>era</code></strong
+    >: Sumary era:
+  </li>
+  <ul>
+    <li>1950-1979</li>
+    <li>1980-2008</li>
+    <li>2010-2039</li>
+    <li>2040-2069</li>
+    <li>2070-2099</li>
+  </ul>
+  <li>
+    <strong><code>model</code></strong
+    >: AR5 model source, or 5-model average, or historical MODEL-SPINUP:
+  </li>
+  <ul>
+    <li>MODEL-SPINUP</li>
+    <li>NCAR-CCSM4</li>
+    <li>MRI-CGCM3</li>
+    <li>IPSL-CM5A-LR</li>
+    <li>GFDL-CM3</li>
+    <li>GISS-E2-R</li>
+    <li>5modelAvg: the average of the above 5 models</li>
+  </ul>
+  <li>
+    <strong><code>scenario</code></strong
+    >: RCP scenario for AR5, or "historical" for historical model spinup
+  </li>
+  <ul>
+    <li>rcp45</li>
+    <li>rcp60</li>
+    <li>rcp85</li>
+    <li>historical</li>
+  </ul>
 </ul>
-<strong>Variables:</strong>
+
+<h3>Vegetation type</h3>
+
+<p>Results from vegetation type endpoints will look like this:</p>
+
+<pre>
+  {
+    "1950-2008": {
+      "MODEL-SPINUP": {
+        "historical": {
+          "barren_lichen_moss": 0,
+          "black_spruce": 0,
+          "deciduous_forest": 50.92,
+          "graminoid_tundra": 0,
+          "not_modeled": 0,
+          "shrub_tundra": 0,
+          "temperate_rainforest": 0,
+          "wetland_tundra": 0,
+          "white_spruce": 49.08
+        }
+      }
+    },
+    ...
+    "NCAR-CCSM4": {
+      "rcp45": {
+        "barren_lichen_moss": 0,
+        "black_spruce": 0,
+        "deciduous_forest": 57.03,
+        "graminoid_tundra": 0,
+        "not_modeled": 0,
+        "shrub_tundra": 0,
+        "temperate_rainforest": 0,
+        "wetland_tundra": 0,
+        "white_spruce": 42.97
+      },
+      "rcp60": {
+        "barren_lichen_moss": 0,
+        "black_spruce": 0,
+        "deciduous_forest": 58.07,
+        "graminoid_tundra": 0,
+        "not_modeled": 0,
+        "shrub_tundra": 0,
+        "temperate_rainforest": 0,
+        "wetland_tundra": 0,
+        "white_spruce": 41.93
+      },
+      "rcp85": {
+        "barren_lichen_moss": 0,
+        "black_spruce": 0,
+        "deciduous_forest": 57.28,
+        "graminoid_tundra": 0,
+        "not_modeled": 0,
+        "shrub_tundra": 0,
+        "temperate_rainforest": 0,
+        "wetland_tundra": 0,
+        "white_spruce": 42.72
+      }
+    },
+    ...
+  }
+</pre>
+
+<p>The above output is structured as such:</p>
+
+<pre>
+{
+  &ltera>: {
+    &ltmodel>: {
+      &ltscenario>: {
+        &ltvegetation_type>: &ltvalue>
+      }
+    }
+  }
+  ...
+}
+</pre>
+
+<h4>Dimensions:</h4>
 <ul>
-    <li><strong><code>rf</code></strong>: <i>(float)</i>, relative flammability.</li>
-    <li><strong><code>rvc</code></strong>: <i>(float)</i>, relative vegetation change.</li>
+  <li>
+    <strong><code>era</code></strong
+    >: Sumary era:
+  </li>
+  <ul>
+    <li>1950-2008</li>
+    <li>2010-2039</li>
+    <li>2040-2069</li>
+    <li>2070-2099</li>
+  </ul>
+  <li>
+    <strong><code>model</code></strong
+    >: AR5 model source or historical MODEL-SPINUP:
+  </li>
+  <ul>
+    <li>MODEL-SPINUP</li>
+    <li>NCAR-CCSM4</li>
+    <li>MRI-CGCM3</li>
+    <li>IPSL-CM5A-LR</li>
+    <li>GFDL-CM3</li>
+    <li>GISS-E2-R</li>
+  </ul>
+  <li>
+    <strong><code>scenario</code></strong
+    >: RCP scenario for AR5, or "historical" for historical model spinup
+  </li>
+  <ul>
+    <li>rcp45</li>
+    <li>rcp60</li>
+    <li>rcp85</li>
+    <li>historical</li>
+  </ul>
 </ul>
 
 <h4>Source data</h4>
 
-These data are derived from ALFRESCO model outputs created for the IEM project at a resolution of 1km. For access to the source data used here, please contact uaf-snap-data-tool@alaska.edu and ask about accessing these data.
-
-SNAP also has some similar datasets available for download at longer year spans and for fewer models and scenarios than available here:
+These data are derived from ALFRESCO model outputs created for the IEM project
+at a resolution of 1km. For access to the source data used here, please contact
+uaf-snap-data-tool@alaska.edu and ask about accessing these data. SNAP also has
+some similar datasets available for download at longer year spans and for fewer
+models and scenarios than available here:
 
 <ul>
-    <li><a href="http://ckan.snap.uaf.edu/dataset/alfresco-model-outputs-relative-vegetation-change">ALFRESCO Model outputs - Relative Vegetation Change</a></li>
-    <li><a href="http://ckan.snap.uaf.edu/dataset/alfresco-model-outputs-relative-flammability">ALFRESCO Model outputs - Relative Flammability</a></li>
+  <li>
+    <a
+      href="http://ckan.snap.uaf.edu/dataset/alfresco-model-outputs-relative-vegetation-change"
+      >ALFRESCO Model outputs - Relative Vegetation Change</a
+    >
+  </li>
+  <li>
+    <a
+      href="http://ckan.snap.uaf.edu/dataset/alfresco-model-outputs-relative-flammability"
+      >ALFRESCO Model outputs - Relative Flammability</a
+    >
+  </li>
 </ul>
 
 {% endblock %}

--- a/templates/alfresco/abstract.html
+++ b/templates/alfresco/abstract.html
@@ -91,7 +91,7 @@
 <ul>
   <li>
     <strong><code>era</code></strong
-    >: Sumary era:
+    >: Summary era:
   </li>
   <ul>
     <li>1950-1979</li>
@@ -205,7 +205,7 @@
 <ul>
   <li>
     <strong><code>era</code></strong
-    >: Sumary era:
+    >: Summary era:
   </li>
   <ul>
     <li>1950-2008</li>

--- a/templates/alfresco/area.html
+++ b/templates/alfresco/area.html
@@ -1,16 +1,40 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>ALFRESCO Geospatial Polygon aggregation</h3>
-<p>Query data derived from 1km ALFRESCO outputs for a <a href="/places/all">area of interest polygon ID</a> and aggregate by mean.</p>
+<p>
+  Query data derived from 1km ALFRESCO outputs for a
+  <a href="/places/all">area of interest polygon ID</a> and aggregate by mean.
+</p>
 <p>Examples for the currently available datasets:</p>
 <ul>
-    <li>Relative flammability: <a href="/alfresco/flammability/area/19080309">/alfresco/flammability/area/19080309</a></li>
-    <li>Relative vegetation change: <a href="/alfresco/veg_change/area/19080309">/alfresco/veg_change/area/19080309</a></li>
-    <li>Vegetation type: <a href="/alfresco/veg_type/area/19080309">/alfresco/veg_type/area/19080309</a></li>
+  <li>
+    Flammability:
+    <a href="/alfresco/flammability/area/19080309"
+      >/alfresco/flammability/area/19080309</a
+    >
+  </li>
+  <li>
+    Vegetation type:
+    <a href="/alfresco/veg_type/area/19080309"
+      >/alfresco/veg_type/area/19080309</a
+    >
+  </li>
 </ul>
 <h4>CSV Export</h4>
-<p>To export the aggregated HUC data in a CSV file, append <code>?format=csv</code>.</p>
-<p>Example: <a href="/alfresco/flammability/area/19080309?format=csv">/alfresco/flammability/area/19080309?format=csv</a></p>
-<hr/>
-<p>8-digit HUC shapefiles accessed at <a href="https://datagateway.nrcs.usda.gov/">https://datagateway.nrcs.usda.gov/</a></p>
+<p>
+  To export the aggregated HUC data in a CSV file, append
+  <code>?format=csv</code>.
+</p>
+<p>
+  Example:
+  <a href="/alfresco/flammability/area/19080309?format=csv"
+    >/alfresco/flammability/area/19080309?format=csv</a
+  >
+</p>
+<hr />
+<p>
+  8-digit HUC shapefiles accessed at
+  <a href="https://datagateway.nrcs.usda.gov/"
+    >https://datagateway.nrcs.usda.gov/</a
+  >
+</p>
 {% endblock %}

--- a/templates/alfresco/local.html
+++ b/templates/alfresco/local.html
@@ -1,16 +1,38 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>ALFRESCO Local aggregation</h3>
-<p>Query data derived from 1km ALFRESCO outputs for a point location specified by latitude and longitude, and return the mean of the pixels within the HUC-12 that intersects the supplied point location.</p>
+<p>
+  Query data derived from 1km ALFRESCO outputs for a point location specified by
+  latitude and longitude, and return the mean of the pixels within the HUC-12
+  that intersects the supplied point location.
+</p>
 <p>Examples for the currently available datasets:</p>
 <ul>
-    <li>Relative flammability: <a href="/alfresco/flammability/local/65.4844/-145.4036">/alfresco/flammability/local/65.4844/-145.4036</a></li>
-    <li>Relative vegetation change: <a href="/alfresco/veg_change/local/65.4844/-145.4036">/alfresco/veg_change/local/65.4844/-145.4036</a></li>
-    <li>Vegetation type: <a href="/alfresco/veg_type/local/65.4844/-145.4036">/alfresco/veg_type/local/65.4844/-145.4036</a></li>
+  <li>
+    Flammability:
+    <a href="/alfresco/flammability/local/65.4844/-145.4036"
+      >/alfresco/flammability/local/65.4844/-145.4036</a
+    >
+  </li>
+  <li>
+    Vegetation type:
+    <a href="/alfresco/veg_type/local/65.4844/-145.4036"
+      >/alfresco/veg_type/local/65.4844/-145.4036</a
+    >
+  </li>
 </ul>
 <h4>CSV Export</h4>
 <p>To export the local data in a CSV file, append <code>?format=csv</code>.</p>
-<p>Example: <a href="/alfresco/flammability/local/65.4844/-145.4036?format=csv">/alfresco/flammability/local/65.4844/-145.4036?format=csv</a></p>
-<hr/>
-<p>12-digit HUC shapefiles accessed at <a href="https://datagateway.nrcs.usda.gov/">https://datagateway.nrcs.usda.gov/</a></p>
+<p>
+  Example:
+  <a href="/alfresco/flammability/local/65.4844/-145.4036?format=csv"
+    >/alfresco/flammability/local/65.4844/-145.4036?format=csv</a
+  >
+</p>
+<hr />
+<p>
+  12-digit HUC shapefiles accessed at
+  <a href="https://datagateway.nrcs.usda.gov/"
+    >https://datagateway.nrcs.usda.gov/</a
+  >
+</p>
 {% endblock %}

--- a/templates/alfresco/point.html
+++ b/templates/alfresco/point.html
@@ -1,14 +1,30 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>ALFRESCO point query</h3>
-<p>Query data derived from 1km ALFRESCO for a single point specified by latitude and longitude.</p>
+<p>
+  Query data derived from 1km ALFRESCO for a single point specified by latitude
+  and longitude.
+</p>
 <p>Examples for the currently available datasets:</p>
 <ul>
-    <li>Relative flammability: <a href="/alfresco/flammability/point/65.0628/-146.1627">/alfresco/flammability/point/65.0628/-146.1627</a></li>
-    <li>Relative vegetation change: <a href="/alfresco/veg_change/point/65.0628/-146.1627">/alfresco/veg_change/point/65.0628/-146.1627</a></li>
-    <li>Vegetation type: <a href="/alfresco/veg_type/point/65.0628/-146.1627">/alfresco/veg_type/point/65.0628/-146.1627</a></li>
+  <li>
+    Flammability:
+    <a href="/alfresco/flammability/point/65.0628/-146.1627"
+      >/alfresco/flammability/point/65.0628/-146.1627</a
+    >
+  </li>
+  <li>
+    Vegetation type:
+    <a href="/alfresco/veg_type/point/65.0628/-146.1627"
+      >/alfresco/veg_type/point/65.0628/-146.1627</a
+    >
+  </li>
 </ul>
 <h4>CSV Export</h4>
-<p>To export the  data in a CSV file, append <code>?format=csv</code>.</p>
-<p>Example: <a href="/alfresco/flammability/point/65.0628/-146.1627?format=csv">/alfresco/flammability/point/65.0628/-146.1627?format=csv</a></p>
+<p>To export the data in a CSV file, append <code>?format=csv</code>.</p>
+<p>
+  Example:
+  <a href="/alfresco/flammability/point/65.0628/-146.1627?format=csv"
+    >/alfresco/flammability/point/65.0628/-146.1627?format=csv</a
+  >
+</p>
 {% endblock %}


### PR DESCRIPTION
Closes #153.
Closes #154.
Closes #160.
Closes #162.

This PR does several things:

- Fixes all area endpoints, which broke mysteriously. After the recent Rasdaman upgrade on Zeus (and earlier on Apollo), the shape of polygon masks suddenly did not match the shape of the original data arrays. To solve this, we are now cropping polygon masks to the correct shape.
- Switches to using the new `alfresco_relative_flammability_30yr` Rasdaman coverage that has pre-computed 30-year projected eras + two distinct historical eras (1950-1979, 1980-2008).
- Removes code that handled dynamic aggregation of ALFRESCO data into 30-year eras since this work has now been precomputed before the Rasdaman ingest.
- Removes the old `veg_change` (vegetation transitions) endpoint that has been superseded by the new `veg_type` (vegetation percentages) endpoint.
- Removes documentation regarding the old `veg_change` endpoint and adds more documentation for the new `veg_type` endpoint.
- Removes the "rf" (relative flammability) and "vt" (vegetation type) variable names from ALFRESCO output that were not quite correct, and no longer served a purpose. This flattens & streamlines the output for both types of ALFRESCO data.
- Parses the slightly different XML metadata structure introduced in part by the new version of Rasdaman, I think.