### PR TITLE
Add AK borough and census areas polygons for zonal area queries

### DIFF
--- a/luts.py
+++ b/luts.py
@@ -79,6 +79,8 @@ permafrost_encodings = {
 
 json_types = {
     "communities": "data/jsons/ak_communities.json",
+    "boroughs": "data/jsons/ak_boroughs.json",
+    "census_areas": "data/jsons/ak_census_areas.json",
     "hucs": "data/jsons/ak_huc8.json",
     "huc8s": "data/jsons/ak_huc8.json",
     "huc12s": "data/jsons/ak_huc12.json",
@@ -94,6 +96,8 @@ json_types = {
 place_type_labels = {
     "huc8s": "HUC",
     "protected_areas": "Protected Area",
+    "boroughs": "Borough",
+    "census_areas": "Census Area",
     "fire_zones": "Fire Management Unit",
     "corporations": "Corporation",
     "climate_divisions": "Climate Division",
@@ -128,6 +132,8 @@ all_jsons = [
     "fire_zones",
     "game_management_units",
     "first_nations",
+    "boroughs",
+    "census_areas",
 ]
 
 # For the forest endpoint.  This file is just a generated pickle
@@ -175,6 +181,14 @@ try:
     cafn_src = "data/shapefiles/first_nation_traditional_territories.shp"
     cafn_gdf = gpd.read_file(cafn_src).set_index("id").to_crs(3338)
 
+    # Alaska Boroughs
+    boro_src = "data/shapefiles/ak_boroughs.shp"
+    boro_gdf = gpd.read_file(boro_src).set_index("id").to_crs(3338)
+
+    # Unorganized Borough Census Areas
+    akcensus_src = "data/shapefiles/ak_census_areas.shp"
+    akcensus_gdf = gpd.read_file(akcensus_src).set_index("id").to_crs(3338)
+
     # join HUCs into same GeoDataFrame for easier lookup
     huc_gdf = pd.concat(
         [huc8_gdf.reset_index(), huc12_gdf.reset_index()], ignore_index=True
@@ -191,6 +205,8 @@ try:
     type_di["fire_zone"] = akfire_gdf
     type_di["game_management_unit"] = akgmu_gdf
     type_di["first_nation"] = cafn_gdf
+    type_di["borough"] = boro_gdf
+    type_di["census_area"] = akcensus_gdf
 
     update_needed = False
 except fiona.errors.DriverError:
@@ -208,8 +224,10 @@ except fiona.errors.DriverError:
         akgmu_gdf,
         cafn_gdf,
         huc_gdf,
+        boro_gdf,
+        akcensus_gdf,
         valid_huc_ids,
-    ) = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    ) = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     type_di = dict()
 
 # look-up for updating place names and data via geo-vector GitHub repo
@@ -266,5 +284,17 @@ shp_di["cnfns"] = {
     "src_dir": "first_nations",
     "prefix": "first_nation_traditional_territories",
     "poly_type": "first_nation",
+    "retain": [],
+}
+shp_di["akboros"] = {
+    "src_dir": "boroughs",
+    "prefix": "ak_boroughs",
+    "poly_type": "borough",
+    "retain": [],
+}
+shp_di["akcensusareas"] = {
+    "src_dir": "census_areas",
+    "prefix": "ak_census_areas",
+    "poly_type": "census_area",
     "retain": [],
 }

--- a/templates/boundary/abstract.html
+++ b/templates/boundary/abstract.html
@@ -1,28 +1,64 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>Boundary data</h3>
-<p>These data are intended for exposing the polygon boundaries used across SNAP tools and data. Each query for a polygon will return the representative GeoJSON.</p>
+<p>
+  These data are intended for exposing the polygon boundaries used across SNAP
+  tools and data. Each query for a polygon will return the representative
+  GeoJSON.
+</p>
 <h4>Service Endpoint</h4>
-<p>The endpoint is <code>boundary/area/&lt;area_id&gt;</code> for all <a href="/places/all">available area&ndash;of&ndash;interest ID codes</a>.</p>
+<p>
+  The endpoint is <code>boundary/area/&lt;area_id&gt;</code> for all
+  <a href="/places/all">available area&ndash;of&ndash;interest ID codes</a>.
+</p>
 <h4>HUC-8 Polygon Query</h4>
 <p>Query HUC-8s of Alaska and return a GeoJSON of the polygon.</p>
-<p>Example HUC-8 query: <a href="/boundary/area/19070506">/boundary/area/19070506</a></p>
+<p>
+  Example HUC-8 query:
+  <a href="/boundary/area/19070506">/boundary/area/19070506</a>
+</p>
 <h4>HUC-12 Polygon Query</h4>
 <p>Query HUC-12s of Alaska and return a GeoJSON of the polygon.</p>
-<p>Example HUC-12 query: <a href="/boundary/area/190202011303">/boundary/area/190202011303</a></p>
+<p>
+  Example HUC-12 query:
+  <a href="/boundary/area/190202011303">/boundary/area/190202011303</a>
+</p>
 <h4>Protected Area Polygons Query</h4>
-<p>Query the protected area polygons of Alaska, British Columbia, and Yukon and return a GeoJSON of the polygon.</p>
+<p>
+  Query the protected area polygons of Alaska, British Columbia, and Yukon and
+  return a GeoJSON of the polygon.
+</p>
 <p>Example: <a href="/boundary/area/NPS12">/boundary/area/NPS12</a></p>
 <h4>Alaska Native Corporation Polygon Query</h4>
-<p>Query Alaska Native corporation regions and return a GeoJSON of the polygon.</p>
+<p>
+  Query Alaska Native corporation regions and return a GeoJSON of the polygon.
+</p>
 <p>Example: <a href="/boundary/area/NC8">/boundary/area/NC8</a></p>
 <h4>Climate Division Polygon Query</h4>
-<p>Query the climate divisions of Alaska and return a GeoJSON of the polygon.</p>
+<p>
+  Query the climate divisions of Alaska and return a GeoJSON of the polygon.
+</p>
 <p>Example: <a href="/boundary/area/CD3">/boundary/area/CD3</a></p>
 <h4>Fire Management Polygon Query</h4>
-<p>Query the fire management zones of Alaska and return a GeoJSON of the polygon.</p>
+<p>
+  Query the fire management zones of Alaska and return a GeoJSON of the polygon.
+</p>
 <p>Example: <a href="/boundary/area/FIRE2">/boundary/area/FIRE2</a></p>
 <h4>Ethnolinguistic Region Polygon Query</h4>
-<p>Query ethnolinguistic regions of Alaska and parts of Canada and return a GeoJSON of the polygon.</p>
+<p>
+  Query ethnolinguistic regions of Alaska and parts of Canada and return a
+  GeoJSON of the polygon.
+</p>
 <p>Example: <a href="/boundary/area/EL4">/boundary/area/EL4</a></p>
+<h4>Alaska Borough Polygon Query</h4>
+<p>
+  Query Alaska administrative boroughs (county equivalents) and return a GeoJSON
+  of the polygon.
+</p>
+<p>Example: <a href="/boundary/area/BORO4">/boundary/area/BORO4</a></p>
+<h4>Unorganized Borough Census Area Polygon Query</h4>
+<p>
+  Query Alaska census areas for the Unorganized Borough (county equivalents) and
+  return a GeoJSON of the polygon.
+</p>
+<p>Example: <a href="/boundary/area/CENS3">/boundary/area/CENS3</a></p>
 {% endblock %}


### PR DESCRIPTION
This PR adds 10 census area and 19 borough polygons (see map below) to the API and makes them available for queries, GeoJSON fetching, and the nearby polygon "geo-search" functionality.

![boro_census](https://user-images.githubusercontent.com/7774271/187559821-8e4fcd86-8e17-4783-8873-d807e1ef3aea.png)

I recommend trying the following areas in various queries, because these were the intially troubling polygons due to either extent or size:

 `BORO1`: The Aleutians Borough
 `BORO3`: The North Slope Borough
 `CENS6`: Nome Census Area
 `CENS9`: Bethel Census Area

I've tested these for the Elevation, Relative Flammability, and Temperature area summary queries. Note that some of these queries will take several minutes when not cached. Also note that when you initially launch the API it will take a moment to download the shapefiles and generate the appropriate JSONs.

To see the full list of new polygons added, vist:

http://localhost:5000/places/boroughs

and

http://localhost:5000/places/census_areas

To test that the search functionality still works, try:

http://localhost:5000/places/search/65/-147

and verify that you see FNSB and the YK Census Area under the `ak_boros_near` and `ak_censusareas_near` items.

Finally, take a peek at http://localhost:5000/boundary/abstract/ and verify that it looks good.

XREF https://github.com/ua-snap/geospatial-vector-veracity/issues/83

XREF https://github.com/ua-snap/iem-webapp/issues/394
