### PR TITLE
Add AK GMUs and CA First Nations to Search Endpoint

### DIFF
--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -110,7 +110,7 @@ def find_containing_polygons(lat, lon):
         near_akgmu_di, gm_bb = {}, box(*[1, 1, 1, 1])
 
     try:
-        near_cafn_di, fm_tb = fetch_cafn_near_point(p_buff)
+        near_cafn_di, fn_tb = fetch_cafn_near_point(p_buff)
         fn_bb = box(*fn_tb)
         fn_bb = fn_bb.buffer(box(*fn_tb).area * total_bounds_buffer)
         fn_tb = fn_bb.bounds


### PR DESCRIPTION
This PR will include both CA First Nations and AK Game Management Units (GMUs) in the results of the `search` endpoint. To test this PR, visit http://localhost:5000/places/search/64.9/-140.8 and verify that the `"Tr'ondëk Hwëch'in"` is included in the `ca_first_nations_near` portion of the results. Also verify that GMU 20E and GMU 25B are in the `game_management_units_near` item. 

This is a pretty quick end-of-the-day PR so please try a few other queries and check the two new dicts I've mentioned here.