### PR TITLE
Fix historical degree day min and max years

### DIFF
--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -49,7 +49,7 @@ var_label_lu = {
 }
 
 years_lu = {
-    "historical": {"min": 1979, "max": 2015},
+    "historical": {"min": 1980, "max": 2009},
     "projected": {"min": 2006, "max": 2100},
 }
 

--- a/templates/mmm/degree_days.html
+++ b/templates/mmm/degree_days.html
@@ -104,16 +104,16 @@
 <h4>Comprehensive queries</h4>
 <p>The following queries will fetch degree day values across all available years.</p>
 
-<p>Query for all heating degree days for all historical and projected models from 1979-2100:</p>
+<p>Query for all heating degree days for all historical and projected models from 1980-2100:</p>
 <p>Example: <a href="/mmm/degree_days/heating/all/65.0628/-146.1627">/mmm/degree_days/heating/all/65.0628/-146.1627</a></p>
 
-<p>Query for all below zero degree days for all historical and projected models from 1979-2100:</p>
+<p>Query for all below zero degree days for all historical and projected models from 1980-2100:</p>
 <p>Example: <a href="/mmm/degree_days/below_zero/all/65.0628/-146.1627">/mmm/degree_days/below_zero/all/65.0628/-146.1627</a></p>
 
-<p>Query for all thawing index for all historical and projected models from 1979-2100:</p>
+<p>Query for all thawing index for all historical and projected models from 1980-2100:</p>
 <p>Example: <a href="/mmm/degree_days/thawing_index/all/65.0628/-146.1627">/mmm/degree_days/thawing_index/all/65.0628/-146.1627</a></p>
 
-<p>Query for all freezing index for all historical and projected models from 1979-2100:</p>
+<p>Query for all freezing index for all historical and projected models from 1980-2100:</p>
 <p>Example: <a href="/mmm/degree_days/freezing_index/all/65.0628/-146.1627">/mmm/degree_days/freezing_index/all/65.0628/-146.1627</a></p>
 
 <b>Results from the query above will look like this:</b>
@@ -121,7 +121,7 @@
 <pre>
 {
   "ERA-Interim": {
-    "1979": {
+    "1980": {
       "dd:" 4802,
     }
     ...


### PR DESCRIPTION
The new minimum and maximum years for historical ERA-Interim-based degree day endpoints was changed to be 1980 and 2009 on Apollo. This is a small change to restore the functionality of affected endpoints in the development API.