### PR TITLE
Handle missing Rasdaman coverages

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -358,21 +358,27 @@ def parse_meta_xml_str(meta_xml_str):
 
 
 async def get_dim_encodings(cov_id):
-    """Get the dimension encodings from a rasdaman
-    coverage that has the encodings stored in an
-    "encodings" attribute
+    """Get the dimension encodings that map integer values to descriptive strings from a
+    Rasdaman coverage that stores the encodings in a metadata "encodings" attribute. We
+    handle exceptions where the coverage we are requesting encodings from does not exist
+    on the backend to prevent Rasdaman work from blocking API development.
 
     Args:
         cov_id (str): ID of the rasdaman coverage
 
-    Rreturns:
+    Returns:
         dict of encodings, with axis name as keys holding
         dicts of integer-keyed categories
     """
     meta_url = generate_wcs_query_url(f"DescribeCoverage&COVERAGEID={cov_id}")
-    meta_xml_str = await fetch_data([meta_url])
-    dim_encodings = parse_meta_xml_str(meta_xml_str)
-    return dim_encodings
+    try:
+        meta_xml_str = await fetch_data([meta_url])
+        dim_encodings = parse_meta_xml_str(meta_xml_str)
+        return dim_encodings
+    except:
+        print(
+            f"Warning: Coverage '{cov_id}' is missing from the Rasdaman server {RAS_BASE_URL} you are using."
+        )
 
 
 def extract_nested_dict_keys(dict_, result_list=None, in_line_list=None):

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -1,12 +1,7 @@
 import asyncio
-import io
-import csv
-import time
 import itertools
-import requests
 import geopandas as gpd
 import numpy as np
-import xarray as xr
 from flask import (
     Blueprint,
     render_template,
@@ -35,25 +30,18 @@ from config import WEST_BBOX, EAST_BBOX
 from . import routes
 
 alfresco_api = Blueprint("alfresco_api", __name__)
-
-try:
-    flammability_dim_encodings = asyncio.run(
-        get_dim_encodings("alfresco_relative_flammability_30yr")
-    )
-
-    veg_type_dim_encodings = asyncio.run(
-        get_dim_encodings("alfresco_vegetation_type_percentage")
-    )
-except:
-    print("Missing from Apollo")
-
+flammability_dim_encodings = asyncio.run(
+    get_dim_encodings("alfresco_relative_flammability_30yr")
+)
+veg_type_dim_encodings = asyncio.run(
+    get_dim_encodings("alfresco_vegetation_type_percentage")
+)
 var_ep_lu = {
     "flammability": {"cov_id_str": "alfresco_relative_flammability_30yr"},
     "veg_type": {
         "cov_id_str": "alfresco_vegetation_type_percentage",
     },
 }
-
 var_label_lu = {
     "flammability": "Flammability",
     "veg_type": "Vegetation Type",

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -21,16 +21,13 @@ from . import routes
 
 degree_days_api = Blueprint("degree_days_api", __name__)
 
-try:
-    # The heating_degree_days, degree_days_below_zero, thawing_index, and
-    # freezing_index coverages all share the same dim_encodings
-    dd_dim_encodings = asyncio.run(get_dim_encodings("heating_degree_days"))
+# The heating_degree_days, degree_days_below_zero, thawing_index, and
+# freezing_index coverages all share the same dim_encodings
+dd_dim_encodings = asyncio.run(get_dim_encodings("heating_degree_days"))
 
-    # The design_thawing_index and design_freezing_index coverages share the
-    # same dim encodings
-    di_dim_encodings = asyncio.run(get_dim_encodings("design_thawing_index"))
-except:
-    print("Missing from Apollo")
+# The design_thawing_index and design_freezing_index coverages share the
+# same dim encodings
+di_dim_encodings = asyncio.run(get_dim_encodings("design_thawing_index"))
 
 var_ep_lu = {
     "heating": {"cov_id_str": "heating_degree_days"},


### PR DESCRIPTION
This PR provides a more general handling of missing Rasdaman coverages. The motivation for this PR was to prevent changes within and between the various Rasdaman servers (Zeus, Apollo) from blocking development on the API. In this PR an exception provides a specific warning message if the DescribeCoverage request to Rasdaman fails.

To test this behavior:

 - Point the API to Apollo
     - `export API_RAS_BASE_URL=http://apollo.snap.uaf.edu:8080/rasdaman/`
 - Edit Line 34 on `alfresco.py` such that coverage name for relative flammability is incorrect and doesn't match what is on Apollo, e.g., change `alfresco_relative_flammability_30yr` to `FOOalfresco_relative_flammability_30yr`
 - Run the API
 - Confirm that you observe a terminal error message, it should read: "Warning: Coverage 'FOOalfresco_relative_flammability_30yr' is missing from the Rasdaman server http://apollo.snap.uaf.edu:8080/rasdaman/ you are using."
 - Endpoints that hit this coverage will hit a TypeError (try http://localhost:5000/alfresco/flammability/point/65.0628/-146.1627) but other endpoints should work as expected. Failing with that error isn't ideal and it should probably 404 instead, but we'll need to deal with that on a per-endpoint basis and is probably beyond the scope of this PR.