### PR TITLE
Modify snow endpoint to use mm units with no decimal places.

### DIFF
--- a/routes/snow.py
+++ b/routes/snow.py
@@ -24,7 +24,7 @@ from config import WEST_BBOX, EAST_BBOX
 
 snow_api = Blueprint("snow_api", __name__)
 # rasdaman targets
-sfe_coverage_id = "mean_annual_snowfall"
+sfe_coverage_id = "mean_annual_snowfall_mm"
 
 
 def package_sfe_data(sfe_resp):
@@ -98,7 +98,7 @@ def summarize_mmm_sfe(all_sfe_di):
     ]
     mmm_sfe_di["historical"]["sfemin"] = min(hist_vals)
     mmm_sfe_di["historical"]["sfemax"] = max(hist_vals)
-    mmm_sfe_di["historical"]["sfemean"] = round(np.mean(hist_vals), 1)
+    mmm_sfe_di["historical"]["sfemean"] = round(np.mean(hist_vals))
     proj_vals = []
     for model in ["GFDL-CM3", "GISS-E2-R", "IPSL-CM5A-LR", "MRI-CGCM3", "NCAR-CCSM4"]:
         for scenario in ["rcp45", "rcp60", "rcp85"]:
@@ -110,7 +110,7 @@ def summarize_mmm_sfe(all_sfe_di):
                 proj_vals.append(mod_sc_val)
     mmm_sfe_di["projected"]["sfemin"] = min(proj_vals)
     mmm_sfe_di["projected"]["sfemax"] = max(proj_vals)
-    mmm_sfe_di["projected"]["sfemean"] = round(np.mean(proj_vals), 1)
+    mmm_sfe_di["projected"]["sfemean"] = round(np.mean(proj_vals))
     return mmm_sfe_di
 
 
@@ -134,7 +134,7 @@ def create_csv(data_pkg, lat=None, lon=None):
         data_pkg,
         fieldnames,
     )
-    metadata = "#SFE is the total annual snowfall equivalent in inches for the specified model-scenario-decade\n"
+    metadata = "#SFE is the total annual snowfall equivalent in millimeters for the specified model-scenario-decade\n"
     filename = "SFE for " + lat + ", " + lon + ".csv"
     return write_csv(csv_dicts, fieldnames, filename, metadata)
 

--- a/templates/mmm/abstract.html
+++ b/templates/mmm/abstract.html
@@ -3,7 +3,7 @@
 <h3>Historical and Projected Minimum, Mean, and Maximum</h3>
 <p>The endpoints here provide access to both historical and projected model data over the state of Alaska for
     the surface temperature in degrees Fahrenheit, total annual precipitation in
-    inches, total annual snowfall equivalent in inches, and degree days at various thresholds.
+    inches, total annual snowfall equivalent in millimeters, and degree days at various thresholds.
 </p>
 <h4>Service endpoints</h4>
 <p>These endpoints are for point queries of minimum, mean, and maximum values of temperature, precipitation, snowfall

--- a/templates/mmm/snow.html
+++ b/templates/mmm/snow.html
@@ -1,31 +1,43 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>Snowfall Equivalent</h3>
-<p>This endpoint accesses historical and projected modeled decadal summaries of annual snowfall equivalent (SFE) for
-    Alaska. Note that
-    SFE has a very specific meaning in a modeling context: it is the product of the fraction of days in a month with
-    precipitation falling as snow and the total monthly precipitation. That product (monthly) is then summed to create a
-    single annual total SFE value. The SFE values provided here are inches of water. </p>
+<p>
+  This endpoint accesses historical and projected modeled decadal summaries of
+  annual snowfall equivalent (SFE) for Alaska. Note that SFE has a very specific
+  meaning in a modeling context: it is the product of the fraction of days in a
+  month with precipitation falling as snow and the total monthly precipitation.
+  That product (monthly) is then summed to create a single annual total SFE
+  value. The SFE values provided here are millimeters of water.
+</p>
 <h4>Summary queries for SFE</h4>
 <p>Query the historical SFE min, mean, and max:</p>
