### PR TITLE
Adds a mmm snow endpoint to access historical and modeled snowfall equivalent.

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -349,7 +349,11 @@ def parse_meta_xml_str(meta_xml_str):
     for dim in encoding_el.iter():
         if not dim.text.isspace():
             encoding_di = eval(dim.text)
-            dim_encodings[dim.tag] = {int(k): v for k, v in encoding_di.items()}
+            for key, value in encoding_di.items():
+                if isinstance(value, dict):
+                    dim_encodings[key] = {int(k): v for k, v in value.items()}
+                else:
+                    dim_encodings[dim.tag] = {int(k): v for k, v in encoding_di.items()}
     return dim_encodings
 
 
@@ -524,3 +528,38 @@ def csv_metadata(place_name, place_id, place_type, lat=None, lon=None):
     metadata += "# View a report for this location at " + report_url + "\n"
 
     return metadata
+
+
+def deepflatten(iterable, depth=None, types=None, ignore=None):
+    """Flatten a nested list of unknown length. Adapted from the "iteration_utilities" library v. 0.11.0.
+
+    Arguments:
+        iterable -- the nested iterable (e.g., list) you want to flatten
+
+    Keyword Arguments:
+        depth -- flatten the iterable up to this depth (default: {None})
+        types -- types to flatten (default: {None})
+        ignore -- types to not flatten (default: {None})
+
+    Yields:
+        generator for the flattened iterable
+    """
+    if depth is None:
+        depth = float("inf")
+    if depth == -1:
+        yield iterable
+    else:
+        for x in iterable:
+            if ignore is not None and isinstance(x, ignore):
+                yield x
+            if types is None:
+                try:
+                    iter(x)
+                except TypeError:
+                    yield x
+                else:
+                    yield from deepflatten(x, depth - 1, types, ignore)
+            elif not isinstance(x, types):
+                yield x
+            else:
+                yield from deepflatten(x, depth - 1, types, ignore)

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -16,3 +16,4 @@ from .recache import *
 from .elevation import *
 from .alfresco import *
 from .degree_days import *
+from .snow import *

