### PR TITLE
Fix Elevation Stats to Ignore NODATA

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -256,12 +256,12 @@ def summarize_within_poly(ds, poly, dim_encodings, varname="Gray", roundkey="Gra
     )[0]["mini_raster_array"]
 
     crop_shape = data_arr[0].shape
-    cropped_poly_mask = poly_mask_arr[0:crop_shape[0], 0:crop_shape[1]]
+    cropped_poly_mask = poly_mask_arr[0 : crop_shape[0], 0 : crop_shape[1]]
     data_arr_mask = np.broadcast_to(cropped_poly_mask.mask, data_arr.shape)
     data_arr[data_arr_mask] = np.nan
 
     # Set any remaining nodata values to nan if they snuck through the mask.
-    data_arr[np.isclose(data_arr, -9.223372e+18)] = np.nan
+    data_arr[np.isclose(data_arr, -9.223372e18)] = np.nan
 
     results = np.nanmean(data_arr, axis=(1, 2)).astype(float)
 
@@ -272,12 +272,13 @@ def summarize_within_poly(ds, poly, dim_encodings, varname="Gray", roundkey="Gra
     return aggr_results
 
 
-def geotiff_zonal_stats(poly, arr, transform, stat_list):
+def geotiff_zonal_stats(poly, arr, nodata_value, transform, stat_list):
+
     poly_mask_arr = zonal_stats(
         poly,
         arr,
         affine=transform,
-        nodata=np.nan,
+        nodata=nodata_value,
         stats=stat_list,
     )
     return poly_mask_arr
@@ -335,7 +336,9 @@ def parse_meta_xml_str(meta_xml_str):
             list(
                 list(
                     list(
-                        meta_xml.getroot().iter("{http://www.opengis.net/wcs/2.0}CoverageDescription")
+                        meta_xml.getroot().iter(
+                            "{http://www.opengis.net/wcs/2.0}CoverageDescription"
+                        )
                     )[0].iter("{http://www.opengis.net/gmlcov/1.0}metadata")
                 )[0].iter("{http://www.opengis.net/gmlcov/1.0}Extension")
             )[0].iter("{http://www.rasdaman.org}covMetadata")

--- a/routes/elevation.py
+++ b/routes/elevation.py
@@ -48,10 +48,10 @@ def package_zonal_stats(src, poly):
     min_band = src.read(1)
     max_band = src.read(2)
     mean_band = src.read(3)
-    zonal_mu = geotiff_zonal_stats(poly, mean_band, transform, ["mean"])
+    zonal_mu = geotiff_zonal_stats(poly, mean_band, src.nodata, transform, ["mean"])
     zonal_mu[0]["mean"] = int(zonal_mu[0]["mean"])
-    zonal_min = geotiff_zonal_stats(poly, min_band, transform, ["min"])
-    zonal_max = geotiff_zonal_stats(poly, max_band, transform, ["max"])
+    zonal_min = geotiff_zonal_stats(poly, min_band, src.nodata, transform, ["min"])
+    zonal_max = geotiff_zonal_stats(poly, max_band, src.nodata, transform, ["max"])
 
     di = {
         "title": "ASTER Global Digital Elevation Model Zonal Statistics",


### PR DESCRIPTION
This PR fixes the summary elevation values that are returned by the API (and used by the dynamic text in the CIR tool, [see this issue.](https://github.com/ua-snap/iem-webapp/issues/317) This fix is accomplished by passing the GeoTIFF source nodata values to the zonal stats function. Previously, the zonal stats used a `nodata=np.nan` implementation which (now obviously) will not work when the no data value is -9999 and not `np.nan`. To test this out visit http://localhost:5000/elevation/area/NC12 on the current main branch of the API. You'll fetch extreme values that really do not make any sense!!

Visit the same URL on this branch and the results are 
```
{
  "max": 2857.0, 
  "mean": 21, 
  "min": -42.0, 
  "res": "1 kilometer", 
  "title": "ASTER Global Digital Elevation Model Zonal Statistics", 
  "units": "meters difference from sea level"
}
```

which is what we would expect for this particular pan-Aleutian polygon. Moderate negative values (like that shown here) ARE expected and legitimate for this dataset.

It also looks like Black did some formatting here.