### PR TITLE
New endpoint for generating combined JSON for all Arctic EDS report sections

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -106,6 +106,11 @@ async def make_get_request(url, session):
     elif "DescribeCoverage" in url:
         # DescribeCoverage in URL ==> XML coming back
         data = await resp.text()
+    else:
+        # Only here when requesting a URL within the API.
+        # Used by eds.py to return compiled JSON for all
+        # ArcticEDS plates.
+        data = await resp.json()
 
     return data
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -20,3 +20,4 @@ from .degree_days import *
 from .snow import *
 from .landfastice import *
 from .beetles import *
+from .eds import *

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -15,6 +15,19 @@ eds_api = Blueprint("eds_api", __name__)
 
 
 async def run_fetch_all_eds(lat, lon):
+    """
+    Fetches a list of data API end points to generate a multiple
+    variable JSON that can be used to generate a full report in the
+    Arctic EDS website.
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+
+
+    Returns:
+        Multiple variable JSON object
+    """
     host = request.host_url
     all_requests = [
         f"{host}eds/temperature/{lat}/{lon}",
@@ -37,4 +50,28 @@ async def run_fetch_all_eds(lat, lon):
 
 @routes.route("/eds/all/<lat>/<lon>")
 def fetch_all_eds(lat, lon):
+    """
+    Endpoint for requesting all data required for the Arctic EDS reports.
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+
+    Notes:
+        example request: http://localhost:5000/eds/all/68.0764/-154.5501
+
+        Order of returned JSON
+        0 - Temperature
+        1 - Precipitation
+        2 - Snowfall
+        3 - Design Freezing Index
+        4 - Design Thawing Index
+        5 - Freezing Index
+        6 - Heating Degree Days
+        7 - Thawing Index
+        8 - Geology
+        9 - Physiography
+       10 - Permafrost
+    """
+
     return asyncio.run(run_fetch_all_eds(lat, lon))

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -97,19 +97,6 @@ def fetch_all_eds(lat, lon):
 
     Notes:
         example request: http://localhost:5000/eds/all/68.0764/-154.5501
-
-        Order of returned JSON
-        0 - Temperature
-        1 - Precipitation
-        2 - Snowfall
-        3 - Design Freezing Index
-        4 - Design Thawing Index
-        5 - Freezing Index
-        6 - Heating Degree Days
-        7 - Thawing Index
-        8 - Geology
-        9 - Physiography
-       10 - Permafrost
     """
 
     return asyncio.run(run_fetch_all_eds(lat, lon))

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -8,7 +8,6 @@ from flask import (
 )
 import asyncio
 from aiohttp import ClientSession
-import os
 from fetch_data import make_get_request
 from . import routes
 

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -20,8 +20,7 @@ async def fetch_data(url):
     executes the urls as asyncio tasks
 
     Args:
-        req (tuple(str, str)): req[0] is the key for the section of the JSON
-                               req[1] is the URL requested from the API.
+        url (string): URL being requested from API.
 
     Returns:
         Results of query as JSON

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -1,0 +1,40 @@
+from flask import (
+    Blueprint,
+    Response,
+    render_template,
+    request,
+    current_app as app,
+    jsonify,
+)
+import asyncio
+import os
+from fetch_data import fetch_data
+from . import routes
+
+eds_api = Blueprint("eds_api", __name__)
+
+
+async def run_fetch_all_eds(lat, lon):
+    host = request.host_url
+    all_requests = [
+        f"{host}eds/temperature/{lat}/{lon}",
+        f"{host}eds/precipitation/{lat}/{lon}",
+        f"{host}mmm/snow/snowfallequivalent/hp/{lat}/{lon}",
+        f"{host}design_index/freezing/hp/point/{lat}/{lon}",
+        f"{host}design_index/thawing/hp/point/{lat}/{lon}",
+        f"{host}eds/degree_days/freezing_index/{lat}/{lon}",
+        f"{host}eds/degree_days/heating/{lat}/{lon}",
+        f"{host}eds/degree_days/thawing_index/{lat}/{lon}",
+        f"{host}geology/point/{lat}/{lon}",
+        f"{host}physiography/point/{lat}/{lon}",
+        f"{host}permafrost/point/{lat}/{lon}",
+    ]
+
+    eds = await asyncio.gather(*[fetch_data([request]) for request in all_requests])
+
+    return eds
+
+
+@routes.route("/eds/all/<lat>/<lon>")
+def fetch_all_eds(lat, lon):
+    return asyncio.run(run_fetch_all_eds(lat, lon))


### PR DESCRIPTION
This PR adds the new endpoint /eds/all/<lat>/<lon> to the API. This combines all of the report sections in the Arctic EDS web application and generates a long JSON listing of the returned data.

Each report section has a key indicating its underlying data such as "thawing_index" or "precipitation". 

Try a few valid lat / lon coordinates such as: 
http://localhost:5000/eds/all/68.0764/-153.5501
http://localhost:5000/eds/all/62.0764/-143.5501

Try some invalid lat / lon coordinates to see what is returned as well, such as:
http://localhost:5000/eds/all/22.0764/-123.5501
http://localhost:5000/eds/all/52.0764/-123.5501