### PR TITLE
Add arctic eds mean annual temp to mmm

### DIFF
--- a/generate_requests.py
+++ b/generate_requests.py
@@ -33,7 +33,7 @@ def generate_mmm_wcs_getcov_str(x, y, cov_id, model, scenario, encoding="json"):
         lower and upper bounds of bbox
         cov_id (str): Rasdaman coverage ID
         model (int): Model number defined in Rasdaman coverage
-            - 1: CRU-TS 4.0
+            - 0: CRU-TS 4.0
             - 2: GFDL-CM3
             - 3: GISS-E2-R
             - 4: IPSL-CM5A-LR

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -652,7 +652,7 @@ def create_csv(
                 metadata += "# tasmean is the mean temperature for the specified model and scenario\n"
                 metadata += "# tasmax is the maximum temperature for the specified model and scenario\n"
             else:
-                metadata += "# tas is the mean annual temperature for the specified model and scenario\n"
+                metadata = "# tas is the mean annual near-surface air temperature for the specified model and scenario\n"
     if var_ep in ["precipitation", "taspr"]:
         metadata += "# pr is precipitation in millimeters\n"
         if mmm is True:

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -46,11 +46,7 @@ taspr_api = Blueprint("taspr_api", __name__)
 # Table generated from luts.py file found here:
 # https://github.com/ua-snap/rasdaman-ingest/blob/main/arctic_eds/jan_july_tas_stats/jan_min_mean_max_tas/luts.py
 mmm_dim_encodings = {
-    "tempstats": {
-        0: "tasmax",
-        1: "tasmean",
-        2: "tasmin",
-    },
+    "tempstats": {0: "tasmax", 1: "tasmean", 2: "tasmin",},
     "models": {
         2: "GFDL-CM3",
         3: "GISS-E2-R",
@@ -58,15 +54,8 @@ mmm_dim_encodings = {
         5: "MRI-CGCM3",
         6: "NCAR-CCSM4",
     },
-    "scenarios": {
-        1: "rcp45",
-        2: "rcp60",
-        3: "rcp85",
-    },
-    "months": {
-        "jan": "January",
-        "july": "July"
-    }
+    "scenarios": {1: "rcp45", 2: "rcp60", 3: "rcp85",},
+    "months": {"jan": "January", "july": "July"},
 }
 
 # encodings hardcoded for now
@@ -134,6 +123,7 @@ dim_encodings = {
         "pr": 0,
     },
 }
+# fmt: on
 
 var_ep_lu = {
     "temperature": "tas",
@@ -143,7 +133,7 @@ var_ep_lu = {
 var_label_lu = {
     "temperature": "Temperature",
     "precipitation": "Precipitation",
-    "taspr": "Temperature & Precipitation"
+    "taspr": "Temperature & Precipitation",
 }
 
 
@@ -201,7 +191,9 @@ def get_wcps_request_str(x, y, var_coord, cov_id, summary_decades, encoding="jso
     return wcps_request_str
 
 
-def get_mmm_wcps_request_str(x, y, cov_id, scenarios, models, years, tempstat, encoding="json"):
+def get_mmm_wcps_request_str(
+    x, y, cov_id, scenarios, models, years, tempstat, encoding="json"
+):
     """Generates a WCPS query specific to the
     coverages used for the temperature min-mean-max.
 
@@ -290,23 +282,35 @@ async def fetch_mmm_point_data(x, y, cov_id, horp, start_year, end_year):
         point_data_list = await fetch_data([generate_wcs_query_url(request_str)])
 
     if horp == "historical" or horp == "hp":
-        timestring = "\"1901-01-01T00:00:00.000Z\":\"2015-01-01T00:00:00.000Z\""
+        timestring = '"1901-01-01T00:00:00.000Z":"2015-01-01T00:00:00.000Z"'
         if start_year is not None:
-            timestring = f"\"{start_year}-01-01T00:00:00.000Z\":\"{end_year}-01-01T00:00:00.000Z\""
+            timestring = (
+                f'"{start_year}-01-01T00:00:00.000Z":"{end_year}-01-01T00:00:00.000Z"'
+            )
 
         # Generates URL for historical scenario of CRU TS 4.0
         for tempstat in range(0, 3):
-            request_str = get_mmm_wcps_request_str(x, y, cov_id, "0:0", "0:0", timestring, tempstat)
-            point_data_list.append(await fetch_data([generate_wcs_query_url(request_str)]))
+            request_str = get_mmm_wcps_request_str(
+                x, y, cov_id, "0:0", "0:0", timestring, tempstat
+            )
+            point_data_list.append(
+                await fetch_data([generate_wcs_query_url(request_str)])
+            )
 
     if horp == "projected" or horp == "hp":
-        timestring = "\"2006-01-01T00:00:00.000Z\":\"2100-01-01T00:00:00.000Z\""
+        timestring = '"2006-01-01T00:00:00.000Z":"2100-01-01T00:00:00.000Z"'
         if start_year is not None:
-            timestring = f"\"{start_year}-01-01T00:00:00.000Z\":\"{end_year}-01-01T00:00:00.000Z\""
+            timestring = (
+                f'"{start_year}-01-01T00:00:00.000Z":"{end_year}-01-01T00:00:00.000Z"'
+            )
         # All other models and scenarios captured in this loop
         for tempstat in range(0, 3):
-            request_str = get_mmm_wcps_request_str(x, y, cov_id, "1:3", "2:6", timestring, tempstat)
-            point_data_list.append(await fetch_data([generate_wcs_query_url(request_str)]))
+            request_str = get_mmm_wcps_request_str(
+                x, y, cov_id, "1:3", "2:6", timestring, tempstat
+            )
+            point_data_list.append(
+                await fetch_data([generate_wcs_query_url(request_str)])
+            )
 
     return point_data_list
 
@@ -500,14 +504,16 @@ def package_ar5_point_data(point_data, varname):
             season = dim_encodings["seasons"][ai]
             point_data_pkg[decade][season] = {}
             for mod_i, s_li in enumerate(
-                    mod_li
+                mod_li
             ):  # (nested list with scenario at dim 0)
                 model = dim_encodings["models"][mod_i]
                 point_data_pkg[decade][season][model] = {}
                 for si, value in enumerate(s_li):  # (nested list with varname at dim 0)
                     scenario = dim_encodings["scenarios"][si]
                     point_data_pkg[decade][season][model][scenario] = {
-                        varname: None if value is None else round(value, dim_encodings["rounding"][varname])
+                        varname: None
+                        if value is None
+                        else round(value, dim_encodings["rounding"][varname])
                     }
 
     return point_data_pkg
@@ -535,7 +541,9 @@ def package_ar5_point_summary(point_data, varname):
             for si, value in enumerate(s_li):  # (nested list with varname at dim 0)
                 scenario = dim_encodings["scenarios"][si]
                 point_data_pkg[season][model][scenario] = {
-                    varname: None if value is None else round(value, dim_encodings["rounding"][varname])
+                    varname: None
+                    if value is None
+                    else round(value, dim_encodings["rounding"][varname])
                 }
 
     return point_data_pkg
@@ -693,9 +701,9 @@ def create_csv(packaged_data, var_ep, place_id, lat=None, lon=None, mmm=False):
                                         "model": model,
                                         "scenario": scenario,
                                         "stat": "mean",
-                                        "value": packaged_data[ar5_period][season][model][
-                                            scenario
-                                        ][varname],
+                                        "value": packaged_data[ar5_period][season][
+                                            model
+                                        ][scenario][varname],
                                     }
                                 )
                             except KeyError:
@@ -799,7 +807,16 @@ def return_csv(csv_data, var_ep, place_id, lat=None, lon=None, month=None):
     if place_name is not None:
         filename = var_label_lu[var_ep] + " for " + quote(place_name) + ".csv"
     elif month is not None:
-        filename = mmm_dim_encodings["months"][month] + " " + var_label_lu[var_ep] + " for " + lat + ", " + lon + ".csv"
+        filename = (
+            mmm_dim_encodings["months"][month]
+            + " "
+            + var_label_lu[var_ep]
+            + " for "
+            + lat
+            + ", "
+            + lon
+            + ".csv"
+        )
     else:
         filename = var_label_lu[var_ep] + " for " + lat + ", " + lon + ".csv"
 
@@ -807,8 +824,12 @@ def return_csv(csv_data, var_ep, place_id, lat=None, lon=None, month=None):
         csv_data,
         mimetype="text/csv",
         headers={
-            "Content-Type": 'text/csv; charset=utf-8',
-            "Content-Disposition": 'attachment; filename="' + filename + '"; filename*=utf-8\'\'"' + filename + '"'
+            "Content-Type": "text/csv; charset=utf-8",
+            "Content-Disposition": 'attachment; filename="'
+            + filename
+            + "\"; filename*=utf-8''\""
+            + filename
+            + '"',
         },
     )
 
@@ -981,16 +1002,24 @@ def run_aggregate_var_polygon(var_ep, poly_gdf, poly_id):
     poly = get_poly_3338_bbox(poly_gdf, poly_id)
     # mapping between coordinate values (ints) and variable names (strs)
     varname = var_ep_lu[var_ep]
-    var_coord = list(dim_encodings["varnames"].keys())[list(dim_encodings["varnames"].values()).index(varname)]
+    var_coord = list(dim_encodings["varnames"].keys())[
+        list(dim_encodings["varnames"].values()).index(varname)
+    ]
     # fetch data within the Polygon bounding box
     cov_ids, summary_decades = make_fetch_args()
-    ds_list = asyncio.run(fetch_bbox_netcdf(*poly.bounds, var_coord, cov_ids, summary_decades))
+    ds_list = asyncio.run(
+        fetch_bbox_netcdf(*poly.bounds, var_coord, cov_ids, summary_decades)
+    )
     # average over the following decades / time periods
     aggr_results = {}
     summary_periods = ["1950_2009", "2040_2069", "2070_2099"]
     for ds, period in zip(ds_list[:-1], summary_periods):
-        aggr_results[period] = summarize_within_poly(ds, poly, dim_encodings, "Gray", varname)
-    ar5_results = summarize_within_poly(ds_list[-1], poly, dim_encodings, "Gray", varname)
+        aggr_results[period] = summarize_within_poly(
+            ds, poly, dim_encodings, "Gray", varname
+        )
+    ar5_results = summarize_within_poly(
+        ds_list[-1], poly, dim_encodings, "Gray", varname
+    )
     for decade, summaries in ar5_results.items():
         aggr_results[decade] = summaries
     #  add the model, scenario, and varname levels for CRU
@@ -1075,12 +1104,17 @@ def mmm_point_data_endpoint(horp, lat, lon, month=None, start_year=None, end_yea
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
-        return render_template("422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX), 422
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
 
     if month is not None:
-        if month == 'jan':
+        if month == "jan":
             cov_id = "jan_min_max_mean_temp"
-        elif month == 'july':
+        elif month == "july":
             cov_id = "july_min_max_mean_temp"
         else:
             return render_template("400/bad_request.html"), 400
@@ -1097,7 +1131,9 @@ def mmm_point_data_endpoint(horp, lat, lon, month=None, start_year=None, end_yea
             return render_template("400/bad_request.html"), 400
 
     try:
-        point_pkg = run_fetch_mmm_point_data(lat, lon, cov_id, horp, start_year, end_year)
+        point_pkg = run_fetch_mmm_point_data(
+            lat, lon, cov_id, horp, start_year, end_year
+        )
     except Exception as exc:
         if hasattr(exc, "status") and exc.status == 404:
             return render_template("404/no_data.html"), 404
@@ -1137,7 +1173,12 @@ def point_data_endpoint(var_ep, lat, lon):
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
-        return render_template("422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX), 422
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
 
     if var_ep in var_ep_lu.keys():
         point_pkg = run_fetch_var_point_data(var_ep, lat, lon)
@@ -1154,7 +1195,7 @@ def point_data_endpoint(var_ep, lat, lon):
         if point_pkg in [{}, None, 0]:
             return render_template("404/no_data.html"), 404
 
-        place_id = request.args.get('community')
+        place_id = request.args.get("community")
         csv_data = create_csv(point_pkg, var_ep, place_id, lat, lon)
         return return_csv(csv_data, var_ep, place_id, lat, lon)
 

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -1158,6 +1158,9 @@ def mmm_point_data_endpoint(
             cov_id = "annual_mean_temp"
 
     if start_year is not None:
+        if horp == "all":
+            return render_template("400/bad_request.html"), 400
+
         if end_year is not None:
             validation = validate_year(start_year, end_year)
 

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -1112,6 +1112,7 @@ def about_mmm_precip():
 
 @routes.route("/mmm/<var_ep>/<horp>/<lat>/<lon>")
 @routes.route("/mmm/<var_ep>/<month>/<horp>/<lat>/<lon>")
+@routes.route("/mmm/<var_ep>/<horp>/<lat>/<lon>/<start_year>/<end_year>")
 @routes.route("/mmm/<var_ep>/<month>/<horp>/<lat>/<lon>/<start_year>/<end_year>")
 def mmm_point_data_endpoint(
     var_ep, horp, lat, lon, month=None, start_year=None, end_year=None

--- a/templates/mmm/abstract.html
+++ b/templates/mmm/abstract.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
 <h3>Historical and Projected Temperature + Precipitation Minimum, Mean, and Maximum</h3>
-<p>The endpoint here provides access to the temperature at surface in degrees Celsius and total annual precipitation in mm for both historical and projected model data over the state of Alaska.</p>
+<p>The endpoint here provides access to the temperature at surface in degrees Fahrenheit and total annual precipitation in inches for both historical and projected model data over the state of Alaska.</p>
 <h4>Service endpoints</h4>
-<p>These endpoints are for point queries to generate TAS and PR min, mean, and max for a given point.
+<p>These endpoints are for point queries to generate temperature and precipitation minimum, mean, and maximum for a given point.
 <ul>
-    <li><a href="/mmm/temperature">Temperature Point Query</a>: TAS min, mean, and max for point.</li>
-    <li><a href="/mmm/precipitation">Precipitation Point Query</a>: PR min, mean, and max for point.</li>
+    <li><a href="/mmm/temperature">Temperature Point Query</a>: min, mean, and max temperature values for point.</li>
+    <li><a href="/mmm/precipitation">Precipitation Point Query</a>: min, mean, and max precipitation values for point.</li>
 </ul>
 {% endblock %}

--- a/templates/mmm/precipitation.html
+++ b/templates/mmm/precipitation.html
@@ -1,16 +1,44 @@
 {% extends 'base.html' %}
 {% block content %}
 <h3>Annual Total Precipitation Min, Mean, and Max Point Query</h3>
+<p>This endpoint allows access to various summaries of point extractions from gridded precipitation data. Note, the quantity being modeled and supplied here is also referred to throughout by its standard abbreviated modeling name, "pr".</p>
+<h4>Summary queries for annual total precipitation</h4>
 <p>Query for historical annual total precipitation min, mean, and max:</p>
 <p>Example: <a href="/mmm/precipitation/historical/65.0628/-146.1627">/mmm/precipitation/historical/65.0628/-146.1627</a></p>
 <p>Query for projected annual total precipitation min, mean, and max:</p>
 <p>Example: <a href="/mmm/precipitation/projected/65.0628/-146.1627">/mmm/precipitation/projected/65.0628/-146.1627</a></p>
-<p>Query for both historical and projected annual total precipitation min, mean, and max:</p>
+<p>Query for both historical and projected annual total precipitation min, mean, and max:
 <p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627">/mmm/precipitation/hp/65.0628/-146.1627</a></p>
-<p>Query for a given date range between 1901-2100 for min, mean, and max to be determined from.</p>
-<p>Add a start year and end year to end of query:</p>
-<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627/1901/2020">/mmm/precipitation/hp/65.0628/-146.1627/1901/2020</a></p>
-<p>Query for all annual total precipitation data across all historical and projected models from 1900-2100:</p>
+
+<b>Results from the queries above will look like this:</b>
+
+<pre>
+{
+  "historical": {
+    "prmax": 21.7,
+    "prmean": 13.5,
+    "prmin": 6.2
+  }
+  ...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &ltsummary time period type, "historical" or "projected">: {
+    "prmax": &ltmax pr value across all models, scenarios, and years>,
+    "prmean": &ltmean pr value across all models, scenarios, and years>,
+    "prmin": &ltmin pr value across all models, scenarios, and years>
+  }
+  ...
+}
+</pre>
+
+<br>
+<h4>Comprehensive queries for annual total precipitation</h4>
+<p>Query for all annual total precipitation data across all historical and projected models from 1901-2099:</p>
 <p>Example: <a href="/mmm/precipitation/all/65.0628/-146.1627">/mmm/precipitation/all/65.0628/-146.1627</a></p>
 <b>Results from the query above will look like this:</b>
 
@@ -18,7 +46,7 @@
 {
   "CRU-TS": {
     "historical": {
-      "1900": {
+      "1901": {
         "pr": 140
       }
   }
@@ -34,13 +62,20 @@
     &ltscenario>:{
       &ltyear>: {
         "pr": &ltpr value>
-        }
       }
+      ...
     }
+    ...
   }
   ...
 }
 </pre>
+
+<h4>Supply summary time period (start / end years)</h4>
+<p>The start and end year to use for any of the summary options from above (i.e. "historical", "projected", or "hp") may be supplied with the query as well, appended to the end of the URL in the form <code>/&ltstart year>/&ltend year></code></p>
+<p>Here is an example to query total annual precipitation data for historical and projected models from 1950-2020:</p>
+<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627/1950/2020">/mmm/precipitation/hp/65.0628/-146.1627/1950/2020</a></p>
+<p>Note - this query option will only work for summary options, not the comprehensive option above (e.g. "all") </p>
 
 <h4>CSV Export</h4>
 <p>To export the annual total precipitation point data in a CSV file, append <code>?format=csv</code>.</p>

--- a/templates/mmm/temperature.html
+++ b/templates/mmm/temperature.html
@@ -1,23 +1,27 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3>Annual Total Precipitation Min, Mean, and Max Point Query</h3>
-<p>This endpoint allows access to various summaries of point extractions from gridded precipitation data. Note, the quantity being modeled and supplied here is also referred to throughout by its standard abbreviated modeling name, "pr".</p>
-<h4>Summary queries for annual total precipitation</h4>
-<p>Query for historical annual total precipitation min, mean, and max:</p>
-<p>Example: <a href="/mmm/precipitation/historical/65.0628/-146.1627">/mmm/precipitation/historical/65.0628/-146.1627</a></p>
-<p>Query for projected annual total precipitation min, mean, and max:</p>
-<p>Example: <a href="/mmm/precipitation/projected/65.0628/-146.1627">/mmm/precipitation/projected/65.0628/-146.1627</a></p>
-<p>Query for both historical and projected annual total precipitation min, mean, and max:
-<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627">/mmm/precipitation/hp/65.0628/-146.1627</a></p>
+<h3>Temperature at Surface Min, Mean, and Max Point Query</h3>
+<p>This endpoint allows access to various summaries of point extractions from gridded near-surface air temperature data. Note, the quantity being modeled and supplied here is also referred to throughout by its standard abbreviated modeling name, "tas".</p>
+<h4>Summary queries for January or July</h4>
+<p>The following queries will fetch temperature values summarized across all models and scenarios for specified time eras.</p>
+<p>Query for historical temperature min, mean, and max for January or July:</p>
+<p>Example: <a href="/mmm/temperature/jan/historical/65.0628/-146.1627">/mmm/temperature/jan/historical/65.0628/-146.1627</a></p>
+<p>Example: <a href="/mmm/temperature/july/historical/65.0628/-146.1627">/mmm/temperature/july/historical/65.0628/-146.1627</a></p>
+<p>Query for projected temperature min, mean, and max for January or July:</p>
+<p>Example: <a href="/mmm/temperature/jan/projected/65.0628/-146.1627">/mmm/temperature/jan/projected/65.0628/-146.1627</a></p>
+<p>Example: <a href="/mmm/temperature/july/projected/65.0628/-146.1627">/mmm/temperature/july/projected/65.0628/-146.1627</a></p>
+<p>Query for both historical and projected temperature min, mean, and max for January or July:
+<p>Example: <a href="/mmm/temperature/jan/hp/65.0628/-146.1627">/mmm/temperature/jan/hp/65.0628/-146.1627</a></p>
+<p>Example: <a href="/mmm/temperature/july/hp/65.0628/-146.1627">/mmm/temperature/july/hp/65.0628/-146.1627</a></p>
 
 <b>Results from the queries above will look like this:</b>
 
 <pre>
 {
   "historical": {
-    "prmax": 21.7,
-    "prmean": 13.5,
-    "prmin": 6.2
+    "tasmax": 21.7,
+    "tasmean": 13.5,
+    "tasmin": 6.2
   }
   ...
 }
@@ -28,18 +32,20 @@
 <pre>
 {
   &ltsummary time period type, "historical" or "projected">: {
-    "prmax": &ltmax pr value across all models, scenarios, and years>,
-    "prmean": &ltmean pr value across all models, scenarios, and years>,
-    "prmin": &ltmin pr value across all models, scenarios, and years>
+    "tasmax": &ltmax tas value across all models, scenarios, and years>,
+    "tasmean": &ltmean tas value across all models, scenarios, and years>,
+    "tasmin": &ltmin tas value across all models, scenarios, and years>
   }
   ...
 }
 </pre>
 
 <br>
-<h4>Comprehensive queries for annual total precipitation</h4>
-<p>Query for all annual total precipitation data across all historical and projected models from 1901-2099:</p>
-<p>Example: <a href="/mmm/precipitation/all/65.0628/-146.1627">/mmm/precipitation/all/65.0628/-146.1627</a></p>
+<h4>Comprehensive queries for January or July</h4>
+<p>The following queries will fetch yearly temperature values across all available years for January or July.</p>
+<p>Query for all Januray or July min, mean, and max temperature data for all historical and projected models from 1901-2099:</p>
+<p>Example: <a href="/mmm/temperature/jan/all/65.0628/-146.1627">/mmm/temperature/jan/all/65.0628/-146.1627</a></p>
+<p>Example: <a href="/mmm/temperature/july/all/65.0628/-146.1627">/mmm/temperature/july/all/65.0628/-146.1627</a></p>
 <b>Results from the query above will look like this:</b>
 
 <pre>
@@ -47,8 +53,12 @@
   "CRU-TS": {
     "historical": {
       "1901": {
-        "pr": 140
+        "tasmax": 19.7,
+        "tasmean": 13.4,
+        "tasmin": 7.1
       }
+      ...
+    }
   }
   ...
 }
@@ -61,7 +71,85 @@
   &ltmodel>: {
     &ltscenario>:{
       &ltyear>: {
-        "pr": &ltpr value>
+        "tasmax": &ltannual max tas value>,
+        "tasmean": &ltannual mean tas value>,
+        "tasmin": &ltannual min tas value>
+        }
+      }
+      ...
+    }
+    ...
+  }
+  ...
+}
+</pre>
+
+<br>
+<h4>Summary queries for annual mean temperature</h4>
+<p>The following queries will fetch mean annual temperature values summarized across all models and scenarios for specified time eras.</p>
+<p>Query for historical min, mean, and max annual mean temperature:</p>
+<p>Example: <a href="/mmm/temperature/historical/65.0628/-146.1627">/mmm/temperature/historical/65.0628/-146.1627</a></p>
+<p>Query for projected min, mean, and max annual mean temperature:</p>
+<p>Example: <a href="/mmm/temperature/projected/65.0628/-146.1627">/mmm/temperature/projected/65.0628/-146.1627</a></p>
+<p>Query for both historical and projected min, mean, and max annual mean temperature:</p>
+<p>Example: <a href="/mmm/temperature/hp/65.0628/-146.1627">/mmm/temperature/hp/65.0628/-146.1627</a></p>
+
+b>Results from the queries above will look like this:</b>
+
+<pre>
+{
+  "historical": {
+    "tasmax": -1.8,
+    "tasmean": -4.4,
+    "tasmin": -7.2
+  }
+  ...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &ltsummary time period type, "historical" or "projected">: {
+    "tasmax": &ltmax tas value across all models, scenarios, and years>,
+    "tasmean": &ltmean tas value across all models, scenarios, and years>,
+    "tasmin": &ltmin tas value across all models, scenarios, and years>
+  }
+  ...
+}
+</pre>
+
+<br>
+<h4>Comprehensive queries for annual mean temperature</h4>
+<p>The following query will fetch annual mean temperature values across all available years.</p>
+<p>Query for all mean annual temperature data for all historical and projected models from 1901-2099:</p>
+<p>Example: <a href="/mmm/temperature/all/65.0628/-146.1627">/mmm/temperature/all/65.0628/-146.1627</a></p>
+
+<b>Results from the query above will look like this:</b>
+
+<pre>
+{
+  "CRU-TS": {
+    "historical": {
+      "1901": {
+        "tas": -5,
+      }
+      ...
+    }
+  }
+  ...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &ltmodel>: {
+    &ltscenario>:{
+      &ltyear>: {
+        "tas": &ltannual mean tas value>,
       }
       ...
     }
@@ -73,11 +161,13 @@
 
 <h4>Supply summary time period (start / end years)</h4>
 <p>The start and end year to use for any of the summary options from above (i.e. "historical", "projected", or "hp") may be supplied with the query as well, appended to the end of the URL in the form <code>/&ltstart year>/&ltend year></code></p>
-<p>Here is an example to query total annual precipitation data for historical and projected models from 1950-2020:</p>
-<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627/1950/2020">/mmm/precipitation/hp/65.0628/-146.1627/1950/2020</a></p>
-<p>Note - this query option will only work for summary options, not the comprehensive option above (e.g. "all") </p>
+<p>Here is an example to query mean annual temperature data for historical and projected models from 1950-2020:</p>
+<p>Example: <a href="/mmm/temperature/hp/65.0628/-146.1627/1950/2020">/mmm/temperature/hp/65.0628/-146.1627/1950/2020</a></p>
+<p>Note - this query option will only work for summary options, not the comprehensive options above (e.g. "all") </p>
 
 <h4>CSV Export</h4>
-<p>To export the annual total precipitation point data in a CSV file, append <code>?format=csv</code>.</p>
-<p>Example: <a href="/mmm/precipitation/all/65.0628/-146.1627?format=csv">/mmm/precipitation/all/65.0628/-146.1627?format=csv</a></p>
+<p>To export the point data in a CSV file, append <code>?format=csv</code>. Currently only available for the "all" option for the time era variable</p>
+<p>Example: <a href="/mmm/temperature/jan/all/65.0628/-146.1627?format=csv">/mmm/temperature/jan/all/65.0628/-146.1627?format=csv</a></p>
+<p>Example: <a href="/mmm/temperature/july/all/65.0628/-146.1627?format=csv">/mmm/temperature/july/all/65.0628/-146.1627?format=csv</a></p>
+<p>Example: <a href="/mmm/temperature/all/65.0628/-146.1627?format=csv">/mmm/temperature/all/65.0628/-146.1627?format=csv</a></p>
 {% endblock %}

--- a/templates/mmm/temperature.html
+++ b/templates/mmm/temperature.html
@@ -1,32 +1,53 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3>Temperature at Surface Min, Mean, and Max Point Query</h3>
-<p>Query for historical temperature min, mean, and max for January or July:</p>
-<p>Example: <a href="/mmm/temperature/jan/historical/65.0628/-146.1627">/mmm/temperature/jan/historical/65.0628/-146.1627</a></p>
-<p>Example: <a href="/mmm/temperature/july/historical/65.0628/-146.1627">/mmm/temperature/july/historical/65.0628/-146.1627</a></p>
-<p>Query for projected temperature min, mean, and max for January or July:</p>
-<p>Example: <a href="/mmm/temperature/jan/projected/65.0628/-146.1627">/mmm/temperature/jan/projected/65.0628/-146.1627</a></p>
-<p>Example: <a href="/mmm/temperature/july/projected/65.0628/-146.1627">/mmm/temperature/july/projected/65.0628/-146.1627</a></p>
-<p>Query for both historical and projected temperature min, mean, and max for January or July:</p>
-<p>Example: <a href="/mmm/temperature/jan/hp/65.0628/-146.1627">/mmm/temperature/jan/hp/65.0628/-146.1627</a></p>
-<p>Example: <a href="/mmm/temperature/july/hp/65.0628/-146.1627">/mmm/temperature/july/hp/65.0628/-146.1627</a></p>
-<p>Query for a given date range between 1901-2100 for min, mean, and max to be determined from.</p>
-<p>Add a start year and end year to end of query:</p>
-<p>Example: <a href="/mmm/temperature/jan/hp/65.0628/-146.1627/1901/2020">/mmm/temperature/jan/hp/65.0628/-146.1627/1901/2020</a></p>
-<p>Example: <a href="/mmm/temperature/july/hp/65.0628/-146.1627/1901/2020">/mmm/temperature/july/hp/65.0628/-146.1627/1901/2020</a></p>
-<p>Query for all temperature min, mean, and max data across all historical and projected models from 1901-2100:</p>
-<p>Example: <a href="/mmm/temperature/jan/all/65.0628/-146.1627">/mmm/temperature/jan/all/65.0628/-146.1627</a></p>
-<p>Example: <a href="/mmm/temperature/july/all/65.0628/-146.1627">/mmm/temperature/july/all/65.0628/-146.1627</a></p>
+<h3>Annual Total Precipitation Min, Mean, and Max Point Query</h3>
+<p>This endpoint allows access to various summaries of point extractions from gridded precipitation data. Note, the quantity being modeled and supplied here is also referred to throughout by its standard abbreviated modeling name, "pr".</p>
+<h4>Summary queries for annual total precipitation</h4>
+<p>Query for historical annual total precipitation min, mean, and max:</p>
+<p>Example: <a href="/mmm/precipitation/historical/65.0628/-146.1627">/mmm/precipitation/historical/65.0628/-146.1627</a></p>
+<p>Query for projected annual total precipitation min, mean, and max:</p>
+<p>Example: <a href="/mmm/precipitation/projected/65.0628/-146.1627">/mmm/precipitation/projected/65.0628/-146.1627</a></p>
+<p>Query for both historical and projected annual total precipitation min, mean, and max:
+<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627">/mmm/precipitation/hp/65.0628/-146.1627</a></p>
+
+<b>Results from the queries above will look like this:</b>
+
+<pre>
+{
+  "historical": {
+    "prmax": 21.7,
+    "prmean": 13.5,
+    "prmin": 6.2
+  }
+  ...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &ltsummary time period type, "historical" or "projected">: {
+    "prmax": &ltmax pr value across all models, scenarios, and years>,
+    "prmean": &ltmean pr value across all models, scenarios, and years>,
+    "prmin": &ltmin pr value across all models, scenarios, and years>
+  }
+  ...
+}
+</pre>
+
+<br>
+<h4>Comprehensive queries for annual total precipitation</h4>
+<p>Query for all annual total precipitation data across all historical and projected models from 1901-2099:</p>
+<p>Example: <a href="/mmm/precipitation/all/65.0628/-146.1627">/mmm/precipitation/all/65.0628/-146.1627</a></p>
 <b>Results from the query above will look like this:</b>
 
 <pre>
 {
   "CRU-TS": {
     "historical": {
-      "1900": {
-        "tasmax": 19.7,
-        "tasmean": 13.4,
-        "tasmin": 7.1
+      "1901": {
+        "pr": 140
       }
   }
   ...
@@ -40,19 +61,23 @@
   &ltmodel>: {
     &ltscenario>:{
       &ltyear>: {
-        "tasmax": &lttasmax value>,
-        "tasmean": &lttasmean value>,
-        "tasmin": &lttasmin value>
-        }
+        "pr": &ltpr value>
       }
+      ...
     }
+    ...
   }
   ...
 }
 </pre>
 
+<h4>Supply summary time period (start / end years)</h4>
+<p>The start and end year to use for any of the summary options from above (i.e. "historical", "projected", or "hp") may be supplied with the query as well, appended to the end of the URL in the form <code>/&ltstart year>/&ltend year></code></p>
+<p>Here is an example to query total annual precipitation data for historical and projected models from 1950-2020:</p>
+<p>Example: <a href="/mmm/precipitation/hp/65.0628/-146.1627/1950/2020">/mmm/precipitation/hp/65.0628/-146.1627/1950/2020</a></p>
+<p>Note - this query option will only work for summary options, not the comprehensive option above (e.g. "all") </p>
+
 <h4>CSV Export</h4>
-<p>To export the point data in a CSV file, append <code>?format=csv</code>.</p>
-<p>Example: <a href="/mmm/temperature/jan/all/65.0628/-146.1627?format=csv">/mmm/temperature/jan/all/65.0628/-146.1627?format=csv</a></p>
-<p>Example: <a href="/mmm/temperature/july/all/65.0628/-146.1627?format=csv">/mmm/temperature/july/all/65.0628/-146.1627?format=csv</a></p>
+<p>To export the annual total precipitation point data in a CSV file, append <code>?format=csv</code>.</p>
+<p>Example: <a href="/mmm/precipitation/all/65.0628/-146.1627?format=csv">/mmm/precipitation/all/65.0628/-146.1627?format=csv</a></p>
 {% endblock %}

--- a/templates/mmm/temperature.html
+++ b/templates/mmm/temperature.html
@@ -94,7 +94,7 @@
 <p>Query for both historical and projected min, mean, and max annual mean temperature:</p>
 <p>Example: <a href="/mmm/temperature/hp/65.0628/-146.1627">/mmm/temperature/hp/65.0628/-146.1627</a></p>
 
-b>Results from the queries above will look like this:</b>
+<b>Results from the queries above will look like this:</b>
 
 <pre>
 {


### PR DESCRIPTION
This PR adds a new endpoint for generating the min-mean-max for mean annual temperature data coming from the annual_mean_temp coverage.

This builds on the recent /mmm endpoint, allowing the option for temperature to be queried without specifying one of the month variable options (jan / july), instead returning min-mean-max of mean annual temperature for the specific time period, or the non-summarized mean annual temp values if the "all" value is used for the time period variable. This is done in a similar way to the /mmm/precipitation, simply omit the month value:

[http://localhost:5000/mmm/temperature/historical/65.0628/-146.1627](http://localhost:5000/mmm/temperature/historical/65.0628/-146.1627)

The recently added functionality for specifying the start and end years to summarize over should be retained with this new option for temperature. Also, a small tweak is included to give a "bad request" response if the start/end years are supplied with "all", since the functionality to subset to specific years for the "all" / comprehensive option is not currently in place (i.e. supplying the start / end years does nothing different for those requests).

In addition, the documentation found at both of those URLs above have been updated with URLs for testing, and with updated text to help clarify all of the possibilities going on with this endpoint.

closes #183 