### PR TITLE
Summarize Design Thawing/Freezing Index data across models, but continue to provide all data through "all" endpoint

### DIFF
--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -3,6 +3,7 @@ from flask import (
     Blueprint,
     render_template,
     request,
+    jsonify,
 )
 
 # local imports
@@ -142,6 +143,42 @@ def design_index_about():
 @routes.route("/design_index/freezing/point")
 def design_index_about_point():
     return render_template("/design_index/point.html")
+
+
+@routes.route("/eds/degree_days/<var_ep>/<lat>/<lon>")
+def get_dd_plate(var_ep, lat, lon):
+    """
+    Endpoint for requesting all data required for the Heating Degree Days,
+    Below Zero Degree Days, Thawing Index, and Freezing Index in the
+    ArcticEDS client.
+    Args:
+        var_ep (str): heating, below_zero, thawing_index, or freezing_index
+        lat (float): latitude
+        lon (float): longitude
+    Notes:
+        example request: http://localhost:5000/eds/degree_days/heating/65.0628/-146.1627
+    """
+    dd_plate = {}
+
+    results = run_fetch_dd_point_data(var_ep, lat, lon, "historical")
+    dd_plate["historical"] = results["historical"]
+
+    results = run_fetch_dd_point_data(
+        var_ep, lat, lon, "projected", start_year="2010", end_year="2039"
+    )
+    dd_plate["2010-2039"] = results["projected"]
+
+    results = run_fetch_dd_point_data(
+        var_ep, lat, lon, "projected", start_year="2040", end_year="2069"
+    )
+    dd_plate["2040-2069"] = results["projected"]
+
+    results = run_fetch_dd_point_data(
+        var_ep, lat, lon, "projected", start_year="2070", end_year="2099"
+    )
+    dd_plate["2070-2099"] = results["projected"]
+
+    return jsonify(dd_plate)
 
 
 def package_dd_point_data(point_data, var_ep, horp):

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -414,19 +414,13 @@ async def fetch_di_point_data(x, y, cov_id, horp):
         point_data_list = await fetch_data([generate_wcs_query_url(request_str)])
 
     if horp in ["historical", "hp"]:
-        request_str = get_di_wcps_request_str(
-            x, y, cov_id, "0:0", "0:0"
-        )
-        point_data_list.append(
-            await fetch_data([generate_wcs_query_url(request_str)])
-        )
+        request_str = get_di_wcps_request_str(x, y, cov_id, "0:0", "0:0")
+        point_data_list.append(await fetch_data([generate_wcs_query_url(request_str)]))
 
     if horp in ["projected", "hp"]:
         for era in range(1, 3):
             eras = str(era) + ":" + str(era)
