### PR TITLE
Add wet_days_per_year endpoint

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -21,3 +21,4 @@ from .snow import *
 from .landfastice import *
 from .beetles import *
 from .eds import *
+from .wet_days_per_year import *

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -62,6 +62,7 @@ async def run_fetch_all_eds(lat, lon):
         f"{host}geology/point/{lat}/{lon}",
         f"{host}physiography/point/{lat}/{lon}",
         f"{host}permafrost/point/{lat}/{lon}",
+        f"{host}eds/wet_days_per_year/point/{lat}/{lon}",
     ]
 
     all_keys = [
@@ -76,6 +77,7 @@ async def run_fetch_all_eds(lat, lon):
         "geology",
         "physiography",
         "permafrost",
+        "wet_days_per_year",
     ]
 
     results = await asyncio.gather(*[fetch_data(url) for url in all_urls])

--- a/routes/wet_days_per_year.py
+++ b/routes/wet_days_per_year.py
@@ -1,0 +1,388 @@
+import asyncio
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    jsonify,
+)
+
+# local imports
+from generate_urls import generate_wcs_query_url
+from fetch_data import *
+from validate_request import (
+    validate_latlon,
+    project_latlon,
+)
+from validate_data import (
+    nullify_and_prune,
+    postprocess,
+)
+from config import WEST_BBOX, EAST_BBOX
+from . import routes
+
+wet_days_per_year_api = Blueprint("wet_days_per_year_api", __name__)
+wet_days_per_year_dim_encodings = asyncio.run(get_dim_encodings("wet_days_per_year"))
+
+# default to min-max temporal range of coverage
+years_lu = {
+    "historical": {"min": 1980, "max": 2009},
+    "projected": {"min": 2006, "max": 2100},
+}
+
+
+def generate_wcps_request_str(
+    x, y, cov_id, models, years, summary_stat, encoding="json"
+):
+    """Generates a WCPS query specific to the
+    coverages used for the min-mean-max summaries over specific axes combinations..
+
+    Args:
+        x (float or str): x-coordinate for point query, or string
+            composed as "x1:x2" for bbox query, where x1 and x2 are
+            lower and upper bounds of bbox
+        y (float or str): y-coordinate for point query, or string
+            composed as "y1:y2" for bbox query, where y1 and y2 are
+            lower and upper bounds of bbox
+        cov_id (str): Rasdaman coverage ID
+        models (str): Comma-separated numbers of requested models
+        years (str): Colon-separated full date-time i.e.
+            "\"2006-01-01T00:00:00.000Z\":\"2100-01-01T00:00:00.000Z\""
+        summary_stat(int): Integer between 0-2 where:
+            - 0 = mean summary
+            - 1 = maximum summary
+            - 2 = minimum summary
+        encoding (str): currently supports either "json" or "netcdf"
+            for point or bbox queries, respectively
+
+    Returns:
+        WCPS query to be included in generate_wcs_url()
+    """
+    if summary_stat == 0:
+        operation = "max"
+    elif summary_stat == 2:
+        operation = "min"
+    else:
+        operation = "+"
+
+    if summary_stat == 0 or summary_stat == 2:
+        wcps_request_str = quote(
+            (
+                f"ProcessCoverages&query=for $c in ({cov_id}) "
+                f"let $a := {operation}(condense {operation} over $m model({models}) "
+                f"using $c[model($m),year({years}),X({x}),Y({y})] ) "
+                f'return encode( $a, "application/{encoding}")'
+            )
+        )
+        return wcps_request_str
+    else:
+        # Generates the mean across models
+        # For projected, 2 models
+        num_results = 2
+        # For historical, only a single model
+        if models == "0:0":
+            num_results = 1
+
+        wcps_request_str = quote(
+            (
+                f"ProcessCoverages&query=for $c in ({cov_id}) "
+                f"let $a := avg(condense {operation} over $m model({models}) "
+                f"using $c[model($m),year({years}),X({x}),Y({y})] / {num_results} ) "
+                f'return encode( $a, "application/{encoding}")'
+            )
+        )
+        return wcps_request_str
+
+
+def validate_years(horp, start_year, end_year):
+    # CP: function could maybe generalized a bit and moved to `validate_request` at some point
+    """Check provided years against valid ranges for historical vs. projected.
+
+    Args:
+        horp [Historical or Projected] (str): historical, projected, hp, or all
+        start_year (int): start year for WCPS query or None
+        end_year (int): end year for WCPS query or None
+
+    Returns:
+        True if years are valid, otherwise an error page to show valid years
+    """
+    if None not in [start_year, end_year]:
+        if horp == "historical":
+            min_year = years_lu["historical"]["min"]
+            max_year = years_lu["historical"]["max"]
+        elif horp == "projected":
+            min_year = years_lu["projected"]["min"]
+            max_year = years_lu["projected"]["max"]
+        elif horp == "hp":
+            min_year = years_lu["historical"]["min"]
+            max_year = years_lu["projected"]["max"]
+
+        for year in [start_year, end_year]:
+            if year < min_year or year > max_year:
+                return (
+                    render_template(
+                        "422/invalid_year.html", min_year=min_year, max_year=max_year
+                    ),
+                    422,
+                )
+    return True
+
+
+def package_wet_days_per_year_point_data(point_data, horp):
+    """Package JSON response data for wet_days_per_year
+
+    Args:
+        point_data (list): nested list containing JSON results of WCPS query
+        horp [Historical or Projected] (str): historical, projected, hp, or all
+
+    Returns:
+        JSON-like dict of query results
+    """
+    point_pkg = {}
+    if horp == "all":
+        for mi, v_li in enumerate(point_data):  # (nested list with model at dim 0)
+            if mi == 0:
+                min_year = years_lu["historical"]["min"]
+                max_year = years_lu["historical"]["max"]
+                years = range(min_year, max_year + 1)
+            else:
+                min_year = years_lu["projected"]["min"]
+                max_year = years_lu["projected"]["max"]
+                years = range(min_year, max_year + 1)
+
+            model = wet_days_per_year_dim_encodings["model"][mi]
+            point_pkg[model] = {}
+
+            # Responses from Rasdaman include the same array length for both
+            # historical and projected data, representing every possible year
+            # (1980-2100). This means both the historical and projected data
+            # arrays include nodata years populated with 0s. The code below
+            # omits nodata gaps and makes sure the correct year is assigned to
+            # its corresponding data in the historical and projected data
+            # arrays.
+            year = years_lu["historical"]["min"]
+            year_index = 0
+            for value in v_li:
+                if year in years:
+                    point_pkg[model][years[year_index]] = {"wdpy": round(value)}
+                    year_index += 1
+                year += 1
+    else:
+        if horp in ["historical", "hp"]:
+            historical_max = round(point_data[0], 1)
+            historical_mean = round(point_data[1], 1)
+            historical_min = round(point_data[2], 1)
+
+            point_pkg["historical"] = {}
+            point_pkg["historical"]["wdpymin"] = round(historical_min)
+            point_pkg["historical"]["wdpymean"] = round(historical_mean)
+            point_pkg["historical"]["wdpymax"] = round(historical_max)
+
+        if horp in ["projected", "hp"]:
+            if horp == "projected":
+                projected_max = round(point_data[0], 1)
+                projected_mean = round(point_data[1], 1)
+                projected_min = round(point_data[2], 1)
+            else:
+                projected_max = round(point_data[3], 1)
+                projected_mean = round(point_data[4], 1)
+                projected_min = round(point_data[5], 1)
+
+            point_pkg["projected"] = {}
+            point_pkg["projected"]["wdpymin"] = round(projected_min)
+            point_pkg["projected"]["wdpymean"] = round(projected_mean)
+            point_pkg["projected"]["wdpymax"] = round(projected_max)
+
+    return point_pkg
+
+
+async def fetch_wet_days_per_year_point_data(x, y, horp, start_year, end_year):
+    """Run the async degree days data request for a single point
+    and return data as json
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+        horp [Historical or Projected] (str): historical, projected, hp, or all
+        start_year (int): start year for WCPS query or None
+        end_year (int): end year for WCPS query or None
+
+    Returns:
+        JSON-like dict of data at provided latitude and longitude
+    """
+    point_data_list = []
+    if horp == "all":
+        request_str = generate_wcs_getcov_str(x, y, "wet_days_per_year")
+        point_data_list = await fetch_data([generate_wcs_query_url(request_str)])
+
+    if horp in ["historical", "hp"]:
+        min_year = years_lu["historical"]["min"]
+        max_year = years_lu["historical"]["max"]
+        timestring = (
+            f'"{min_year}-01-01T00:00:00.000Z":"{max_year}-01-01T00:00:00.000Z"'
+        )
+        if start_year is not None:
+            timestring = (
+                f'"{start_year}-01-01T00:00:00.000Z":"{end_year}-01-01T00:00:00.000Z"'
+            )
+        for summary_stat in range(0, 3):
+            request_str = generate_wcps_request_str(
+                x, y, "wet_days_per_year", "0:0", timestring, summary_stat
+            )
+            point_data_list.append(
+                await fetch_data([generate_wcs_query_url(request_str)])
+            )
+
+    if horp in ["projected", "hp"]:
+        min_year = years_lu["projected"]["min"]
+        max_year = years_lu["projected"]["max"]
+        timestring = (
+            f'"{min_year}-01-01T00:00:00.000Z":"{max_year}-01-01T00:00:00.000Z"'
+        )
+        if start_year is not None:
+            timestring = (
+                f'"{start_year}-01-01T00:00:00.000Z":"{end_year}-01-01T00:00:00.000Z"'
+            )
+        for summary_stat in range(0, 3):
+            request_str = generate_wcps_request_str(
+                x, y, "wet_days_per_year", "1:2", timestring, summary_stat
+            )
+            point_data_list.append(
+                await fetch_data([generate_wcs_query_url(request_str)])
+            )
+
+    return point_data_list
+
+
+def create_csv(data_pkg, lat=None, lon=None):
+    """Create CSV file with metadata string and location based filename.
+    Args:
+        data_pkg (dict): JSON-like object of data
+        lat: latitude for points or None for polygons
+        lon: longitude for points or None for polygons
+    Returns:
+        CSV response object
+    """
+    fieldnames = [
+        "model",
+        "year",
+        "variable",
+        "value",
+    ]
+    csv_dicts = build_csv_dicts(
+        data_pkg,
+        fieldnames,
+    )
+    metadata = "# wdpy is the count of wet days (days where the total precipitation amount is greater than or equal to 1.0 mm) per calendar year\n"
+    filename = "Wet Days Per Year" + " for " + lat + ", " + lon + ".csv"
+
+    return write_csv(csv_dicts, fieldnames, filename, metadata)
+
+
+# CP: consider if routing synonyms (top-level and mmm-nested) make sense for this endpoint. another alternative could be /precip_inidcators/wet_days_per_year...
+@routes.route("/wet_days_per_year/")
+@routes.route("/wet_days_per_year/abstract/")
+@routes.route("/mmm/wet_days_per_year/")
+@routes.route("/mmm/wet_days_per_year/abstract/")
+def wet_days_per_year_about():
+    return render_template("/wet_days_per_year/abstract.html")
+
+
+@routes.route("/mmm/wet_days_per_year/point")
+@routes.route("/wet_days_per_year/point")
+def wet_days_per_year_about_point():
+    return render_template("/wet_days_per_year/point.html")
+
+
+@routes.route("/wet_days_per_year/<horp>/point/<lat>/<lon>")
+@routes.route("/wet_days_per_year/<horp>/point/<lat>/<lon>/<start_year>/<end_year>")
+@routes.route("/mmm/wet_days_per_year/<horp>/point/<lat>/<lon>")
+@routes.route("/mmm/wet_days_per_year/<horp>/point/<lat>/<lon>/<start_year>/<end_year>")
+def run_fetch_wet_days_per_year_point_data(
+    lat, lon, horp, start_year=None, end_year=None
+):
+    """Wet Days Per Year data endpoint. Fetch point data for
+    specified lat/lon and return JSON-like dict.
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+        horp [Historical or Projected] (str): historical, projected, hp, or all
+        start_year (int): optional start year for WCPS query
+        end_year (int): optional end year for WCPS query
+
+    Returns:
+        JSON-like dict of requested degree days data
+
+    Notes:
+        example request: http://localhost:5000/mmm/wet_days_per_year/all/65/-147
+    """
+    validation = validate_latlon(lat, lon)
+    if validation == 400:
+        return render_template("400/bad_request.html"), 400
+    if validation == 422:
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
+
+    x, y = project_latlon(lat, lon, 3338)
+
+    if None not in [start_year, end_year]:
+        valid_years = validate_years(horp, int(start_year), int(end_year))
+        if valid_years is not True:
+            return valid_years
+
+    try:
+        point_data_list = asyncio.run(
+            fetch_wet_days_per_year_point_data(x, y, horp, start_year, end_year)
+        )
+    except Exception as exc:
+        if hasattr(exc, "status") and exc.status == 404:
+            return render_template("404/no_data.html"), 404
+        return render_template("500/server_error.html"), 500
+
+    point_pkg = package_wet_days_per_year_point_data(point_data_list, horp)
+
+    if request.args.get("format") == "csv":
+        point_pkg = nullify_and_prune(point_pkg, "wet_days_per_year")
+        if point_pkg in [{}, None, 0]:
+            return render_template("404/no_data.html"), 404
+        return create_csv(point_pkg, lat=lat, lon=lon)
+
+    return postprocess(point_pkg, "wet_days_per_year")
+
+
+@routes.route("/eds/wet_days_per_year/point/<lat>/<lon>")
+def get_wet_days_per_year_plate(lat, lon):
+    """
+    Endpoint for requesting all data required for the Wet Days Per Year plate in the
+    Arctic-EDS client.
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+    Notes:
+        example request: http://localhost:5000/eds/wet_days_per_year/point/65.0628/-146.1627
+    """
+    wdpy_plate = {}
+
+    results = run_fetch_wet_days_per_year_point_data(lat, lon, "historical")
+    wdpy_plate["historical"] = results["historical"]
+
+    results = run_fetch_wet_days_per_year_point_data(
+        lat, lon, "projected", start_year="2010", end_year="2039"
+    )
+    wdpy_plate["2010-2039"] = results["projected"]
+
+    results = run_fetch_wet_days_per_year_point_data(
+        lat, lon, "projected", start_year="2040", end_year="2069"
+    )
+    wdpy_plate["2040-2069"] = results["projected"]
+
+    results = run_fetch_wet_days_per_year_point_data(
+        lat, lon, "projected", start_year="2070", end_year="2099"
+    )
+    wdpy_plate["2070-2099"] = results["projected"]
+
+    return jsonify(wdpy_plate)

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
       Max</a
     >
   </li>
