### PR TITLE
Round degree days to whole numbers, and MAGT to one decimal

### DIFF
--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -257,7 +257,7 @@ def package_dd_point_data(point_data, var_ep, horp):
             year_index = 0
             for value in v_li:
                 if year in years:
-                    point_pkg[model][years[year_index]] = {"dd": value}
+                    point_pkg[model][years[year_index]] = {"dd": round(value)}
                     year_index += 1
                 year += 1
     else:
@@ -267,9 +267,9 @@ def package_dd_point_data(point_data, var_ep, horp):
             historical_min = round(point_data[2], 1)
 
             point_pkg["historical"] = {}
-            point_pkg["historical"]["ddmin"] = historical_min
-            point_pkg["historical"]["ddmean"] = historical_mean
-            point_pkg["historical"]["ddmax"] = historical_max
+            point_pkg["historical"]["ddmin"] = round(historical_min)
+            point_pkg["historical"]["ddmean"] = round(historical_mean)
+            point_pkg["historical"]["ddmax"] = round(historical_max)
 
         if horp in ["projected", "hp"]:
             if horp == "projected":
@@ -282,9 +282,9 @@ def package_dd_point_data(point_data, var_ep, horp):
                 projected_min = round(point_data[5], 1)
 
             point_pkg["projected"] = {}
-            point_pkg["projected"]["ddmin"] = projected_min
-            point_pkg["projected"]["ddmean"] = projected_mean
-            point_pkg["projected"]["ddmax"] = projected_max
+            point_pkg["projected"]["ddmin"] = round(projected_min)
+            point_pkg["projected"]["ddmean"] = round(projected_mean)
+            point_pkg["projected"]["ddmax"] = round(projected_max)
 
     return point_pkg
 
@@ -314,7 +314,7 @@ def package_di_point_data(point_data, horp):
                 if value is None:
                     point_pkg[model][era] = None
                 else:
-                    point_pkg[model][era] = {"di": value}
+                    point_pkg[model][era] = {"di": round(value)}
     else:
         keys = []
         if horp in ["historical", "hp"]:
@@ -325,7 +325,7 @@ def package_di_point_data(point_data, horp):
 
         index = 0
         for key in keys:
-            point_pkg[key] = {"di": point_data[index]}
+            point_pkg[key] = {"di": round(point_data[index])}
             index += 1
 
     return point_pkg

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -125,10 +125,11 @@ def package_gipl(gipl_resp):
     for era in di.keys():
         for model in di[era].keys():
             for scenario in di[era][model]:
-                di[era][model][scenario]["magt"] = float(
-                    flattened_resp[i].split(" ")[0]
-                )
-                di[era][model][scenario]["alt"] = float(flattened_resp[i].split(" ")[1])
+                values = flattened_resp[i].split(" ")
+                magt_value = round(float(values[0]), 1)
+                alt_value = float(values[1])
+                di[era][model][scenario]["magt"] = magt_value
+                di[era][model][scenario]["alt"] = alt_value
                 i += 1
     # This block drops all the invalid dimensional combinations that are a result of jamming historical and projected data into the same data cube. These are no data values (-9999) that should be culled.
     models.remove("cruts31")

--- a/templates/mmm/degree_days.html
+++ b/templates/mmm/degree_days.html
@@ -81,7 +81,7 @@
 {
   "historical": {
     "ddmax": 14972,
-    "ddmean": 13696.3,
+    "ddmean": 13696,
     "ddmin": 9357
   },
   ...

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -11,7 +11,7 @@
       "cruts31": {
         "historical": {
           "alt": 0.59,
-          "magt": -2.17,
+          "magt": -2.2
         }
       }
     },
@@ -19,51 +19,51 @@
       "gfdlcm3": {
         "rcp45": {
           "alt": 0.68,
-          "magt": -0.02,
+          "magt": 0
         },
         "rcp85": {
           "alt": 0.66,
-          "magt": -0.03,
+          "magt": 0
         }
       },
       "gisse2r": {
         "rcp45": {
           "alt": 0.61,
-          "magt": -1.03,
+          "magt": -1
         },
         "rcp85": {
           "alt": 0.6,
-          "magt": -1.09,
+          "magt": -1.1
         }
       },
       "ipslcm5alr": {
         "rcp45": {
           "alt": 0.65,
-          "magt": -0.92,
+          "magt": -0.9
         },
         "rcp85": {
           "alt": 0.69,
-          "magt": -0.14,
+          "magt": -0.1
         }
       },
       "mricgcm3": {
         "rcp45": {
           "alt": 0.61,
-          "magt": -1.2,
+          "magt": -1.2
         },
         "rcp85": {
           "alt": 0.6,
-          "magt": -1.14,
+          "magt": -1.1
         }
       },
       "ncarccsm4": {
         "rcp45": {
           "alt": 0.66,
-          "magt": -0.6,
+          "magt": -0.6
         },
         "rcp85": {
           "alt": 0.64,
-          "magt": -0.5,
+          "magt": -0.5
         }
       }
     },