--- a/routes/snow.py
+++ b/routes/snow.py
@@ -1,0 +1,201 @@
+import asyncio
+import numpy as np
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+)
+
+# local imports
+from fetch_data import (
+    fetch_wcs_point_data,
+    get_dim_encodings,
+    deepflatten,
+    build_csv_dicts,
+    write_csv,
+)
+from validate_request import (
+    validate_latlon,
+    project_latlon,
+)
+from validate_data import nullify_and_prune, postprocess
+from . import routes
+from config import WEST_BBOX, EAST_BBOX
+
+snow_api = Blueprint("snow_api", __name__)
+# rasdaman targets
+sfe_coverage_id = "mean_annual_snowfall"
+
+
+def package_sfe_data(sfe_resp):
+    """Package the SFE data into a nested JSON-like dict.
+
+    Arguments:
+        sfe_resp -- the response(s) from the WCS GetCoverage request(s).
+
+    Returns:
+        di -- a nested dictionary of all SFE values
+    """
+    # intialize the output dict
+    sfe_encodings = asyncio.run(get_dim_encodings(sfe_coverage_id))
+    models = list(sfe_encodings["model"].values())
+    scenarios = list(sfe_encodings["scenario"].values())
+    decades = list(sfe_encodings["decade"].values())
+    di = {
+        m: {sc: {dec: {"SFE": None} for dec in decades} for sc in scenarios}
+        for m in models
+    }
+    # populate the dict with the response
+    flat_list = list(deepflatten(sfe_resp))
+    i = 0
+    for model in di.keys():
+        for scenario in di[model].keys():
+            for decade in di[model][scenario]:
+                di[model][scenario][decade]["SFE"] = flat_list[i]
+                i += 1
+    # remove the nonsense encoding combinations
+    # e.g., CRU-TS/RCP8.5 or NCAR-CCSM4/1920-1929
+    projection_decades = [
+        "2010-2019",
+        "2020-2029",
+        "2030-2039",
+        "2040-2049",
+        "2050-2059",
+        "2060-2069",
+        "2070-2079",
+        "2080-2089",
+        "2090-2099",
+    ]
+    historical_decades = list(set(decades) - set(projection_decades))
+    di["CRU-TS"].pop("rcp45", None)
+    di["CRU-TS"].pop("rcp60", None)
+    di["CRU-TS"].pop("rcp85", None)
+    for proj_dec in projection_decades:
+        di["CRU-TS"]["historical"].pop(proj_dec, None)
+    for model in ["GFDL-CM3", "GISS-E2-R", "IPSL-CM5A-LR", "MRI-CGCM3", "NCAR-CCSM4"]:
+        di[model].pop("historical")
+        for scenario in ["rcp45", "rcp60", "rcp85"]:
+            for hist_dec in historical_decades:
+                di[model][scenario].pop(hist_dec, None)
+    return di
+
+
+def summarize_mmm_sfe(all_sfe_di):
+    """Generate min-mean-max summaries of the historical and projected SFE data.
+
+    Arguments:
+        all_sfe_di -- the intial nested dict package of all SFE data
+
+    Returns:
+        mmm_sfe_di -- a nested dict that is a subset of the intial package
+    """
+    mmm_sfe_di = {}
+    mmm_sfe_di["historical"] = {}
+    mmm_sfe_di["projected"] = {}
+    hist_vals = [
+        all_sfe_di["CRU-TS"]["historical"][k]["SFE"]
+        for k in all_sfe_di["CRU-TS"]["historical"].keys()
+    ]
+    mmm_sfe_di["historical"]["sfemin"] = min(hist_vals)
+    mmm_sfe_di["historical"]["sfemax"] = max(hist_vals)
+    mmm_sfe_di["historical"]["sfemean"] = int(np.mean(hist_vals))
+    proj_vals = []
+    for model in ["GFDL-CM3", "GISS-E2-R", "IPSL-CM5A-LR", "MRI-CGCM3", "NCAR-CCSM4"]:
+        for scenario in ["rcp45", "rcp60", "rcp85"]:
+            model_scenario_vals = [
+                all_sfe_di[model][scenario][k]["SFE"]
+                for k in all_sfe_di[model][scenario].keys()
+            ]
+            for mod_sc_val in model_scenario_vals:
+                proj_vals.append(mod_sc_val)
+    mmm_sfe_di["projected"]["sfemin"] = min(proj_vals)
+    mmm_sfe_di["projected"]["sfemax"] = max(proj_vals)
+    mmm_sfe_di["projected"]["sfemean"] = int(np.mean(proj_vals))
+    return mmm_sfe_di
+
+
+def create_csv(data_pkg, lat=None, lon=None):
+    """Create CSV file with metadata string and location based filename.
+    Args:
+        data_pkg (dict): JSON-like object of data
+        lat: latitude for points or None for polygons
+        lon: longitude for points or None for polygons
+    Returns:
+        CSV response object
+    """
+    fieldnames = [
+        "model",
+        "scenario",
+        "decade",
+        "variable",
+        "value",
+    ]
+    csv_dicts = build_csv_dicts(
+        data_pkg,
+        fieldnames,
+    )
+    metadata = "#SFE is the total annual snowfall equivalent in inches for the specified model-scenario-decade\n"
+    filename = "SFE for " + lat + ", " + lon + ".csv"
+    return write_csv(csv_dicts, fieldnames, filename, metadata)
+
+
+@routes.route("/mmm/snow/")
+@routes.route("/mmm/snow/snowfallequivalent/")
+def about_mmm_snow():
+    return render_template("mmm/snow.html")
+
+
+@routes.route("/mmm/snow/snowfallequivalent/<lat>/<lon>")
+# the above route is included to avoid a 500 error when horp is omitted entirely
+@routes.route("/mmm/snow/snowfallequivalent/<horp>/<lat>/<lon>")
+def run_point_fetch_all_sfe(lat, lon, horp="hp"):
+    """Run the async request for SFE data at a single point.
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+        horp (string): one of "historical", "projected", "hp", or "all")
+
+    Returns:
+        JSON-like dict of SFE data
+    """
+    validation = validate_latlon(lat, lon)
+    if validation == 400:
+        return render_template("400/bad_request.html"), 400
+    if validation == 422:
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
+    x, y = project_latlon(lat, lon, 3338)
+    try:
+        rasdaman_response = asyncio.run(fetch_wcs_point_data(x, y, sfe_coverage_id))
+        horp_case_di = {
+            "all": package_sfe_data(rasdaman_response),
+            "hp": summarize_mmm_sfe(package_sfe_data(rasdaman_response)),
+            "historical": {
+                "historical": summarize_mmm_sfe(package_sfe_data(rasdaman_response))[
+                    "historical"
+                ]
+            },
+            "projected": {
+                "projected": summarize_mmm_sfe(package_sfe_data(rasdaman_response))[
+                    "projected"
+                ]
+            },
+        }
+        try:
+            if horp == "all" and request.args.get("format") == "csv":
+                point_pkg = nullify_and_prune(horp_case_di[horp], "snow")
+                if point_pkg in [{}, None, 0]:
+                    return render_template("404/no_data.html"), 404
+                return create_csv(point_pkg, lat, lon)
+            else:
+                return postprocess(horp_case_di[horp], "snow")
+        except KeyError:
+            return render_template("400/bad_request.html"), 400
+    except Exception as exc:
+        if hasattr(exc, "status") and exc.status == 404:
+            return render_template("404/no_data.html"), 404
+        return render_template("500/server_error.html"), 500

