### PR TITLE
Landfast Sea Ice Endpoint 1.0

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -323,11 +323,13 @@ def get_from_dict(data_dict, map_list):
 
 def parse_meta_xml_str(meta_xml_str):
     """Parse the DescribeCoverage request to get the XML and
-    restructure to dict
+    restructure the block called "Encoding" to a dict.
 
-    Args:
-        meta_xml_str (str): decoded text XML response from
-            DescribeCoverage WCS query
+    Arguments:
+        meta_xml_str (str): string representation of the byte XML response from the WCS DescribeCoverage request
+
+    Returns:
+        dim_encodings (dict): lookup table to match data axes or parameters to integer encodings, e.g., '2': 'GFDL-CM3'
     """
     meta_xml = ET.ElementTree(ET.fromstring(meta_xml_str))
     # wow xml
@@ -357,23 +359,45 @@ def parse_meta_xml_str(meta_xml_str):
     return dim_encodings
 
 
-async def get_dim_encodings(cov_id):
+def get_xml_str_between_tags(meta_xml_str, tag):
+    """Get string encapsulated by a known XML tag.
+
+    Arguments:
+        meta_xml_str (str): string representation of the byte XML response from the WCS DescribeCoverage request
+        tag (str): the xml string that encapsulates the desired information, e.g., 'gmlrgrid:coefficients'
+
+    Returns:
+        str_within_tag (str): string encapsulated by the provided XML tag
+    """
+    tag_open = f"<{tag}>"
+    tag_close = "<"
+    str_after_tag = meta_xml_str.split(tag_open)[1]
+    str_within_tag = str_after_tag.split(tag_close)[0]
+    return str_within_tag
+
+
+async def get_dim_encodings(cov_id, scrape=None):
     """Get the dimension encodings that map integer values to descriptive strings from a
     Rasdaman coverage that stores the encodings in a metadata "encodings" attribute. We
     handle exceptions where the coverage we are requesting encodings from does not exist
-    on the backend to prevent Rasdaman work from blocking API development.
+    on the backend to prevent Rasdaman work from blocking API development. We can use the same request to scrape various other parts of the DescribeCoverage XML response, but this optional.
 
     Args:
         cov_id (str): ID of the rasdaman coverage
+        scrape (2-tuple of strings): (description, tag to scrape between)
 
     Returns:
-        dict of encodings, with axis name as keys holding
-        dicts of integer-keyed categories
+        dim_encodings (nested dict): a lookup where coverage axis names are keys that store dicts of integer-keyed categories.
     """
     meta_url = generate_wcs_query_url(f"DescribeCoverage&COVERAGEID={cov_id}")
     try:
         meta_xml_str = await fetch_data([meta_url])
         dim_encodings = parse_meta_xml_str(meta_xml_str)