+  <li><a href="/wet_days_per_year">Wet Days Per Year</a></li>
   <li><a href="/fire">Wildfire</a></li>
 </ul>
 {% endblock %}

--- a/templates/wet_days_per_year/abstract.html
+++ b/templates/wet_days_per_year/abstract.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %} {% block content %}
+<h3>Wet Days Per Year</h3>
+<h4>Service Endpoints</h4>
+<p>
+  Query the historical and projected number of wet days (defined as a day with
+  precipitation accumulation greater than or equal to 1.0 mm) per year.
+</p>
+<ul>
+  <li><a href="/wet_days_per_year/point">Point Query</a></li>
+</ul>
+{% endblock %}

--- a/templates/wet_days_per_year/point.html
+++ b/templates/wet_days_per_year/point.html
@@ -25,8 +25,7 @@
 
 <h5>Wet Days Per Year</h5>
 <p>
-  Query the downscaled ERA-Interim historical average (1980-2009) min, mean, and max number of wet
-  days per year for a point location:
+  Query the downscaled ERA-Interim historical average (1980-2009) min, mean, and max number of wet days per year for a point location:
 </p>
 <p></p>
 <p>
@@ -48,13 +47,24 @@
 </p>
 
 <p>
-  Query for the historical and projected  min, mean, and max numbers of wet days per year for a point location:
+  Query the historical and projected min, mean, and max numbers of wet days per year for a point location:
 </p>
 <p></p>
 <p>
   Example:
   <a href="/wet_days_per_year/hp/point/65.0628/-146.1627"
     >/wet_days_per_year/hp/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>