--- a/routes/snow.py
+++ b/routes/snow.py
@@ -98,7 +98,7 @@ def summarize_mmm_sfe(all_sfe_di):
     ]
     mmm_sfe_di["historical"]["sfemin"] = min(hist_vals)
     mmm_sfe_di["historical"]["sfemax"] = max(hist_vals)
-    mmm_sfe_di["historical"]["sfemean"] = int(np.mean(hist_vals))
+    mmm_sfe_di["historical"]["sfemean"] = round(np.mean(hist_vals), 1)
     proj_vals = []
     for model in ["GFDL-CM3", "GISS-E2-R", "IPSL-CM5A-LR", "MRI-CGCM3", "NCAR-CCSM4"]:
         for scenario in ["rcp45", "rcp60", "rcp85"]:
@@ -110,7 +110,7 @@ def summarize_mmm_sfe(all_sfe_di):
                 proj_vals.append(mod_sc_val)
     mmm_sfe_di["projected"]["sfemin"] = min(proj_vals)
     mmm_sfe_di["projected"]["sfemax"] = max(proj_vals)
-    mmm_sfe_di["projected"]["sfemean"] = int(np.mean(proj_vals))
+    mmm_sfe_di["projected"]["sfemean"] = round(np.mean(proj_vals), 1)
     return mmm_sfe_di
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,13 +3,14 @@
 <h3>Overview</h3>
 <p>This is a data service that facilitates access to a variety of Alaska and Arctic geospatial data.
 </p>
-<p>The code is hosted on <a href="https://github.com/ua-snap/data-api">Github</a>. Instructions on how to use each data endpoint is given below.</p>
+<p>The code is hosted on <a href="https://github.com/ua-snap/data-api">Github</a>. Instructions on how to use each data
+    endpoint is given below.</p>
 <h4>Service endpoints</h4>
 <ul>
     <li><a href="/fire">Wildfire</a></li>
     <li><a href="/permafrost">Permafrost</a></li>
     <li><a href="/taspr">Temperature and Precipitation</a></li>