+        if scrape is not None:
+            scrape_desc, scrape_tag = scrape
+            dim_encodings[scrape_desc] = get_xml_str_between_tags(
+                meta_xml_str, scrape_tag
+            )
         return dim_encodings
     except:
         print(

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -378,9 +378,7 @@ def get_xml_str_between_tags(meta_xml_str, tag):
 
 async def get_dim_encodings(cov_id, scrape=None):
     """Get the dimension encodings that map integer values to descriptive strings from a
-    Rasdaman coverage that stores the encodings in a metadata "encodings" attribute. We
-    handle exceptions where the coverage we are requesting encodings from does not exist
-    on the backend to prevent Rasdaman work from blocking API development. We can use the same request to scrape various other parts of the DescribeCoverage XML response, but this optional.
+    Rasdaman coverage that stores the encodings in a metadata "encodings" attribute. We handle exceptions where the coverage we are requesting encodings from does not exist on the backend to prevent Rasdaman work from blocking API development. We can use the same request to scrape various other parts of the DescribeCoverage XML response, but this optional.
 
     Args:
         cov_id (str): ID of the rasdaman coverage

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -18,3 +18,4 @@ from .elevation import *
 from .alfresco import *
 from .degree_days import *
 from .snow import *
+from .landfastice import *

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -18,6 +18,7 @@ from validate_request import (
     validate_latlon,
     project_latlon,
 )
+from validate_data import postprocess
 from . import routes
 from config import WEST_BBOX, EAST_BBOX
 
@@ -125,14 +126,13 @@ def run_point_fetch_all_landfastice(lat, lon):
             fetch_wcs_point_data(x, y, landfastice_coverage_id)
         )
         landfastice_time_series = package_landfastice_data(rasdaman_response)
-        # Unlike other endpoints, I'm electing to not call the post-process function on the data package because having an intact time series at this stage may be most useful, and the absence of landfast ice (i.e., no data) may prove useful as well.
         if request.args.get("format") == "csv":
             return create_landfast_csv(
-                landfastice_time_series,
+                postprocess(landfastice_time_series, "landfastice"),
                 lat,
                 lon,
             )
-        return landfastice_time_series
+        return postprocess(landfastice_time_series, "landfastice")
     except Exception as exc:
         if hasattr(exc, "status") and exc.status == 404:
             return render_template("404/no_data.html"), 404

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -58,7 +58,7 @@ def package_landfastice_data(landfastice_resp):
         landfastice_resp (list) -- the response from the WCS GetCoverage request
 
     Returns:
-        di (dict) -- a dict where the key is a single date and the value is the landfast ice status (1 or 0)
+        di (dict) -- a dict where the key is a single date and the value is the landfast ice status (1 indicates landfast ice is present)
     """
     time_index = generate_time_index("all")
     di = {}
@@ -84,7 +84,7 @@ def create_landfast_csv(data_pkg, lat=None, lon=None):
         data_pkg,
         fieldnames,
     )
-    metadata = "# Landfast Ice Status: 0 indicates absence and 1 indicates presence.\n"
+    metadata = "# Landfast Ice Status: A null value indicates absence and 1 indicates presence.\n"
     filename = "Landfast Ice Extent for " + lat + ", " + lon + ".csv"
     return write_csv(csv_dicts, fieldnames, filename, metadata)
 

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -76,7 +76,7 @@ def create_landfast_csv(data_pkg, lat=None, lon=None):
         CSV response object
     """
     fieldnames = [
-        "time",
+        "date",
         "value",
     ]
     csv_dicts = build_csv_dicts(

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -29,24 +29,15 @@ landfastice_encodings = asyncio.run(
 )
 
 
-def generate_time_index(ice_season="all"):
+def generate_time_index():
     """Generate a Pythonic time index for a single October-July ice season.
-
-    Arguments:
-        ice_season (str): Ice season string (YYYY) between 1996 and 2007 or 'all' for the entire time series.
 
     Returns:
         dt_range (pandas DatetimeIndex): a time index with daily frequency
     """
 
-    if ice_season == "all":
-        timestamps = [x[1:-2] for x in landfastice_encodings["time"].split(" ")]
-        date_index = pd.DatetimeIndex(timestamps)
-    else:
-        start, end = landfastice_encodings["ice_season"][ice_season][0].split(", ")
-        dt_start = start.split("T", 1)[0]
-        dt_end = end.split("T", 1)[0]
-        date_index = pd.date_range(start=dt_start, end=dt_end)
+    timestamps = [x[1:-2] for x in landfastice_encodings["time"].split(" ")]
+    date_index = pd.DatetimeIndex(timestamps)
     return date_index
 
 
@@ -60,7 +51,7 @@ def package_landfastice_data(landfastice_resp):
     Returns:
         di (dict) -- a dict where the key is a single date and the value is the landfast ice status (1 indicates landfast ice is present)
     """