-            request_str = get_di_wcps_request_str(
-                x, y, cov_id, "1:2", eras
-            )
+            request_str = get_di_wcps_request_str(x, y, cov_id, "1:2", eras)
             point_data_list.append(
                 await fetch_data([generate_wcs_query_url(request_str)])
             )

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -120,6 +120,47 @@ def get_dd_wcps_request_str(x, y, cov_id, models, years, tempstat, encoding="jso
         return wcps_request_str
 
 
+def get_di_wcps_request_str(x, y, cov_id, models, eras, encoding="json"):
+    """Generates a WCPS query specific to the design index coverages
+
+    Args:
+        x (float or str): x-coordinate for point query, or string
+            composed as "x1:x2" for bbox query, where x1 and x2 are
+            lower and upper bounds of bbox
+        y (float or str): y-coordinate for point query, or string
+            composed as "y1:y2" for bbox query, where y1 and y2 are
+            lower and upper bounds of bbox
+        cov_id (str): Rasdaman coverage ID
+        models (str): Comma-separated numbers of requested models
+        eras (str): The era(s) to calculate mean across
+        encoding (str): currently supports either "json" or "netcdf"
+            for point or bbox queries, respectively
+
+    Returns:
+        WCPS query to be included in generate_wcs_url()
+    """
+    # Generates the mean across models
+
+    # For projected, 2 models
+    num_results = 2
+
+    # For historical, only a single model
+    if models == "0:0":
+        num_results = 1
+
+    operation = "+"
+
+    wcps_request_str = quote(
+        (
+            f"ProcessCoverages&query=for $c in ({cov_id}) "
+            f"let $a := avg(condense {operation} over $m model({models}) "
+            f"using $c[model($m),era({eras}),X({x}),Y({y})] / {num_results} ) "
+            f'return encode( $a, "application/{encoding}")'
+        )
+    )
+    return wcps_request_str
+
+
 @routes.route("/mmm/degree_days/")
 @routes.route("/mmm/degree_days/abstract/")
 @routes.route("/mmm/degree_days/heating/")
@@ -251,30 +292,45 @@ def package_dd_point_data(point_data, var_ep, horp):
     return point_pkg
 
 
-def package_di_point_data(point_data):
+def package_di_point_data(point_data, horp):
     """Add JSON response data for design_thawing_index and
     design_freezing_index coverages
 
     Args:
         point_data (list): nested list containing JSON results of WCPS query
+        horp [Historical or Projected] (str): historical, projected, hp, or all
 
     Returns:
         JSON-like dict of query results
     """
     point_pkg = {}
-    for mi, m_li in enumerate(point_data):
-        model = di_dim_encodings["model"][mi]
-        point_pkg[model] = {}
-        for ei, value in enumerate(m_li):
-            era = di_dim_encodings["era"][ei]
-            if mi > 0 and era == "1980-2009":
-                continue
-            if mi == 0 and era != "1980-2009":
-                continue
-            if value is None:
-                point_pkg[model][era] = None
-            else:
-                point_pkg[model][era] = {"di": value}
+    if horp == "all":
+        for mi, m_li in enumerate(point_data):
+            model = di_dim_encodings["model"][mi]
+            point_pkg[model] = {}
+            for ei, value in enumerate(m_li):
+                era = di_dim_encodings["era"][ei]
+                if mi > 0 and era == "1980-2009":
+                    continue
+                if mi == 0 and era != "1980-2009":
+                    continue
+                if value is None:
+                    point_pkg[model][era] = None
+                else:
+                    point_pkg[model][era] = {"di": value}
+    else:
+        keys = []
+        if horp in ["historical", "hp"]:
+            keys.append("historical")
+        if horp in ["projected", "hp"]:
+            keys.append("2040-2069")
+            keys.append("2070-2099")
+
+        index = 0
+        for key in keys:
+            point_pkg[key] = {"di": point_data[index]}
+            index += 1
+
     return point_pkg
 
 
@@ -338,7 +394,7 @@ async def fetch_dd_point_data(x, y, cov_id, horp, start_year, end_year):
     return point_data_list
 
 
-async def fetch_di_point_data(x, y, cov_id):
+async def fetch_di_point_data(x, y, cov_id, horp):
     """Run the async design index data request for a single point
     and return data as json
 
@@ -346,12 +402,35 @@ async def fetch_di_point_data(x, y, cov_id):
         lat (float): latitude
         lon (float): longitude
         cov_id (str): design_thawing_index or freezing_thawing_index
+        horp [Historical or Projected] (str): historical, projected, hp, or all
 
     Returns:
         JSON-like dict of data at provided latitude and longitude
     """
-    request_str = generate_wcs_getcov_str(x, y, cov_id)
-    point_data_list = await fetch_data([generate_wcs_query_url(request_str)])
+    point_data_list = []
+
+    if horp == "all":
+        request_str = generate_wcs_getcov_str(x, y, cov_id)
+        point_data_list = await fetch_data([generate_wcs_query_url(request_str)])
+
+    if horp in ["historical", "hp"]:
+        request_str = get_di_wcps_request_str(
+            x, y, cov_id, "0:0", "0:0"
+        )
+        point_data_list.append(
+            await fetch_data([generate_wcs_query_url(request_str)])
+        )
+
+    if horp in ["projected", "hp"]:
+        for era in range(1, 3):
+            eras = str(era) + ":" + str(era)
+            request_str = get_di_wcps_request_str(
+                x, y, cov_id, "1:2", eras
+            )
+            point_data_list.append(
+                await fetch_data([generate_wcs_query_url(request_str)])
+            )
+
     return point_data_list
 
 
@@ -462,8 +541,8 @@ def run_fetch_dd_point_data(var_ep, lat, lon, horp, start_year=None, end_year=No
     return postprocess(point_pkg, "degree_days")
 
 
-@routes.route("/design_index/<var_ep>/point/<lat>/<lon>")
-def run_fetch_di_point_data(var_ep, lat, lon):
+@routes.route("/design_index/<var_ep>/<horp>/point/<lat>/<lon>")
+def run_fetch_di_point_data(var_ep, lat, lon, horp):
     """Design index data endpoint. Fetch point data for
     specified lat/lon and return JSON-like dict.
 
@@ -471,6 +550,7 @@ def run_fetch_di_point_data(var_ep, lat, lon):
         var_ep (str): thawing or freezing
         lat (float): latitude
         lon (float): longitude
+        horp [Historical or Projected] (str): historical, projected, hp, or all
 
     Returns:
         JSON-like dict of requested design index data
@@ -497,13 +577,13 @@ def run_fetch_di_point_data(var_ep, lat, lon):
         cov_id_str = "design_freezing_index"
 
     try:
-        point_data_list = asyncio.run(fetch_di_point_data(x, y, cov_id_str))
+        point_data_list = asyncio.run(fetch_di_point_data(x, y, cov_id_str, horp))
     except Exception as exc:
         if hasattr(exc, "status") and exc.status == 404:
             return render_template("404/no_data.html"), 404
         return render_template("500/server_error.html"), 500
 
-    point_pkg = package_di_point_data(point_data_list)
+    point_pkg = package_di_point_data(point_data_list, horp)
 
     if request.args.get("format") == "csv":
         point_pkg = nullify_and_prune(point_pkg, "degree_days")

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import csv
+import json
 import time
 import itertools
 from urllib.parse import quote
@@ -1110,6 +1111,40 @@ def about_mmm_precip():
     return render_template("mmm/precipitation.html")
 
 
+@routes.route("/eds/temperature/<lat>/<lon>")
+def get_temperature_plate(lat, lon):
+    temp_plate = list()
+    temp_plate.append(mmm_point_data_endpoint("temperature", "historical", lat, lon))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "historical", lat, lon, "jan"))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "historical", lat, lon, "july"))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "projected", lat, lon, start_year="2010", end_year="2039"))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "projected", lat, lon, month="jan", start_year="2010", end_year="2039"))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "projected", lat, lon, month="july", start_year="2010", end_year="2039"))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "projected", lat, lon, start_year="2040", end_year="2069"))
+    temp_plate.append(
+        mmm_point_data_endpoint("temperature", "projected", lat, lon, month="jan", start_year="2040", end_year="2069"))
+    temp_plate.append(
+        mmm_point_data_endpoint("temperature", "projected", lat, lon, month="july", start_year="2040", end_year="2069"))
+    temp_plate.append(mmm_point_data_endpoint("temperature", "projected", lat, lon, start_year="2070", end_year="2099"))
+    temp_plate.append(
+        mmm_point_data_endpoint("temperature", "projected", lat, lon, month="jan", start_year="2070", end_year="2099"))
+    temp_plate.append(
+        mmm_point_data_endpoint("temperature", "projected", lat, lon, month="july", start_year="2070", end_year="2099"))
+
+    return json.dumps(temp_plate)
+
+
+@routes.route("/eds/precipitation/<lat>/<lon>")
+def get_precipitation_plate(lat, lon):
+    pr_plate = list()
+    pr_plate.append(mmm_point_data_endpoint("precipitation", "historical", lat, lon))
+    pr_plate.append(mmm_point_data_endpoint("precipitation", "projected", lat, lon, start_year="2010", end_year="2039"))
+    pr_plate.append(mmm_point_data_endpoint("precipitation", "projected", lat, lon, start_year="2040", end_year="2069"))
+    pr_plate.append(mmm_point_data_endpoint("precipitation", "projected", lat, lon, start_year="2070", end_year="2099"))
+
+    return json.dumps(pr_plate)
+
+
 @routes.route("/mmm/<var_ep>/<horp>/<lat>/<lon>")
 @routes.route("/mmm/<var_ep>/<month>/<horp>/<lat>/<lon>")
 @routes.route("/mmm/<var_ep>/<horp>/<lat>/<lon>/<start_year>/<end_year>")
@@ -1156,6 +1191,8 @@ def mmm_point_data_endpoint(
             cov_id = "annual_precip_totals"
         elif var_ep == "temperature":
             cov_id = "annual_mean_temp"
+        else:
+            return render_template("400/bad_request.html"), 400
 
     if start_year is not None:
         if horp == "all":

--- a/templates/design_index/point.html
+++ b/templates/design_index/point.html
@@ -1,8 +1,8 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>Design Index Point Query</h3>
 <p>
-  The endpoints here provide access to the design thawing index and design freezing index.
+  The endpoints here provide access to the design thawing index and design
+  freezing index.
 </p>
 
 <h4>Endpoints</h4>
@@ -16,28 +16,138 @@
   <tbody>
     <tr>
       <td>thawing</td>
-      <td>The mean of the three highest cumulative annual degree days from the thawing index for each era.</td>
+      <td>
+        The mean of the three highest cumulative annual degree days from the
+        thawing index for each era.
+      </td>
     </tr>
     <tr>
       <td>freezing</td>
-      <td>The mean of the three highest cumulative annual degree days from the freezing index for each era.</td>
+      <td>
+        The mean of the three highest cumulative annual degree days from the
+        freezing index for each era.
+      </td>
     </tr>
   </tbody>
 </table>
 
 <h4>Examples</h4>
-<p>Query for the historical and projected design thawing index at a provided point:</p>
-<p>Example: <a href="/design_index/thawing/point/65.0628/-146.1627">/design_index/thawing/point/65.0628/-146.1627</a></p>
-<p>Query for the historical and projected design freezing index at a provided point:</p>
-<p>Example: <a href="/design_index/freezing/point/65.0628/-146.1627">/design_index/freezing/point/65.0628/-146.1627</a></p>
+
+<h5>Design Thawing Index</h5>
+<p>Query for the historical design thawing index at a provided point:</p>
+<p></p>
+<p>
+  Example:
+  <a href="/design_index/thawing/historical/point/65.0628/-146.1627"
+    >/design_index/thawing/historical/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>Query for the projected design thawing index at a provided point:</p>
+<p></p>
+<p>
+  Example:
+  <a href="/design_index/thawing/projected/point/65.0628/-146.1627"
+    >/design_index/thawing/projected/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>
+  Query for the historical and projected design thawing index at a provided
+  point:
+</p>
+<p></p>
+<p>
+  Example:
+  <a href="/design_index/thawing/hp/point/65.0628/-146.1627"
+    >/design_index/thawing/hp/point/65.0628/-146.1627</a
+  >
+</p>
+
+<h5>Design Freezing Index</h5>
+<p>Query for the historical design freezing index at a provided point:</p>
+<p></p>
+<p>
+  Example:
+  <a href="/design_index/freezing/historical/point/65.0628/-146.1627"
+    >/design_index/freezing/historical/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>Query for the projected design freezing index at a provided point:</p>
+<p></p>
+<p>
+  Example:
+  <a href="/design_index/freezing/projected/point/65.0628/-146.1627"
+    >/design_index/freezing/projected/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>
+  Query for the historical and projected design freezing index at a provided
+  point:
+</p>
+<p></p>
+<p>
+  Example:
+  <a href="/design_index/freezing/hp/point/65.0628/-146.1627"
+    >/design_index/freezing/hp/point/65.0628/-146.1627</a
+  >
+</p>
 
 <b>Results from the queries above will look like this:</b>
 
 <pre>
 {
-  "ERA-Interim": {
-    "1980-2009": {
-      "di": 3429
+  "2040-2069": {
+    "di": 3787
+  },
+  ...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &lt;era>: {
+    "di": &lt;mean of degree days across top three years across models and era>
+  },
+  ...
+}
+</pre>
+
+<h4>Comprehensive queries</h4>
+<p>
+  The following queries will fetch design index values across all available
+  models.
+</p>
+
+<p>
+  Example:
+  <a href="/design_index/freezing/all/point/65.0628/-146.1627"
+    >/design_index/freezing/all/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>
+  Example:
+  <a href="/design_index/thawing/all/point/65.0628/-146.1627"
+    >/design_index/thawing/all/point/65.0628/-146.1627</a
+  >
+</p>
+
+<b>Results from the query above will look like this:</b>
+
+<pre>
+{
+  ...
+  "GFDL-CM3": {
+    "2040-2069": {
+      "di": 1548
+    },
+    "2070-2099": {
+      "di": 775
     }
   },
   ...
@@ -50,15 +160,26 @@
 {
   &lt;model>: {
     &lt;era>: {
-      "di": &lt;mean of degree days for top three years in era>
-    }
-  },
+      "dd": &lt;mean of degree days across top three years across era>
+    },
+    ...
+  }
   ...
 }
 </pre>
 
 <h4>CSV Export</h4>
 <p>To export the point data in a CSV file, append <code>?format=csv</code>.</p>
-<p>Example: <a href="/design_index/thawing/point/65.0628/-146.1627?format=csv">/design_index/thawing/point/65.0628/-146.1627?format=csv</a></p>
-<p>Example: <a href="/design_index/freezing/point/65.0628/-146.1627?format=csv">/design_index/freezing/point/65.0628/-146.1627?format=csv</a></p>
+<p>
+  Example:
+  <a href="/design_index/thawing/all/point/65.0628/-146.1627?format=csv"
+    >/design_index/thawing/all/point/65.0628/-146.1627?format=csv</a
+  >
+</p>
+<p>
+  Example:
+  <a href="/design_index/freezing/all/point/65.0628/-146.1627?format=csv"
+    >/design_index/freezing/all/point/65.0628/-146.1627?format=csv</a
+  >
+</p>
 {% endblock %}


### PR DESCRIPTION
Closes #197.

This PR updates the `/design_index` endpoints to support the same options as the `/mmm` endpoints:

- historical
- projected
- hp
- all

The projected data from the `projected` and `hp` options is the mean of the data across the two available models.

With this change, when you click a point on the map of the Design Thawing Index or Design Freezing Index plate in the Arctic EDS web app, you are shown a data table similar to what you see in the Temperature and Precipitation plates (means, not data for individual models).

The data that had previously been returned by the `design_index` endpoints is still accessible via the `all` option.

To test, view the revised Design Index endpoint documentation here and make sure the URLs work as expected:

http://localhost:5000/design_index/point