### PR TITLE
Catch and convert remaining taspr nodata values that sneak through polygon mask

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -261,7 +261,7 @@ def summarize_within_poly(ds, poly, dim_encodings, varname="Gray", roundkey="Gra
     data_arr[data_arr_mask] = np.nan
 
     # Set any remaining nodata values to nan if they snuck through the mask.
-    data_arr[data_arr == -9.223372e+18] = np.nan
+    data_arr[np.isclose(data_arr, -9.223372e+18)] = np.nan
 
     results = np.nanmean(data_arr, axis=(1, 2)).astype(float)
 


### PR DESCRIPTION
Closes https://github.com/ua-snap/iem-webapp/issues/337.

The comparison operation used to determine if nodata values are sneaking through the polygon mask is failing to catch nodata values that are close, but not precisely the same, as the value we are checking against (-9.223372e+18). It appears that the -9.223372e+18 values become slightly different when they are averaged across decades. This was causing ~-9.223372e+18 values to sneak through the polygon mask only for 30-year era summaries of taspr data.

For example, look at the 30-year summary data (not the decadal data) for this endpoint:

http://localhost:5000/taspr/area/NPS12

Without this PR, the ~-9.223372e+18 values sneaking through the polygon mask are being included in the average of the 30-year area summary data, making the values extremely small (like -4465442767782180, -4465442767782154, -4465442767782505.5, etc.)

To test this PR, compare the output from URL above (or any other taspr area endpoint) from the `main` branch vs. the `fix_taspr_area_summaries` branch and make sure the 30-year eras have valid data.