-    time_index = generate_time_index("all")
+    time_index = generate_time_index()
     di = {}
     for t, x in zip(list(time_index), landfastice_resp):
         di[t.date().strftime("%m-%d-%Y")] = x

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -1,0 +1,131 @@
+import asyncio
+import calendar
+import numpy as np
+import pandas as pd
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+)
+
+# local imports
+from fetch_data import (
+    fetch_wcs_point_data,
+    get_dim_encodings,
+    build_csv_dicts,
+    write_csv,
+)
+from validate_request import (
+    validate_latlon,
+    project_latlon,
+    # validate_landfastice_year,  # we would want this, but or the ice seasons (oct to july) that are in the actual dataset.
+)
+from validate_data import nullify_and_prune, postprocess
+from . import routes
+from config import WEST_BBOX, EAST_BBOX
+
+landfastice_api = Blueprint("landfastice_api", __name__)
+landfastice_coverage_id = "landfast_sea_ice_extent"
+landfastice_encodings = asyncio.run(
+    get_dim_encodings(landfastice_coverage_id, scrape=("time", "gmlrgrid:coefficients"))
+)
+
+
+def generate_time_index(ice_season="all"):
+    """Generate a Pythonic time index for a single October-July ice season.
+
+    Arguments:
+        ice_season (str): Ice season string (YYYY) between 1996 and 2007 or 'all' for the entire time series.
+
+    Returns:
+        dt_range (pandas DatetimeIndex): a time index with daily frequency
+    """
+
+    if ice_season == "all":
+        timestamps = [x[1:-2] for x in landfastice_encodings["time"].split(" ")]
+        date_index = pd.DatetimeIndex(timestamps)
+    else:
+        start, end = landfastice_encodings["ice_season"][ice_season][0].split(", ")
+        dt_start = start.split("T", 1)[0]
+        dt_end = end.split("T", 1)[0]
+        date_index = pd.date_range(start=dt_start, end=dt_end)
+    return date_index
+
+
+def package_landfastice_data(landfastice_resp):
+    """Package landfast ice extent data into a nested JSON-like dict.
+
+    Arguments:
+        time_index (pandas DateRange object) -- a time index with daily frequency
+        landfastice_resp (list) -- the response from the WCS GetCoverage request
+
+    Returns:
+        di (dict) -- a dict where the key is a single date and the value is the landfast ice status (1 or 0)
+    """
+    time_index = generate_time_index("all")
+    di = {}
+    for t, x in zip(list(time_index), landfastice_resp):
+        di[t.date().strftime("%m-%d-%Y")] = x
+    return di
+
+
+@routes.route("/landfastice/")
+@routes.route("/landfastice/abstract/")
+def about_landfastice():
+    return render_template("landfastice/abstract.html")
+
+
+@routes.route("/landfastice/point/")
+def about_landfastice_point():
+    return render_template("landfastice/point.html")
+
+
+@routes.route("/landfastice/point/<lat>/<lon>/")
+def run_point_fetch_all_landfastice(lat, lon):
+    """Run the async request for landfast ice extent data at a single point.
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+
+    Returns:
+        JSON-like dict of landfast ice extent data
+    """
+    validation = validate_latlon(lat, lon)
+    if validation == 400:
+        return render_template("400/bad_request.html"), 400
+    if validation == 422:
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
+    x, y = project_latlon(lat, lon, 3338)
+    try:
+        rasdaman_response = asyncio.run(
+            fetch_wcs_point_data(x, y, landfastice_coverage_id)
+        )
+        landfastice_time_series = package_landfastice_data(rasdaman_response)
+
+        # landfastice_conc = postprocess(
+        #     package_landfastice_data(rasdaman_response), "landfastice"
+        # )
+        # if request.args.get("format") == "csv":
+        #     if type(landfastice_conc) is not dict:
+        #         # Returns errors if any are generated
+        #         return landfastice_conc
+        #     # Returns CSV for download
+        #     return create_csv(
+        #         postprocess(package_landfastice_data(rasdaman_response), "landfastice"),
+        #         lat,
+        #         lon,
+        #     )
+        # # Returns sea ice concentrations across years & months
+        # return postprocess(package_landfastice_data(rasdaman_response), "landfastice")
+        # return landfast_time_index
+        # return package_landfastice_data(rasdaman_response)
+        return landfastice_time_series
+    except Exception as exc:
+        if hasattr(exc, "status") and exc.status == 404:
+            return render_template("404/no_data.html"), 404
+        return render_template("500/server_error.html"), 500

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,25 +1,35 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h3>Overview</h3>
-<p>This is a data service that facilitates access to a variety of Alaska and Arctic geospatial data.
+<p>
+  This is a data service that facilitates access to a variety of Alaska and
+  Arctic geospatial data.
 </p>