-    <li><a href="/mmm">Temperature, Precipitation, and Degree Days Min, Mean, and Max</a></li>
+    <li><a href="/mmm">Temperature, Precipitation, Snow, and Degree Days Min, Mean, and Max</a></li>
     <li><a href="/geology">Geology</a></li>
     <li><a href="/physiography">Physiography</a></li>
     <li><a href="/glacier">Glaciology</a></li>

--- a/templates/mmm/abstract.html
+++ b/templates/mmm/abstract.html
@@ -1,12 +1,20 @@
 {% extends 'base.html' %}
 {% block content %}
 <h3>Historical and Projected Minimum, Mean, and Maximum</h3>
-<p>The endpoint here provides access to the temperature at surface in degrees Fahrenheit, total annual precipitation in inches, and degree days at various thresholds for both historical and projected model data over the state of Alaska.</p>
+<p>The endpoints here provide access to both historical and projected model data over the state of Alaska for
+    the surface temperature in degrees Fahrenheit, total annual precipitation in
+    inches, total annual snowfall equivalent in inches, and degree days at various thresholds.
+</p>
 <h4>Service endpoints</h4>
-<p>These endpoints are for point queries to generate temperature, precipitation, and degree day minimum, mean, and maximum for a given point.
+<p>These endpoints are for point queries of minimum, mean, and maximum values of temperature, precipitation, snowfall
+    equilvalent, and degree days.
 <ul>
-    <li><a href="/mmm/temperature">Temperature Point Query</a>: min, mean, and max temperature values for point.</li>
-    <li><a href="/mmm/precipitation">Precipitation Point Query</a>: min, mean, and max precipitation values for point.</li>
-    <li><a href="/mmm/degree_days">Degree Days Point Query</a>: min, mean, and max at various degree day thresholds for point.</li>
+    <li><a href="/mmm/temperature">Temperature Point Query</a>: min, mean, and max temperature values for a point.</li>
+    <li><a href="/mmm/precipitation">Precipitation Point Query</a>: min, mean, and max precipitation values for a point.
+    </li>
+    <li><a href="/mmm/snow">Snow Point Query</a>: min, mean, and max snow values for a point.</li>
+    <li><a href="/mmm/degree_days">Degree Days Point Query</a>: min, mean, and max at various degree day thresholds for
+        a
+        point.</li>
 </ul>
 {% endblock %}

