### PR TITLE
Adds new variables to temperature and precipitation MMM endpoints

### DIFF
--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -371,7 +371,7 @@ def package_mmm_point_data(point_data, cov_id, horp):
         point_pkg["CRU-TS"]["historical"] = dict()
 
         for year in range(0, 115):
-            full_year = str(year + 1900)
+            full_year = str(year + 1901)
             point_pkg["CRU-TS"]["historical"][full_year] = dict()
             if cov_id == "annual_precip_totals":
                 point_pkg["CRU-TS"]["historical"][full_year]["pr"] = point_data[0][year][0]
@@ -390,7 +390,7 @@ def package_mmm_point_data(point_data, cov_id, horp):
                 dim_scenario = mmm_dim_encodings["scenarios"][scenario]
                 point_pkg[dim_model][dim_scenario] = dict()
                 for year in range(106, 200):
-                    full_year = str(year + 1900)
+                    full_year = str(year + 1901)
                     point_pkg[dim_model][dim_scenario][full_year] = dict()
                     if cov_id == "annual_precip_totals":
                         point_pkg[dim_model][dim_scenario][full_year]["pr"] = point_data[model][year][scenario]

--- a/templates/mmm/precipitation.html
+++ b/templates/mmm/precipitation.html
@@ -5,8 +5,11 @@
 <p>Example: <a href="/mmm/precipitation/historical/65.0628/-146.1627">/mmm/precipitation/historical/65.0628/-146.1627</a></p>
 <p>Query for projected annual total precipitation min, mean, and max:</p>
 <p>Example: <a href="/mmm/precipitation/projected/65.0628/-146.1627">/mmm/precipitation/projected/65.0628/-146.1627</a></p>
-<p>Query for both historical and projected annual total precipitation min, mean, and max:
+<p>Query for both historical and projected annual total precipitation min, mean, and max:</p>
 <p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627">/mmm/precipitation/hp/65.0628/-146.1627</a></p>
+<p>Query for a given date range between 1901-2100 for min, mean, and max to be determined from.</p>
+<p>Add a start year and end year to end of query:</p>
+<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627/1901/2020">/mmm/precipitation/hp/65.0628/-146.1627/1901/2020</a></p>
 <p>Query for all annual total precipitation data across all historical and projected models from 1900-2100:</p>
 <p>Example: <a href="/mmm/precipitation/all/65.0628/-146.1627">/mmm/precipitation/all/65.0628/-146.1627</a></p>
 <b>Results from the query above will look like this:</b>

--- a/templates/mmm/temperature.html
+++ b/templates/mmm/temperature.html
@@ -7,10 +7,14 @@
 <p>Query for projected temperature min, mean, and max for January or July:</p>
 <p>Example: <a href="/mmm/temperature/jan/projected/65.0628/-146.1627">/mmm/temperature/jan/projected/65.0628/-146.1627</a></p>
 <p>Example: <a href="/mmm/temperature/july/projected/65.0628/-146.1627">/mmm/temperature/july/projected/65.0628/-146.1627</a></p>
-<p>Query for both historical and projected temperature min, mean, and max for January or July:
+<p>Query for both historical and projected temperature min, mean, and max for January or July:</p>
 <p>Example: <a href="/mmm/temperature/jan/hp/65.0628/-146.1627">/mmm/temperature/jan/hp/65.0628/-146.1627</a></p>
 <p>Example: <a href="/mmm/temperature/july/hp/65.0628/-146.1627">/mmm/temperature/july/hp/65.0628/-146.1627</a></p>
-<p>Query for all temperature min, mean, and max data across all historical and projected models from 1900-2100:</p>
+<p>Query for a given date range between 1901-2100 for min, mean, and max to be determined from.</p>
+<p>Add a start year and end year to end of query:</p>
+<p>Example: <a href="/mmm/temperature/jan/hp/65.0628/-146.1627/1901/2020">/mmm/temperature/jan/hp/65.0628/-146.1627/1901/2020</a></p>
+<p>Example: <a href="/mmm/temperature/july/hp/65.0628/-146.1627/1901/2020">/mmm/temperature/july/hp/65.0628/-146.1627/1901/2020</a></p>
+<p>Query for all temperature min, mean, and max data across all historical and projected models from 1901-2100:</p>
 <p>Example: <a href="/mmm/temperature/jan/all/65.0628/-146.1627">/mmm/temperature/jan/all/65.0628/-146.1627</a></p>
 <p>Example: <a href="/mmm/temperature/july/all/65.0628/-146.1627">/mmm/temperature/july/all/65.0628/-146.1627</a></p>
 <b>Results from the query above will look like this:</b>

--- a/validate_request.py
+++ b/validate_request.py
@@ -61,7 +61,7 @@ def validate_bbox(lat1, lon1, lat2, lon2):
 
 
 def validate_year(start_year, end_year):
-    if 1900 < int(start_year) <= 2100 and 1900 < int(end_year) <= 2100:
+    if 1900 < int(start_year) <= 2100 and 1900 < int(end_year) <= 2100 and int(start_year) <= int(end_year):
         return True
     else:
         return 400

--- a/validate_request.py
+++ b/validate_request.py
@@ -60,6 +60,13 @@ def validate_bbox(lat1, lon1, lat2, lon2):
     return valid
 
 
+def validate_year(start_year, end_year):
+    if 1900 < int(start_year) <= 2100 and 1900 < int(end_year) <= 2100:
+        return True
+    else:
+        return 400
+
+
 def validate_var_id(var_id):
     if re.search("[^A-Za-z0-9]", var_id):
         return render_template("400/bad_request.html"), 400


### PR DESCRIPTION
This PR adds an optional start year and end year to the endpoint for generating the min, mean, and max for historical, projected, or both in the Jan and July temperature and annual precipitation totals coverages. 

Ensure that you try doing something like this:

**Without date range:**
http://localhost:5000/mmm/temperature/jan/hp/65.0628/-146.1627

**With date range:**
http://localhost:5000/mmm/temperature/jan/hp/65.0628/-146.1627/1901/2020

You should see that for that particular set of queries that the historical records do not change as it has the full range of data to find min, mean, and max but a different set of values for the projected values since we are only looking for data between 2006 - 2020.