-<p>The code is hosted on <a href="https://github.com/ua-snap/data-api">Github</a>. Instructions on how to use each data
-    endpoint is given below.</p>
+<p>
+  The code is hosted on
+  <a href="https://github.com/ua-snap/data-api">Github</a>. Instructions on how
+  to use each data endpoint is given below.
+</p>
 <h4>Service endpoints</h4>
 <ul>
-    <li><a href="/alfresco">ALFRESCO model outputs</a></li>
-    <li><a href="/design_index">Design Index</a></li>
-    <li><a href="/elevation">Digital Elevation Models (DEMs)</a></li>
-    <li><a href="/forest">Forests and Vegetation</a></li>
-    <li><a href="/geology">Geology</a></li>
-    <li><a href="/glacier">Glaciology</a></li>
-    <li><a href="/mean_annual_precip">Mean Annual Precipitation</a></li>
-    <li><a href="/permafrost">Permafrost</a></li>
-    <li><a href="/boundary">Physical and Administrative Boundary Polygons</a></li>
-    <li><a href="/physiography">Physiography</a></li>
-    <li><a href="/seaice">Sea Ice Concentration</a></li>
-    <li><a href="/taspr">Temperature and Precipitation</a></li>
-    <li><a href="/mmm">Temperature, Precipitation, Snow, Degree Days and Sea Ice Min, Mean, and Max</a></li>
-    <li><a href="/fire">Wildfire</a></li>
+  <li><a href="/alfresco">ALFRESCO model outputs</a></li>
+  <li><a href="/design_index">Design Index</a></li>
+  <li><a href="/elevation">Digital Elevation Models (DEMs)</a></li>
+  <li><a href="/forest">Forests and Vegetation</a></li>
+  <li><a href="/geology">Geology</a></li>
+  <li><a href="/glacier">Glaciology</a></li>
+  <li><a href="/landfastice">Landfast Sea Ice</a></li>
+  <li><a href="/mean_annual_precip">Mean Annual Precipitation</a></li>
+  <li><a href="/permafrost">Permafrost</a></li>
+  <li><a href="/boundary">Physical and Administrative Boundary Polygons</a></li>
+  <li><a href="/physiography">Physiography</a></li>
+  <li><a href="/seaice">Sea Ice Concentration</a></li>
+  <li><a href="/taspr">Temperature and Precipitation</a></li>
+  <li>
+    <a href="/mmm"
+      >Temperature, Precipitation, Snow, Degree Days and Sea Ice Min, Mean, and
+      Max</a
+    >
+  </li>
+  <li><a href="/fire">Wildfire</a></li>
 </ul>
 {% endblock %}

--- a/templates/landfastice/abstract.html
+++ b/templates/landfastice/abstract.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %} {% block content %}
+<h3>Landfast Sea Ice Extent.</h3>
+<p>Query landfast sea ice extent information for the Alaskan coastline.</p>
+<h4>Service Endpoints</h4>
+<ul>
+  <li><a href="/landfastice/point/">Point Query</a></li>
+</ul>
+{% endblock %}

--- a/templates/landfastice/abstract.html
+++ b/templates/landfastice/abstract.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %} {% block content %}
-<h3>Landfast Sea Ice Extent.</h3>
+<h3>Landfast Sea Ice Extent</h3>
 <p>Query landfast sea ice extent information for the Alaskan coastline.</p>
 <h4>Service Endpoints</h4>
 <ul>

--- a/templates/landfastice/point.html
+++ b/templates/landfastice/point.html
@@ -15,9 +15,9 @@
 <b>Results from queries like the above example will look like this:</b>
 <pre>
   {
-    "01-01-1997": 0, 
-    "01-01-1998": 0, 
-    "01-01-1999": 0, 
+    "01-01-1997": null, 
+    "01-01-1998": null, 
+    "01-01-1999": null, 
     "01-01-2000": 1, 
     "01-01-2001": 1, 
     "01-01-2002": 1, 
@@ -26,14 +26,14 @@
     "01-01-2005": 1, 
     "01-01-2006": 1, 
     "01-01-2007": 1, 
-    "01-01-2008": 0,
+    "01-01-2008": null,
     ... 
 } 
 </pre>
 <b>The above output is structured like this:</b>
 <pre>
 {
-    "&lt;month&gt;&ndash;&lt;day&gt;&ndash;&lt;year&gt;": &lt;landfast ice <strong>presence (1) or absence (0)</strong> for a specific date in the time series&gt;
+    "&lt;month&gt;&ndash;&lt;day&gt;&ndash;&lt;year&gt;": &lt;landfast ice <strong>presence (1) or absence (null)</strong> for a specific date in the time series&gt;
     ...
 }
 </pre>