+  Query the historical or projected min, mean, and max numbers of wet days per year for a point location with specific start and end years:
+</p>
+<p></p>
+<p>
+  Example:
+  <a href="/wet_days_per_year/projected/point/65.0628/-146.1627/2070/2099"
+    >/wet_days_per_year/projected/point/65.0628/-146.1627/2070/2099</a
   >
 </p>
 

--- a/templates/wet_days_per_year/point.html
+++ b/templates/wet_days_per_year/point.html
@@ -1,0 +1,140 @@
+{% extends 'base.html' %} {% block content %}
+<h3>Wet Days Per Year Point Query</h3>
+<p>The endpoints here provide access to wet days per year data.</p>
+
+<h4>Endpoints</h4>
+<table>
+  <thead>
+    <tr>
+      <th>Endpoint</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>wet_days_per_year</td>
+      <td>
+        The number of days per calendar year where total precipitation amounts
+        are greater than or equal to 1.0 mm.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h4>Examples</h4>
+
+<h5>Wet Days Per Year</h5>
+<p>
+  Query the downscaled ERA-Interim historical average (1980-2009) min, mean, and max number of wet
+  days per year for a point location:
+</p>
+<p></p>
+<p>
+  Example:
+  <a href="/wet_days_per_year/historical/point/65.0628/-146.1627"
+    >/wet_days_per_year/historical/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>
+  Query the projected RCP 8.5 mid-century (2040-2069) two-model min, mean, and max  number of wet days per year for a point location:
+</p>
+<p></p>
+<p>
+  Example:
+  <a href="/wet_days_per_year/projected/point/65.0628/-146.1627"
+    >/wet_days_per_year/projected/point/65.0628/-146.1627</a
+  >
+</p>
+
+<p>
+  Query for the historical and projected  min, mean, and max numbers of wet days per year for a point location:
+</p>
+<p></p>
+<p>
+  Example:
+  <a href="/wet_days_per_year/hp/point/65.0628/-146.1627"
+    >/wet_days_per_year/hp/point/65.0628/-146.1627</a
+  >
+</p>
+
+<b>Results from the queries above will look like this:</b>
+
+<pre>
+{
+  "historical": {
+    "wdpymax": 160, 
+    "wdpymean": 134, 
+    "wdpymin": 112
+  }
+}  
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &lt;era>: {
+    "wdpymax": &lt;max number of wet days per year across all models and years used for the summary era time period>,
+    "wdpymean": &lt;number of wet days per year across all models and years used for the summary era time period>,
+    "wdpymin": &lt;number of wet days per year across all models and years used for the summary era time period>
+  },
+  ...
+}
+</pre>
+
+<h4>Comprehensive queries</h4>
+<p>
+  The following query will fetch a complete wet days per year set of data composed of the ERA-Interim historical baseline (1980-2009) and the entire projection range (2006-2100) for both available models, GFDL-CM3 and NCAR-CCSM4 (both RCP 8.5).
+</p>
+
+<p>
+  Example:
+  <a href="/wet_days_per_year/all/point/65.0628/-146.1627"
+    >/wet_days_per_year/all/point/65.0628/-146.1627</a
+  >
+</p>
+
+<b>Results from the query above will look like this:</b>
+
+<pre>
+{
+  "ERA-Interim": {
+    "1980": {
+      "wdpy": 124
+    }, 
+    "1981": {
+      "wdpy": 119
+    }, 
+    "1982": {
+      "wdpy": 145
+    }, 
+...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &lt;model>: {
+    &lt;year>: {
+      "wdpy": &lt;count of wet days per year>
+    },
+    ...
+  }
+  ...
+}
+</pre>
+
+</pre>
+
+<h4>CSV Export</h4>
+<p>To export the point data to a CSV file, append <code>?format=csv</code>.</p>
+<p>
+  Example:
+  <a href="/wet_days_per_year/all/point/65.0628/-146.1627?format=csv"
+    >/wet_days_per_year/all/point/65.0628/-146.1627?format=csv</a
+  >
+</p>
+{% endblock %}

--- a/validate_data.py
+++ b/validate_data.py
@@ -21,7 +21,8 @@ nodata_values = {
     "snow": [-9999],
     "seaice": [120, 254, 255],
     "landfastice": [0],
-    "beetles": [0]
+    "beetles": [0],
+    "wet_days_per_year": [-9999]
 }
 
 


### PR DESCRIPTION
This PR adds an endpoint for the number of wet days per year (days where total precip accumulation is >= 1.0 mm).

The endpoints in this PR are min-mean-max summarized (except for `/all/`) but `wet_days_per_year` is a top-level route.

To test this PR, try a few different queries after setting your Rasdaman backend to Apollo.

http://localhost:5000/wet_days_per_year/projected/point/62.0628/-150

http://localhost:5000/wet_days_per_year/historical/point/68/-149

http://localhost:5000/wet_days_per_year/hp/point/62/-166.1627

http://localhost:5000/wet_days_per_year/all/point/69/-151

http://localhost:5000/wet_days_per_year/projected/point/65/-145/2070/2099

http://localhost:5000/eds/wet_days_per_year/point/65/-147