### PR TITLE
Fix server error and return valid response if point query returns no nearby HUCs

### DIFF
--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -50,6 +50,7 @@ def find_containing_polygons(lat, lon):
     geo_suggestions = {}
 
     proximal_di = {}
+    huc_tb = []
     try:
         near_huc_di, huc_tb = fetch_huc_near_point(p_buff)
         huc_bb = box(*huc_tb)


### PR DESCRIPTION
Looks like this problem started occurring when the Aleutian Island HUCs were removed in https://github.com/ua-snap/geospatial-vector-veracity/pull/86.

To replicate, view a point query from a Western Aleutian Island while running the data-api from the `main` branch. For example:

http://localhost:5000/places/search/51.77/-176.67

The `no_huc_fix` branch will return a valid response, which I have tested against the web app.

Xref: https://github.com/ua-snap/iem-webapp/issues/317.