--- a/templates/mmm/snow.html
+++ b/templates/mmm/snow.html
@@ -1,0 +1,86 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Snowfall Equivalent</h3>
+<p>This endpoint accesses historical and projected modeled decadal summaries of annual snowfall equivalent (SFE) for
+    Alaska. Note that
+    SFE has a very specific meaning in a modeling context: it is the product of the fraction of days in a month with
+    precipitation falling as snow and the total monthly precipitation. That product (monthly) is then summed to create a
+    single annual total SFE value. The SFE values provided here are inches of water. </p>
+<h4>Summary queries for SFE</h4>
+<p>Query the historical SFE min, mean, and max:</p>
+<p>Example: <a
+        href="/mmm/snow/snowfallequivalent/historical/61.5/-147">/mmm/snow/snowfallequivalent/historical/61.5/-147</a>
+</p>
+<p>Query the projected SFE min, mean, and max:</p>
+<p>Example: <a
+        href="/mmm/snow/snowfallequivalent/projected/61.5/-147">/mmm/snow/snowfallequivalent/projected/61.5/-147</a>
+</p>
+<p>Query both the historical and projected SFE min, mean, and max:</p>
+<p>
+<p>Example: <a href="/mmm/snow/snowfallequivalent/hp/61.5/-147">/mmm/snow/snowfallequivalent/hp/61.5/-147</a>
+</p>
+<b>Results from the queries above will look like this:</b>
+<pre>
+{
+  "historical": {
+    "sfemax": 192,
+    "sfemean": 145,
+    "sfemin": 116
+  }
+  ...
+}
+</pre>
+<b>The above output is structured like this:</b>
+<pre>
+{
+  &ltsummary time period type, "historical" or "projected">: {
+    "sfemax": &ltmax SFE value across all models, scenarios, and decades>,
+    "sfemean": &ltmean SFE value across all models, scenarios, and decades>,
+    "sfemin": &ltmin SFE value across all models, scenarios, and decades>
+  }
+  ...
+}
+</pre>
+<h4>Comprehensive queries for SFE</h4>
+<p>Query both the historical and projected SFE values for all models, scenarios, and decades (1910-1919 through
+    2090-2099):</p>
+<p>Example: <a href="/mmm/snow/snowfallequivalent/all/61.5/-147">/mmm/snow/snowfallequivalent/all/61.5/-147</a></p>
+<b>Results from the query above will look like this:</b>
+<pre>
+{
+    "CRU-TS": {
+    "historical": {
+        "1910-1919": {
+        "SFE": 149,
+        }
+        ...
+    }
+    ...
+    }
+    ...
+}
+</pre>
+<b>The above output is structured like this:</b>
+<pre>
+{
+    &ltmodel>: {
+    &ltscenario>:{
+        &ltdecade>: {
+        "SFE": &ltannual total sfe value>,
+        }
+        ...
+    }
+    ...
+    }
+    ...
+}
+</pre>
+
+
+<h4>CSV Export</h4>
+<p>To export the point data in a CSV file, append <code>?format=csv</code>. Currently only available for the "all" data
+    option.</p>
+<p>Example: <a
+        href="/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv">/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv</a>
+</p>
+{% endblock %}

--- a/validate_data.py
+++ b/validate_data.py
@@ -18,6 +18,7 @@ nodata_values = {
     "permafrost": [-9999, -9999.0],
     "physiography": [],
     "taspr": [-9999, -9.223372e18, -9.223372036854776e18],
+    "snow": [-9999],
 }
 
 


### PR DESCRIPTION
This PR creates a new endpoint under the top-level `mmm` route to access modeled snowfall equivalent data (SFE) for ultimate use in the Arctic-EDS. The routing follows the existing convention for summarizing over either `historical` or `projected` or both (`hp`) - or for accessing `all` data values. The `all` option is also available for CSV export. The native temporal resolution of this dataset is decadal, so custom time-slicing is *not* available in this endpoint because users could unwittingly summarize over very few values. For example, a 2020-2050 summary would only compute min-mean-max over 3 values - not 30.

To use this endpoint fire up the API and point it at Apollo
`export API_RAS_BASE_URL=http://apollo.snap.uaf.edu:8080/rasdaman/`

Some URLs to test:
http://localhost:5000/mmm/snow/snowfallequivalent/historical/61.5/-147
http://localhost:5000/mmm/snow/snowfallequivalent/projected/61.5/-147
http://localhost:5000/mmm/snow/snowfallequivalent/hp/61.5/-147
http://localhost:5000/mmm/snow/snowfallequivalent/all/61.5/-147

A CSV export to test:
http://localhost:5000/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv

The above URLs should return integer values of SWE (units are inches of water) and the `hp` and `all` responses should reveal a decreasing trend in SFE which is expected as the length of snow season shortens in response to a warming climate.

A malformed summary option will 400:
http://localhost:5000/mmm/snow/snowfallequivalent/foo/61.5/-147

While a request outside the data boundary will 404:
http://localhost:5000/mmm/snow/snowfallequivalent/hp/51.5/-147

Notes
 - If no summary option is given `hp` is used as a default, e.g.,:
http://localhost:5000/mmm/snow/snowfallequivalent/61.5/-147
 - For low SFE (dry) areas, there is a signal-to-noise issue with this dataset, e.g.,:
 http://localhost:5000/mmm/snow/snowfallequivalent/65.5/-146