-<p>Example: <a
-        href="/mmm/snow/snowfallequivalent/historical/61.5/-147">/mmm/snow/snowfallequivalent/historical/61.5/-147</a>
+<p>
+  Example:
+  <a href="/mmm/snow/snowfallequivalent/historical/61.5/-147"
+    >/mmm/snow/snowfallequivalent/historical/61.5/-147</a
+  >
 </p>
 <p>Query the projected SFE min, mean, and max:</p>
-<p>Example: <a
-        href="/mmm/snow/snowfallequivalent/projected/61.5/-147">/mmm/snow/snowfallequivalent/projected/61.5/-147</a>
+<p>
+  Example:
+  <a href="/mmm/snow/snowfallequivalent/projected/61.5/-147"
+    >/mmm/snow/snowfallequivalent/projected/61.5/-147</a
+  >
 </p>
 <p>Query both the historical and projected SFE min, mean, and max:</p>
+<p></p>
 <p>
-<p>Example: <a href="/mmm/snow/snowfallequivalent/hp/61.5/-147">/mmm/snow/snowfallequivalent/hp/61.5/-147</a>
+  Example:
+  <a href="/mmm/snow/snowfallequivalent/hp/61.5/-147"
+    >/mmm/snow/snowfallequivalent/hp/61.5/-147</a
+  >
 </p>
 <b>Results from the queries above will look like this:</b>
 <pre>
 {
   "historical": {
-    "sfemax": 192,
-    "sfemean": 145,
-    "sfemin": 116
+    "sfemax": 4876,
+    "sfemean": 3701,
+    "sfemin": 2946
   }
   ...
 }
@@ -42,16 +54,23 @@
 }
 </pre>
 <h4>Comprehensive queries for SFE</h4>
-<p>Query both the historical and projected SFE values for all models, scenarios, and decades (1910-1919 through
-    2090-2099):</p>
-<p>Example: <a href="/mmm/snow/snowfallequivalent/all/61.5/-147">/mmm/snow/snowfallequivalent/all/61.5/-147</a></p>
+<p>
+  Query both the historical and projected SFE values for all models, scenarios,
+  and decades (1910-1919 through 2090-2099):
+</p>
+<p>
+  Example:
+  <a href="/mmm/snow/snowfallequivalent/all/61.5/-147"
+    >/mmm/snow/snowfallequivalent/all/61.5/-147</a
+  >
+</p>
 <b>Results from the query above will look like this:</b>
 <pre>
 {
     "CRU-TS": {
     "historical": {
         "1910-1919": {
-        "SFE": 149,
+        "SFE": 3801,
         }
         ...
     }
@@ -76,11 +95,15 @@
 }
 </pre>
 
-
 <h4>CSV Export</h4>
-<p>To export the point data in a CSV file, append <code>?format=csv</code>. Currently only available for the "all" data
-    option.</p>
-<p>Example: <a
-        href="/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv">/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv</a>
+<p>
+  To export the point data in a CSV file, append <code>?format=csv</code>.
+  Currently only available for the "all" data option.
+</p>
+<p>
+  Example:
+  <a href="/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv"
+    >/mmm/snow/snowfallequivalent/all/61.5/-147?format=csv</a
+  >
 </p>
 {% endblock %}


### PR DESCRIPTION
This endpoint is being updated to return SI units with appropriate levels of precision. In this case, this means changing inches to millimeters with no decimal places.

To test this endpoint visit http://localhost:5000/mmm/snow/snowfallequivalent/hp/61.5/-147 and confirm that the results are as follows:

```
{
  "historical": {
    "sfemax": 4876, 
    "sfemean": 3701, 
    "sfemin": 2946
  }, 
  "projected": {
    "sfemax": 3945, 
    "sfemean": 3419, 
    "sfemin": 2589
  }
}
```

You may also try a few other locations - all returned values should have no decimal places.

XREF these issues:
https://github.com/ua-snap/rasdaman-ingest/issues/35
https://github.com/ua-snap/rasdaman-ingest/issues/34

Note - the "Prettier" formatter on VSCode did a lot of formatting to the HTML that documents this endpoint.