--- a/templates/landfastice/point.html
+++ b/templates/landfastice/point.html
@@ -4,45 +4,37 @@
   This endpoint accesses daily landfast ice extent information for the Alaska
   Coastline between October 17th, 1996 and July 14th, 2008.
 </p>
-<h4>Fetch the entire daily time series.</h4>
+<h4>Fetch the entire daily time series</h4>
 <p>Query the daily landfast ice extent for a certain geographic point:</p>
 <p>
   Example:
-  <a href="/landfastice/point/70.77/-146.32"
-    >/landfastice/point/70.77/&minus;146.32</a
+  <a href="/landfastice/point/70.6123/-149.8869/"
+    >/landfastice/point/70.6123/&minus;149.8869</a
   >
 </p>
 <b>Results from queries like the above example will look like this:</b>
 <pre>
-{
-  ...
-}
+  {
+    "01-01-1997": 0, 
+    "01-01-1998": 0, 
+    "01-01-1999": 0, 
+    "01-01-2000": 1, 
+    "01-01-2001": 1, 
+    "01-01-2002": 1, 
+    "01-01-2003": 1, 
+    "01-01-2004": 1, 
+    "01-01-2005": 1, 
+    "01-01-2006": 1, 
+    "01-01-2007": 1, 
+    "01-01-2008": 0,
+    ... 
+} 
 </pre>
 <b>The above output is structured like this:</b>
 <pre>
 {
-  ...
+    "&lt;month&gt;&ndash;&lt;day&gt;&ndash;&lt;year&gt;": &lt;landfast ice <strong>presence (1) or absence (0)</strong> for a specific date in the time series&gt;
+    ...
 }
-</pre>
-<h4>Fetch a single annual ice season (October to July).</h4>
-<p>Query the daily landfast ice extent for a certain geographic point:</p>
-<p>
-  Example:
-  <a href="/landfastice/point/70.77/-146.32"
-    >/landfastice/point/70.77/&minus;146.32</a
-  >
-</p>
-<b>Results from queries like the above example will look like this:</b>
-<pre>
-{
-  ...
-}
-</pre>
-<b>The above output is structured like this:</b>
-<pre>
-{
-  ...
-}
-</pre>
 <h4>Source data</h4>
 {% endblock %}

--- a/templates/landfastice/point.html
+++ b/templates/landfastice/point.html
@@ -36,5 +36,29 @@
     "&lt;month&gt;&ndash;&lt;day&gt;&ndash;&lt;year&gt;": &lt;landfast ice <strong>presence (1) or absence (0)</strong> for a specific date in the time series&gt;
     ...
 }
+</pre>
+<h4>CSV Export</h4>
+<p>To export the point data in a CSV file, append <code>?format=csv</code>.</p>
+<p>
+  Example:
+  <a href="/landfastice/point/70.6123/-149.8869?format=csv"
+    >/landfastice/point/70.6123/-149.8869?format=csv</a
+  >
+</p>
 <h4>Source data</h4>
+<!-- This is a bit of a placeholder until the we launch ARDAC or get PI approval to publish in the Catalog.-->
+<p>
+  These data are part of the Arctic Data Collaborative (ARDAC). Scientists
+  working on Arctic research need easily obtainable climate and environmental
+  data. ARDAC is a system of online technologies that curate distribute relevant
+  Arctic environmental data in formats that improve the ability of scientists to
+  use this data. Users of these data should cite:
+</p>
+<p>
+  Mahoney, A., Eicken, H., Gaylord, A. G., and Shapiro, L. (2007), Alaska
+  landfast sea ice: Links with bathymetry and atmospheric circulation<i
+    >, J. Geophys. Res.,</i
+  >
+  112, C02001, doi:10.1029/2006JC003559.
+</p>
 {% endblock %}