@@ -71,51 +71,51 @@
       "gfdlcm3": {
         "rcp45": {
           "alt": 0.98,
-          "magt": 2.22,
+          "magt": 2.2
         },
         "rcp85": {
           "alt": 0.81,
-          "magt": 3.25,
+          "magt": 3.2
         }
       },
       "gisse2r": {
         "rcp45": {
           "alt": 0.62,
-          "magt": -0.82,
+          "magt": -0.8
         },
         "rcp85": {
           "alt": 0.64,
-          "magt": -0.23,
+          "magt": -0.2
         }
       },
       "ipslcm5alr": {
         "rcp45": {
           "alt": 0.68,
-          "magt": -0.25,
+          "magt": -0.2
         },
         "rcp85": {
           "alt": 0.69,
-          "magt": -0.15,
+          "magt": -0.1
         }
       },
       "mricgcm3": {
         "rcp45": {
           "alt": 0.63,
-          "magt": -0.85,
+          "magt": -0.8
         },
         "rcp85": {
           "alt": 0.63,
-          "magt": -0.59,
+          "magt": -0.6
         }
       },
       "ncarccsm4": {
         "rcp45": {
           "alt": 0.67,
-          "magt": -0.38,
+          "magt": -0.4
         },
         "rcp85": {
           "alt": 1.21,
-          "magt": 0.31,
+          "magt": 0.3
         }
       }
     },
@@ -123,51 +123,51 @@
       "gfdlcm3": {
         "rcp45": {
           "alt": 0.81,
-          "magt": 3.4,
+          "magt": 3.4
         },
         "rcp85": {
           "alt": 0.54,
-          "magt": 5.6,
+          "magt": 5.6
         }
       },
       "gisse2r": {
         "rcp45": {
           "alt": 0.62,
-          "magt": -0.74,
+          "magt": -0.7
         },
         "rcp85": {
           "alt": 0.65,
-          "magt": -0.02,
+          "magt": 0
         }
       },
       "ipslcm5alr": {
         "rcp45": {
           "alt": 1.26,
-          "magt": 0.14,
+          "magt": 0.1
         },
         "rcp85": {
           "alt": 0.91,
-          "magt": 3.08,
+          "magt": 3.1
         }
       },
       "mricgcm3": {
         "rcp45": {
           "alt": 0.64,
-          "magt": -0.69,
+          "magt": -0.7
         },
         "rcp85": {
           "alt": 1.19,
-          "magt": 0.13,
+          "magt": 0.1
         }
       },
       "ncarccsm4": {
         "rcp45": {
           "alt": 1.17,
-          "magt": 0.68,
+          "magt": 0.7
         },
         "rcp85": {
           "alt": 0.9,
-          "magt": 2.61,
+          "magt": 2.6
         }
       }
     },
@@ -175,55 +175,55 @@
       "gfdlcm3": {
         "rcp45": {
           "alt": 0.81,
-          "magt": 3.88,
+          "magt": 3.9
         },
         "rcp85": {
           "alt": 0.33,
-          "magt": 7.48,
+          "magt": 7.5
         }
       },
       "gisse2r": {
         "rcp45": {
           "alt": 0.61,
-          "magt": -0.69,
+          "magt": -0.7
         },
         "rcp85": {
           "alt": 1.1,
-          "magt": 0.73,
+          "magt": 0.7
         }
       },
       "ipslcm5alr": {
         "rcp45": {
           "alt": 1.15,
-          "magt": 0.92,
+          "magt": 0.9
         },
         "rcp85": {
           "alt": 0.66,
-          "magt": 5.17,
+          "magt": 5.2
         }
       },
       "mricgcm3": {
         "rcp45": {
           "alt": 0.66,
-          "magt": -0.37,
+          "magt": -0.4
         },
         "rcp85": {
           "alt": 0.99,
-          "magt": 1.69,
+          "magt": 1.7
         }
       },
       "ncarccsm4": {
         "rcp45": {
           "alt": 1.18,
-          "magt": 0.53,
+          "magt": 0.5
         },
         "rcp85": {
           "alt": 0.6,
-          "magt": 5.54,
+          "magt": 5.5
         }
       }
-    }
-    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature and Active Layer Thickness Model Output"
+    },
+    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (°C) and Active Layer Thickness (m) Model Output"
   },
   "jorg": {
     "ice": "Moderate",
@@ -232,8 +232,8 @@
   },
   "obu_magt": {
     "depth": "Top of Permafrost",
-    "temp": 0.17,
-    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (deg. C)",
+    "temp": 0.2,
+    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (°C)",
     "year": "2000-2016"
   },
   "obupfx": {


### PR DESCRIPTION
Closes #202.

To test:

- Try out some example URLs from the [Design Index](http://localhost:5000/design_index/point) and [Degree Days](http://localhost:5000/mmm/degree_days/) endpoints (+ try some lat/lon coordinates of your own). Every value returned from these endpoints should be rounded to a whole number.
- Try the [Permafrost](http://localhost:5000/permafrost/point/) endpoint with several different lat/lon coordinates. Make sure all MAGT values are rounded to one decimal place.
- Observe that values in the example output in the documentation pages linked above match the expected decimal precision.