--- a/templates/landfastice/point.html
+++ b/templates/landfastice/point.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %} {% block content %}
+<h3>Landfast Sea Ice Extent Point Query</h3>
+<p>
+  This endpoint accesses daily landfast ice extent information for the Alaska
+  Coastline between October 17th, 1996 and July 14th, 2008.
+</p>
+<h4>Fetch the entire daily time series.</h4>
+<p>Query the daily landfast ice extent for a certain geographic point:</p>
+<p>
+  Example:
+  <a href="/landfastice/point/70.77/-146.32"
+    >/landfastice/point/70.77/&minus;146.32</a
+  >
+</p>
+<b>Results from queries like the above example will look like this:</b>
+<pre>
+{
+  ...
+}
+</pre>
+<b>The above output is structured like this:</b>
+<pre>
+{
+  ...
+}
+</pre>
+<h4>Fetch a single annual ice season (October to July).</h4>
+<p>Query the daily landfast ice extent for a certain geographic point:</p>
+<p>
+  Example:
+  <a href="/landfastice/point/70.77/-146.32"
+    >/landfastice/point/70.77/&minus;146.32</a
+  >
+</p>
+<b>Results from queries like the above example will look like this:</b>
+<pre>
+{
+  ...
+}
+</pre>
+<b>The above output is structured like this:</b>
+<pre>
+{
+  ...
+}
+</pre>
+<h4>Source data</h4>
+{% endblock %}

--- a/templates/landfastice/point.html
+++ b/templates/landfastice/point.html
@@ -50,9 +50,9 @@
 <p>
   These data are part of the Arctic Data Collaborative (ARDAC). Scientists
   working on Arctic research need easily obtainable climate and environmental
-  data. ARDAC is a system of online technologies that curate distribute relevant
-  Arctic environmental data in formats that improve the ability of scientists to
-  use this data. Users of these data should cite:
+  data. ARDAC is a system of online technologies that curate and distribute
+  relevant Arctic environmental data in formats that improve the ability of
+  scientists to use this data. Users of these data should cite:
 </p>
 <p>
   Mahoney, A., Eicken, H., Gaylord, A. G., and Shapiro, L. (2007), Alaska

--- a/validate_data.py
+++ b/validate_data.py
@@ -19,7 +19,8 @@ nodata_values = {
     "physiography": [],
     "taspr": [-9999, -9.223372e18, -9.223372036854776e18],
     "snow": [-9999],
-    "seaice": [120, 254, 255]
+    "seaice": [120, 254, 255],
+    "landfastice": [0],
 }
 
 


### PR DESCRIPTION
This PR adds the first version of the landfast sea ice endpoint.

The data accessed by this endpoint are described in this [curation notebook](https://github.com/ua-snap/ardac-curation/blob/main/seaice/pipeline/qc.ipynb) and have been through a [QC process](https://github.com/ua-snap/ardac-curation/blob/main/seaice/pipeline/qc.ipynb). The data rely on the coverage `landfast_sea_ice_extent` which is currently on Apollo, but not Zeus.

We expect this service endpoint to significantly grow in both query versatility and in availability of diffferent data variables - but this initial service only provides a time series of landfast ice status (present or absent) for a geographic point. A value of `1` indicates that landfast ice exists. A value of `0` indicates that landfast ice does not exist.

To test this PR:
 - Point your local API at Apollo
 - Visit http://localhost:5000/landfastice/ and /landfastice/point/ and verify that text is clear and complete and that example links work as you'd expect.
 - Verify that "Landfast Sea Ice" is present on the API home page.
 - Try a few different points for queries and CSV results. You may need to scroll through the time series or sort it to see a scatter of `0` and `1` values.
 - Try a terrestrial lat-lon (like 65/-147) and verify you get a "No Data" message.

Other notes:
 - This PR adds a function where you can scrape between known tags in the XML returned by the DescribeCoverage request to Rasdaman. This is done to fetch and create the time index.
