### PR TITLE
Add service endpoints for the most recent GIPL 2.0 outputs

### DIFF
--- a/generate_requests.py
+++ b/generate_requests.py
@@ -8,7 +8,7 @@ def get_wcs_xy_str_from_bbox_bounds(poly):
     Args:
         poly (object): shapely.Polygon with 4-tuple bounding box (xmin, ymin, xmax, ymax).
     Returns:
-        xy (tuple): 2-tuple of coordinate strings formatted for WCS requests. 
+        xy (tuple): 2-tuple of coordinate strings formatted for WCS requests.
             Instantiated as a namedtuple for access convenience and s
             elf-documentation when used in service endpoints.
     """
@@ -58,7 +58,9 @@ def generate_mmm_wcs_getcov_str(x, y, cov_id, model, scenario, encoding="json"):
     return wcs_getcov_str
 
 
-def generate_wcs_getcov_str(x, y, cov_id, var_coord=None, encoding="json"):
+def generate_wcs_getcov_str(
+    x, y, cov_id, var_coord=None, time_slice=None, encoding="json"
+):
     """Generate a WCS GetCoverage request for fetching a
     subset of a coverage over X and Y axes.
 
@@ -71,6 +73,7 @@ def generate_wcs_getcov_str(x, y, cov_id, var_coord=None, encoding="json"):
         lower and upper bounds of bbox
         cov_id (str): Rasdaman coverage ID
         var_coord (int): coordinate value corresponding to variable name to query, default=None will include all variables
+        time_slice (tuple): two-tuple of the time axis name (e.g., `year`) and the ISO time-string used to slice the data
         encoding (str): currently supports either "json" or "netcdf"
         for point or bbox queries, respectively
     Returns:
@@ -82,9 +85,14 @@ def generate_wcs_getcov_str(x, y, cov_id, var_coord=None, encoding="json"):
         var_subset_str = f"&SUBSET=varname({var_coord})"
     else:
         var_subset_str = ""
+    if time_slice is not None:
+        time_axis, slice_string = time_slice
+        time_slice_str = f"&SUBSET={time_axis}({slice_string})"
+    else:
+        time_slice_str = ""
     wcs_getcov_str = (
         f"GetCoverage&COVERAGEID={cov_id}"
-        f"&SUBSET=X({x})&SUBSET=Y({y}){var_subset_str}"
+        f"&SUBSET=X({x})&SUBSET=Y({y}){var_subset_str}{time_slice_str}"
         f"&FORMAT=application/{encoding}"
     )
     return wcs_getcov_str
@@ -96,7 +104,7 @@ def generate_netcdf_wcs_getcov_str(bbox_bounds, cov_id, var_coord=None):
     Args:
         bbox_bounds (tuple): 4-tuple of bounding polygon extent (xmin, ymin, xmax, ymax)
         cov_id (str): Rasdaman coverage ID
-        var_coord (int): coordinate value corresponding to variable name to query, 
+        var_coord (int): coordinate value corresponding to variable name to query,
             default=None will include all variables
     Returns:
         netcdf_wcs_getcov_str (str): WCS GetCoverage Request to append to a query URL
@@ -127,7 +135,7 @@ def generate_average_wcps_str(
         axis_coords (tuple): 2-tuple of coordinates to average over
             of the form (start, stop)
         slice_di (dict): dict with axis names for keys and
-            coordinates for the values to be used in further 
+            coordinates for the values to be used in further
             subsetting in WCPS query. E.g., {"varname": 0}
         encoding (str): currently supports either "json" or "netcdf"
             for point or bbox queries, respectively
@@ -167,6 +175,8 @@ def generate_netcdf_average_wcps_str(bbox_bounds, generate_average_wcps_str_kwar
     x = f"{x1}:{x2}"
     y = f"{y1}:{y2}"
     netcdf_avg_wcps_str = generate_average_wcps_str(
-        x, y, **generate_average_wcps_str_kwargs,
+        x,
+        y,
+        **generate_average_wcps_str_kwargs,
     )
     return netcdf_avg_wcps_str

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -25,7 +25,9 @@ from config import WEST_BBOX, EAST_BBOX
 landfastice_api = Blueprint("landfastice_api", __name__)
 landfastice_coverage_id = "landfast_sea_ice_extent"
 landfastice_encodings = asyncio.run(
-    get_dim_encodings(landfastice_coverage_id, scrape=("time", "gmlrgrid:coefficients"))
+    get_dim_encodings(
+        landfastice_coverage_id, scrape=("time", "gmlrgrid:coefficients", 1)
+    )
 )
 
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -122,10 +122,9 @@ def package_gipl1km_point_data(gipl1km_point_resp):
                 for gipl_var_name in gipl1km_dim_encodings["variable"].values():
                     gipl1km_point_pkg[model_name][year][scenario_name][
                         gipl_var_name
-                    ] = flat_list[i]
+                    ] = round(flat_list[i], 1)
                     i += 1
 
-    # return gipl1km_dim_encodings
     return gipl1km_point_pkg
 
 
@@ -241,7 +240,8 @@ def run_fetch_gipl_1km_point_data(lat, lon):
             return render_template("404/no_data.html"), 404
         return render_template("500/server_error.html"), 500
 
-    return package_gipl1km_point_data(gipl_1km_point_data)
+    gipl_1km_point_package = package_gipl1km_point_data(gipl_1km_point_data)
+    return postprocess(gipl_1km_point_package, "crrel_gipl")
 
 
 @routes.route("/permafrost/point/<lat>/<lon>")

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -33,6 +33,7 @@ permafrost_api = Blueprint("permafrost_api", __name__)
 
 # rasdaman targets
 permafrost_coverage_id = "iem_gipl_magt_alt_4km"
+gipl_1km_coverage_id = "crrel_gipl_outputs"
 
 # geoserver targets
 wms_targets = [
@@ -44,7 +45,8 @@ wfs_targets = {
 }
 
 titles = {
-    "gipl": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (°C) and Active Layer Thickness (m) Model Output",
+    "gipl": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (°C) and Active Layer Thickness (m) 4 km Model Output",
+    "gipl1km": "GIPL 2.0 Mean Annual Ground Temperature (°C), Permafrost Base, Permafrost Top, and Talik Thickness (m) 1 km Model Output",
     "jorg": "Jorgenson et al. (2008) Permafrost Extent and Ground Ice Volume",
     "obupfx": "Obu et al. (2018) Permafrost Extent",
 }
@@ -173,28 +175,11 @@ def combine_gipl_poly_var_pkgs(magt_di, alt_di):
 
 @routes.route("/permafrost/")
 @routes.route("/permafrost/abstract/")
-@routes.route("/groundtemperature/")
-@routes.route("/groundtemperature/abstract/")
-@routes.route("/activelayer/")
-@routes.route("/activelayer/abstract/")
-@routes.route("/magtalt/")
-@routes.route("/magtalt/abstract/")
-@routes.route("/magtalt/")
-@routes.route("/magtalt/abstract/")
-@routes.route("/alt/")
-@routes.route("/alt/abstract/")
-@routes.route("/magt/")
-@routes.route("/magt/abstract/")
 def pf_about():
     return render_template("permafrost/abstract.html")
 
 
 @routes.route("/permafrost/point/")
-@routes.route("/groundtemperature/point/")
-@routes.route("/activelayer/point/")
-@routes.route("/magtalt/point/")
-@routes.route("/alt/point/")
-@routes.route("/magt/point/")
 def pf_about_point():
     return render_template("permafrost/point.html")
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -303,7 +303,7 @@ def run_fetch_gipl_1km_point_data(
     x, y = project_latlon(lat, lon, 3338)
 
     # CP: the next two code blocks that validate year and summary type selections could be in the `validate_request` module but the first does use a specific time index so that needs more thought
-    if start_year is not None and end_year is not None:
+    if start_year is not None or end_year is not None:
         try:
             time_index = generate_gipl1km_time_index()
             start_valid = pd.Timestamp(int(start_year), 1, 1) >= time_index.min()
@@ -312,17 +312,17 @@ def run_fetch_gipl_1km_point_data(
             years_valid = start_valid and end_valid and chronological
         except:
             return render_template("400/bad_request.html"), 400
-    if years_valid != True:
-        return render_template("400/bad_request.html"), 400
+        if years_valid != True:
+            return render_template("400/bad_request.html"), 400
 
-    # code block to validate summarize option
+    # validate the summarize option
     if summarize is not None:
         try:
-            summarize_valid = summarize in ["summarize", "mmm"]
+            summarize_valid = summarize in ["summary", "mmm"]
         except:
             return render_template("400/bad_request.html"), 400
-    if summarize_valid != True:
-        return render_template("400/bad_request.html"), 400
+        if summarize_valid != True:
+            return render_template("400/bad_request.html"), 400
 
     try:
         gipl_1km_point_data = asyncio.run(
@@ -454,8 +454,6 @@ def run_point_fetch_all_permafrost(lat, lon):
 
 
 # must handle case where years are provided, but no summary option is given
-
-
 async def fetch_gipl_1km_point_data(x, y, start_year, end_year, summarize):
     if all(val != None for val in [start_year, end_year, summarize]):
         wcps_response_data = []

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -113,25 +113,25 @@ def make_gipl1km_wcps_request_str(x, y, years, summary_operation):
 
 
 def package_gipl1km_wcps_data(gipl1km_wcps_resp):
-    """Package a min-mean-max summary of ten GIPL 1 km variables for a given year range.
+    """Package a min-mean-max summary of ten GIPL 1 km variables for a given year range. Values are rounded to one decimal place because units are either meters or degrees C.
 
     Arguments:
-        gipl1km_wcps_resp -- (list) nested 2-level list of the WCPS response values. The response order must be min-mean-max.
+        gipl1km_wcps_resp -- (list) nested 2-level list of the WCPS response values. The response order must be min-mean-max: [[min], [mean], [max]]
 
     Returns:
-        gipl1km_wcps_point_pkg -- (dict) results
+        gipl1km_wcps_point_pkg -- (dict) min-mean-max summarized results for all ten variables
     """
     gipl1km_wcps_point_pkg = {}
     summary_methods = ["min", "mean", "max"]
     for resp, stat_type in zip(gipl1km_wcps_resp, summary_methods):
         gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"] = {}
         for k, v in zip(gipl1km_dim_encodings["variable"].values(), resp):
-            gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][k] = v
+            gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][k] = round(v, 1)
     return gipl1km_wcps_point_pkg
 
 
 def generate_gipl1km_time_index():
-    """Generate a Pythonic time index for annual GIPL 1km outputs.
+    """Generate a time index for annual GIPL 1km outputs.
 
     Returns:
         dt_range (pandas DatetimeIndex): a time index with annual frequency
@@ -142,7 +142,7 @@ def generate_gipl1km_time_index():
 
 
 def package_gipl1km_point_data(gipl1km_point_resp):
-    """Package the response for full set of point data. The native structure of the response is nested as follows: model (0 1 2), year, scenario (0 1), variable (0 9)."""
+    """Package the response for full set of point data. The native structure of the response is nested as follows: model (0 1 2), year, scenario (0 1), variable (0 9). Values are rounded to one decimal place because units are either meters or degrees C."""
 
     flat_list = list(deepflatten(gipl1km_point_resp))
     i = 0

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -8,6 +8,7 @@ from flask import (
 
 # local imports
 from fetch_data import (
+    get_dim_encodings,
     fetch_data_api,
     fetch_wcs_point_data,
     build_csv_dicts,
@@ -26,7 +27,10 @@ from validate_data import (
     place_name_and_type,
 )
 from config import GS_BASE_URL, WEST_BBOX, EAST_BBOX
-from luts import permafrost_encodings
+from luts import permafrost_encodings  # there are for the Melvin 4 km data
+
+gipl1km_dim_encodings = asyncio.run(get_dim_encodings("crrel_gipl_outputs"))
+
 from . import routes
 
 permafrost_api = Blueprint("permafrost_api", __name__)
@@ -91,6 +95,13 @@ def package_obu_vector(obu_vector_resp):
     pfx = obu_vector_resp["features"][0]["properties"]["PFEXTENT"]
     di = {"pfx": pfx}
     return di
+
+
+def package_gipl1km_point_data(gipl1km_resp):
+
+    di = {}
+
+    return
 
 
 def package_gipl(gipl_resp):

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -100,15 +100,33 @@ def generate_gipl1km_time_index():
     Returns:
         dt_range (pandas DatetimeIndex): a time index with annual frequency
     """
+    timestamps = [x[1:-2] for x in gipl1km_dim_encodings["time"].split(" ")]
+    date_index = pd.DatetimeIndex(timestamps)
+    return date_index
 
 
 def package_gipl1km_point_data(gipl1km_point_resp):
+    """Package the response. The native structure of the response is nested as follows: model (0 1 2), year, scenario (0 1), variable (0 9)."""
+
+    flat_list = list(deepflatten(gipl1km_point_resp))
+    i = 0
 
     gipl1km_point_pkg = {}
+    for model_name in gipl1km_dim_encodings["model"].values():
+        gipl1km_point_pkg[model_name] = {}
+        for t in generate_gipl1km_time_index():
+            year = t.date().strftime("%Y")
+            gipl1km_point_pkg[model_name][year] = {}
+            for scenario_name in gipl1km_dim_encodings["scenario"].values():
+                gipl1km_point_pkg[model_name][year][scenario_name] = {}
+                for gipl_var_name in gipl1km_dim_encodings["variable"].values():
+                    gipl1km_point_pkg[model_name][year][scenario_name][
+                        gipl_var_name
+                    ] = flat_list[i]
+                    i += 1
 
-    # create data package with time index information
-    return gipl1km_dim_encodings
-    # return gipl1km_point_pkg
+    # return gipl1km_dim_encodings
+    return gipl1km_point_pkg
 
 
 def package_gipl(gipl_resp):

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -1,11 +1,7 @@
 import asyncio
-import io
-import csv
-import copy
 from urllib.parse import quote
 from flask import (
     Blueprint,
-    Response,
     render_template,
     request,
 )
@@ -14,29 +10,23 @@ from flask import (
 from fetch_data import (
     fetch_data_api,
     fetch_wcs_point_data,
-    fetch_bbox_netcdf,
-    summarize_within_poly,
     build_csv_dicts,
     write_csv,
-    add_titles,
     csv_metadata,
 )
 
-from generate_requests import generate_netcdf_wcs_getcov_str
-from generate_urls import generate_wcs_query_url
 from validate_request import (
     validate_latlon,
     project_latlon,
 )
 from validate_data import (
-    get_poly_3338_bbox,
     nullify_nodata,
     nullify_and_prune,
     postprocess,
     place_name_and_type,
 )
 from config import GS_BASE_URL, WEST_BBOX, EAST_BBOX
-from luts import huc_gdf, permafrost_encodings, akpa_gdf
+from luts import permafrost_encodings
 from . import routes
 
 permafrost_api = Blueprint("permafrost_api", __name__)

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -1,8 +1,74 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
+<h3>
+  Geophysical Institute Permafrost Lab (GIPL) model 1 km output point query
+</h3>
+<p>
+  Query GIPL model output for a single point specified by latitude and
+  longitude.
+</p>
+<p>
+  Example:
+  <a href="/permafrost/point/gipl/63.0628/-146.1627"
+    >/permafrost/point/63.0628/-146.1627</a
+  >
+</p>
+<h4>Results from the query above will look like this:</h4>
+<pre>
+{
+  "5ModelAvg": {
+    "2021": {
+      "RCP 4.5": {
+        "magt0.5m": -2.6,
+        "magt1m": -3.1,
+        "magt2m": -3.3,
+        "magt3m": -3.4,
+        "magt4m": -3.5,
+        "magt5m": -3.5,
+        "magtsurface": -0.0,
+        "permafrostbase": 153.2,
+        "permafrosttop": 0.7,
+        "talikthickness": 0
+  ...
+}
+</pre>
+
+<b>The above output is structured as such:</b>
+
+<pre>
+{
+  &ltmodel>: {
+    &ltyear>:{
+      &ltscenario>: {
+        "magt0.5m": &ltmean annual ground temperature value at 0.5 m depth (°C)>,
+        "magt1m": &ltmean annual ground temperature value at 1 m depth (°C)>,
+        "magt2m": &ltmean annual ground temperature value at 2 m depth (°C)>,
+        "magt3m": &ltmean annual ground temperature value at 3 m depth (°C)>,
+        "magt4m": &ltmean annual ground temperature value at 4 m depth (°C)>,
+        "magt5m": &ltmean annual ground temperature value at 5 m depth (°C)>,
+        "magtsurface": &ltmean annual ground temperature value at 0.01 m depth (°C)>,
+        "permafrostbase": &ltdepth of permafrost base (m)>,
+        "permafrosttop": &ltdepth of permafrost top (m)>,
+        "talikthickness": &ltthickness of talik layer (m)>
+      }
+      ...
+    }
+    ...
+  }
+  ...
+}
+</pre>
+
 <h3>Permafrost point query</h3>
-<p>Query permafrost data (e.g. extent, ground temperatures) for a single point specified by latitude and longitude.</p>
-<p>Example: <a href="/permafrost/point/65.0628/-146.1627">/permafrost/point/65.0628/-146.1627</a></p>
+<p>
+  Query permafrost data (e.g. extent, ground temperatures) for a single point
+  specified by latitude and longitude.
+</p>
+<p>
+  Example:
+  <a href="/permafrost/point/65.0628/-146.1627"
+    >/permafrost/point/65.0628/-146.1627</a
+  >
+</p>
 <h4>Results from the query above will look like this:</h4>
 <pre>
 {
@@ -243,73 +309,170 @@
 }
 </pre>
 <ul>
-    <li><strong><code>gipl</code></strong>: GIPL 2.0 Model Outputs
+  <li>
+    <strong><code>gipl</code></strong
+    >: GIPL 2.0 Model Outputs
+    <ul>
+      <li>
+        <strong><code>era</code></strong
+        >: <i>(str)</i>, Era name. "1995" refers to the historical baseline.
+        Otherwise these are 30 year eras surrounding the following center dates,
+        except last era is truncated at 2100: "2025" (2011 - 2040), "2050" (2036
+        - 2065), "2075" (2061 – 2090), "2095" (2086 – 2100).
+      </li>
+      <ul>
+        <li>
+          <strong><code>model</code></strong
+          >: <i>(str)</i>, Climate model driving the GIPL model output.
+        </li>
         <ul>
-            <li><strong><code>era</code></strong>: <i>(str)</i>, Era name. "1995" refers to the historical baseline. Otherwise these are 30 year eras surrounding the following center dates, except last era is truncated at 2100: "2025" (2011 - 2040), "2050" (2036 - 2065), "2075" (2061 – 2090), "2095" (2086 – 2100).</li>
-            <ul>
-                <li><strong><code>model</code></strong>: <i>(str)</i>, Climate model driving the GIPL model output.</li>
-                <ul>
-                    <li><strong><code>scenario</code></strong>: <i>(str)</i>, RCP Emissions Scenario driving the GIPL model output.</li>
-                    <ul>
-                        <li><strong><code>alt</code></strong>: <i>(float)</i>, Active Layer Thickness (m).</li>
-                        <li><strong><code>magt</code></strong>: <i>(float)</i>, Mean annual ground temperature (&deg;C).</li>
-                        <li><strong><code>title</code></strong>: <i>(str)</i>, Title describing these results.</li>
-                    </ul>
-                </ul>
-            </ul>
+          <li>
+            <strong><code>scenario</code></strong
+            >: <i>(str)</i>, RCP Emissions Scenario driving the GIPL model
+            output.
+          </li>
+          <ul>
+            <li>
+              <strong><code>alt</code></strong
+              >: <i>(float)</i>, Active Layer Thickness (m).
+            </li>
+            <li>
+              <strong><code>magt</code></strong
+              >: <i>(float)</i>, Mean annual ground temperature (&deg;C).
+            </li>
+            <li>
+              <strong><code>title</code></strong
+              >: <i>(str)</i>, Title describing these results.
+            </li>
+          </ul>
         </ul>
-    <li><strong><code>jorg</code></strong>: Jorgenson et al. (2008) Permafrost Characteristics of Alaska
-        <ul>
-            <li><strong><code>ice</code></strong>: <i>(str)</i>, Estimated ground ice volume.</li>
-            <li><strong><code>pfx</code></strong>: <i>(str)</i>, Permafrost extent.</li>
-            <li><strong><code>title</code></strong>: <i>(str)</i>, Title describing these results.</li>
-        </ul>
-    <li><strong><code>obu_magt</code></strong>: Obu et al. (2018) Modeled Mean Annual Ground Temperature at Top of Permafrost
-        <ul>
-            <li><strong><code>depth</code></strong>: <i>(str)</i>, Top of permafrost (i.e. depth of active layer).</li>
-            <li><strong><code>temp</code></strong>: <i>(float)</i>, Mean annual ground temperature (&deg;C).</li>
-            <li><strong><code>title</code></strong>: <i>(str)</i>, Title describing these results.</li>
-            <li><strong><code>year</code></strong>: <i>(str)</i>, Date range of model output.</li>
-        </ul>
-    <li><strong><code>jorg</code></strong>: Obu et al. (2018) Modeled Permafrost Extent
-        <ul>
-            <li><strong><code>pfx</code></strong>: <i>(str)</i>, Permafrost extent.</li>
-            <li><strong><code>title</code></strong>: <i>(str)</i>, Title describing these results.</li>
-        </ul>
+      </ul>
+    </ul>
+  </li>
+
+  <li>
+    <strong><code>jorg</code></strong
+    >: Jorgenson et al. (2008) Permafrost Characteristics of Alaska
+    <ul>
+      <li>
+        <strong><code>ice</code></strong
+        >: <i>(str)</i>, Estimated ground ice volume.
+      </li>
+      <li>
+        <strong><code>pfx</code></strong
+        >: <i>(str)</i>, Permafrost extent.
+      </li>
+      <li>
+        <strong><code>title</code></strong
+        >: <i>(str)</i>, Title describing these results.
+      </li>
+    </ul>
+  </li>
+
+  <li>
+    <strong><code>obu_magt</code></strong
+    >: Obu et al. (2018) Modeled Mean Annual Ground Temperature at Top of
+    Permafrost
+    <ul>
+      <li>
+        <strong><code>depth</code></strong
+        >: <i>(str)</i>, Top of permafrost (i.e. depth of active layer).
+      </li>
+      <li>
+        <strong><code>temp</code></strong
+        >: <i>(float)</i>, Mean annual ground temperature (&deg;C).
+      </li>
+      <li>
+        <strong><code>title</code></strong
+        >: <i>(str)</i>, Title describing these results.
+      </li>
+      <li>
+        <strong><code>year</code></strong
+        >: <i>(str)</i>, Date range of model output.
+      </li>
+    </ul>
+  </li>
+
+  <li>
+    <strong><code>jorg</code></strong
+    >: Obu et al. (2018) Modeled Permafrost Extent
+    <ul>
+      <li>
+        <strong><code>pfx</code></strong
+        >: <i>(str)</i>, Permafrost extent.
+      </li>
+      <li>
+        <strong><code>title</code></strong
+        >: <i>(str)</i>, Title describing these results.
+      </li>
+    </ul>
+  </li>
 </ul>
+
 <h4>Source data</h4>
 <table>
-    <thead>
-        <tr>
-            <th>Data Layer</th>
-            <th>Variables</th>
-            <th>Download link</th>
-            <th>Source</th>
-            <th>Notes</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>GIPL Model Ouputs</td>
-            <td>Mean Annual Ground Temperature, Active Layer Thickness</td>
-            <td><a href="https://raw.githubusercontent.com/ua-snap/rasdaman-ingest/main/iem/gipl2_4km/download_melvin.sh">Shell Download Script</a></td>
-            <td><a href="https://doi.org/10.1073/pnas.1611056113">Melvin et al. (2017)</a></td>
-            <td>MAGT is modeled for the depth of the active layer.</td>
-        </tr>
-        <tr>
-            <td>Jorgenson Permafrost Characteristics</td>
-            <td>Permafrost Extent, Ground Ice Volume</td>
-            <td><a href="https://catalog.northslopescience.org/dataset/1725/resource/5811669f-860c-450e-9bc0-9dfc21821606">https://catalog.northslopescience.org/dataset/1725/resource/5811669f-860c-450e-9bc0-9dfc21821606</a></td>
-            <td><a href="https://catalog.northslopescience.org/dataset/1725">https://catalog.northslopescience.org/dataset/1725</a></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>Obu et al. 2018</td>
-            <td>Mean Annual Ground Temperature, Permafrost Extent</td>
-            <td><a href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip">https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip</a>, <a href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip">https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip</a></td>
-            <td><a href="https://doi.org/10.1594/PANGAEA.888600">https://doi.org/10.1594/PANGAEA.888600</a></td>
-            <td></td>
-        </tr>
-    </tbody>
+  <thead>
+    <tr>
+      <th>Data Layer</th>
+      <th>Variables</th>
+      <th>Download link</th>
+      <th>Source</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>GIPL Model Ouputs</td>
+      <td>Mean Annual Ground Temperature, Active Layer Thickness</td>
+      <td>
+        <a
+          href="https://raw.githubusercontent.com/ua-snap/rasdaman-ingest/main/iem/gipl2_4km/download_melvin.sh"
+          >Shell Download Script</a
+        >
+      </td>
+      <td>
+        <a href="https://doi.org/10.1073/pnas.1611056113"
+          >Melvin et al. (2017)</a
+        >
+      </td>
+      <td>MAGT is modeled for the depth of the active layer.</td>
+    </tr>
+    <tr>
+      <td>Jorgenson Permafrost Characteristics</td>
+      <td>Permafrost Extent, Ground Ice Volume</td>
+      <td>
+        <a
+          href="https://catalog.northslopescience.org/dataset/1725/resource/5811669f-860c-450e-9bc0-9dfc21821606"
+          >https://catalog.northslopescience.org/dataset/1725/resource/5811669f-860c-450e-9bc0-9dfc21821606</a
+        >
+      </td>
+      <td>
+        <a href="https://catalog.northslopescience.org/dataset/1725"
+          >https://catalog.northslopescience.org/dataset/1725</a
+        >
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Obu et al. 2018</td>
+      <td>Mean Annual Ground Temperature, Permafrost Extent</td>
+      <td>
+        <a
+          href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip"
+          >https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip</a
+        >,
+        <a
+          href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip"
+          >https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip</a
+        >
+      </td>
+      <td>
+        <a href="https://doi.org/10.1594/PANGAEA.888600"
+          >https://doi.org/10.1594/PANGAEA.888600</a
+        >
+      </td>
+      <td></td>
+    </tr>
+  </tbody>
 </table>
 {% endblock %}

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -9,7 +9,7 @@
 <p>
   Example:
   <a href="/permafrost/point/gipl/63.0628/-146.1627"
-    >/permafrost/point/63.0628/-146.1627</a
+    >/permafrost/point/gipl/63.0628/-146.1627</a
   >
 </p>
 <h4>Results from the query above will look like this:</h4>
@@ -58,6 +58,14 @@
 }
 </pre>
 
+<h4>CSV Export</h4>
+<p>To export the point data to a CSV file, append <code>?format=csv</code>.</p>
+<p>
+  Example:
+  <a href="/permafrost/point/gipl/63.0628/-146.1627?format=csv"
+    >/permafrost/point/gipl/63.0628/-146.1627?format=csv</a
+  >
+</p>
 <h3>Permafrost point query</h3>
 <p>
   Query permafrost data (e.g. extent, ground temperatures) for a single point

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -1,10 +1,8 @@
 {% extends 'base.html' %} {% block content %}
-<h3>
-  Geophysical Institute Permafrost Lab (GIPL) model 1 km output point query
-</h3>
+<h3>Geophysical Institute Permafrost Lab (GIPL) model output</h3>
 <p>
-  Query GIPL model output for a single point specified by latitude and
-  longitude.
+  Query the entire time series of GIPL model outputs (1 km spatial resolution)
+  for ten variables for a single point specified by latitude and longitude.
 </p>
 <p>
   Example:
@@ -12,7 +10,17 @@
     >/permafrost/point/gipl/63.0628/-146.1627</a
   >
 </p>
-<h4>Results from the query above will look like this:</h4>
+<p>
+  Query a specific time slice of GIPL model outputs (1 km spatial resolution)
+  for ten variables for a single point specified by latitude and longitude.
+</p>
+<p>
+  Example:
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050"
+    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050</a
+  >
+</p>
+<h4>Results from the above queries will look like this:</h4>
 <pre>
 {
   "5ModelAvg": {
@@ -58,8 +66,40 @@
 }
 </pre>
 
+<p>
+  Query a specific time slice of GIPL model outputs (1 km spatial resolution)
+  for ten variables for a single point specified by latitude and longitude.
+  Summarize the results by computing the minimum, mean, and maximum values for
+  each of the ten variables for the duration of the time slice. Statistics are
+  computed for all models and scenarios.
+</p>
+<p>
+  Example:
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm"
+    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm</a
+  >
+</p>
+<h4>Results from the above summary query will look like this:</h4>
+<pre>
+{
+  "gipl1kmmax": {...},
+  gipl1kmmean": {...},
+  gipl1kmmin": {...},
+}
+</pre>
+<b>The above output is structured like this:</b>
+<pre>
+{
+    "gipl1kmmax": &ltmax values for all ten variables across all models, scenarios, and years>,
+    "gipl1kmmean": &ltmean values for all ten variables across all models, scenarios, and years>,
+    "gipl1kmmin": &ltmin values for all ten variables across all models, scenarios, and years>
+}
+</pre>
 <h4>CSV Export</h4>
-<p>To export the point data to a CSV file, append <code>?format=csv</code>.</p>
+<p>
+  To export the data from the above queries to a CSV file, append
+  <code>?format=csv</code> to the URL.
+</p>
 <p>
   Example:
   <a href="/permafrost/point/gipl/63.0628/-146.1627?format=csv"
@@ -89,214 +129,7 @@
         }
       }
     },
-    "2025": {
-      "gfdlcm3": {
-        "rcp45": {
-          "alt": 0.68,
-          "magt": 0
-        },
-        "rcp85": {
-          "alt": 0.66,
-          "magt": 0
-        }
-      },
-      "gisse2r": {
-        "rcp45": {
-          "alt": 0.61,
-          "magt": -1
-        },
-        "rcp85": {
-          "alt": 0.6,
-          "magt": -1.1
-        }
-      },
-      "ipslcm5alr": {
-        "rcp45": {
-          "alt": 0.65,
-          "magt": -0.9
-        },
-        "rcp85": {
-          "alt": 0.69,
-          "magt": -0.1
-        }
-      },
-      "mricgcm3": {
-        "rcp45": {
-          "alt": 0.61,
-          "magt": -1.2
-        },
-        "rcp85": {
-          "alt": 0.6,
-          "magt": -1.1
-        }
-      },
-      "ncarccsm4": {
-        "rcp45": {
-          "alt": 0.66,
-          "magt": -0.6
-        },
-        "rcp85": {
-          "alt": 0.64,
-          "magt": -0.5
-        }
-      }
-    },
-    "2050": {
-      "gfdlcm3": {
-        "rcp45": {
-          "alt": 0.98,
-          "magt": 2.2
-        },
-        "rcp85": {
-          "alt": 0.81,
-          "magt": 3.2
-        }
-      },
-      "gisse2r": {
-        "rcp45": {
-          "alt": 0.62,
-          "magt": -0.8
-        },
-        "rcp85": {
-          "alt": 0.64,
-          "magt": -0.2
-        }
-      },
-      "ipslcm5alr": {
-        "rcp45": {
-          "alt": 0.68,
-          "magt": -0.2
-        },
-        "rcp85": {
-          "alt": 0.69,
-          "magt": -0.1
-        }
-      },
-      "mricgcm3": {
-        "rcp45": {
-          "alt": 0.63,
-          "magt": -0.8
-        },
-        "rcp85": {
-          "alt": 0.63,
-          "magt": -0.6
-        }
-      },
-      "ncarccsm4": {
-        "rcp45": {
-          "alt": 0.67,
-          "magt": -0.4
-        },
-        "rcp85": {
-          "alt": 1.21,
-          "magt": 0.3
-        }
-      }
-    },
-    "2075": {
-      "gfdlcm3": {
-        "rcp45": {
-          "alt": 0.81,
-          "magt": 3.4
-        },
-        "rcp85": {
-          "alt": 0.54,
-          "magt": 5.6
-        }
-      },
-      "gisse2r": {
-        "rcp45": {
-          "alt": 0.62,
-          "magt": -0.7
-        },
-        "rcp85": {
-          "alt": 0.65,
-          "magt": 0
-        }
-      },
-      "ipslcm5alr": {
-        "rcp45": {
-          "alt": 1.26,
-          "magt": 0.1
-        },
-        "rcp85": {
-          "alt": 0.91,
-          "magt": 3.1
-        }
-      },
-      "mricgcm3": {
-        "rcp45": {
-          "alt": 0.64,
-          "magt": -0.7
-        },
-        "rcp85": {
-          "alt": 1.19,
-          "magt": 0.1
-        }
-      },
-      "ncarccsm4": {
-        "rcp45": {
-          "alt": 1.17,
-          "magt": 0.7
-        },
-        "rcp85": {
-          "alt": 0.9,
-          "magt": 2.6
-        }
-      }
-    },
-    "2095": {
-      "gfdlcm3": {
-        "rcp45": {
-          "alt": 0.81,
-          "magt": 3.9
-        },
-        "rcp85": {
-          "alt": 0.33,
-          "magt": 7.5
-        }
-      },
-      "gisse2r": {
-        "rcp45": {
-          "alt": 0.61,
-          "magt": -0.7
-        },
-        "rcp85": {
-          "alt": 1.1,
-          "magt": 0.7
-        }
-      },
-      "ipslcm5alr": {
-        "rcp45": {
-          "alt": 1.15,
-          "magt": 0.9
-        },
-        "rcp85": {
-          "alt": 0.66,
-          "magt": 5.2
-        }
-      },
-      "mricgcm3": {
-        "rcp45": {
-          "alt": 0.66,
-          "magt": -0.4
-        },
-        "rcp85": {
-          "alt": 0.99,
-          "magt": 1.7
-        }
-      },
-      "ncarccsm4": {
-        "rcp45": {
-          "alt": 1.18,
-          "magt": 0.5
-        },
-        "rcp85": {
-          "alt": 0.6,
-          "magt": 5.5
-        }
-      }
-    },
+    ...
     "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (°C) and Active Layer Thickness (m) Model Output"
   },
   "jorg": {

--- a/validate_data.py
+++ b/validate_data.py
@@ -22,7 +22,8 @@ nodata_values = {
     "seaice": [120, 254, 255],
     "landfastice": [0],
     "beetles": [0],
-    "wet_days_per_year": [-9999]
+    "wet_days_per_year": [-9999],
+    "crrel_gipl": [-9999],
 }
 
 


### PR DESCRIPTION
This PR adds service endpoints for the most recent of GIPL model outputs (ten variables at 1 km spatial resolution) that were provided to SNAP by Sergey Marchenko in August 2022. The backend data supporting these endpoints is a Rasdaman coverage called `crrel_gipl_outputs` (currently on Apollo only) that was created by ingesting 6000 GeoTIFFs. The spatial extent of these data are Alaska only - although the Western Aleutian chain is not present. 

There are 3 model cases (5-Model-Average, GFDL-CM3, and NCAR-CCSM4), and two scenarios (RCPs 4.5 and 8.5).

Only point queries are implemented at this time.

To test this PR, try queries constructed as follows to fetch the complete set of GIPL model outputs (all models, scenarios, and years) for a point location:

http://localhost:5000/permafrost/point/gipl/66.0628/-146.1627

To slice a time span from these annual-frequency data, simply append a start and stop year to your path - try these examples to fetch data and test validation:

http://localhost:5000/permafrost/point/gipl/65/-148/2040/2049
http://localhost:5000/permafrost/point/gipl/65/-148/2049/2040
http://localhost:5000/permafrost/point/gipl/65/-148/2040/3049
http://localhost:5000/permafrost/point/gipl/65/-148/1040/2049

To slice a time span from these annual-frequency data and then compute mean-min-max summaries for each of the ten variables, simply append "mmm" to your URL:

http://localhost:5000/permafrost/point/gipl/65/-148/2040/2069/mmm

To test validation:

http://localhost:5000/permafrost/point/gipl/65/-148/2040/2069/foo

Highlights:
 - Check the new WCPS syntax courtesy of Dimitar! Pretty clean, and easy to flip between min / mean / max.
 - I like how this route came together: all data > time slice > time slice summarized

Notes:
 - I tread carefully to make sure the other permafrost data (including the Melvin et al 4 km GIPL outputs served used in NCR) endpoints were not impacted. But keep an eye out for that.
 - Also, take a close look at the template. Are the GIPL outputs distinct enough? I think we'd love to mothball the 4 km stuff, but that could be work because of the NCR.
 - In the code I've tried to distinguish the new GIPL data by using `gipl1km` everywhere.

Misses:
 - We need to add to the Data Source table. You have to scroll far to even get to that table, but it is important. This means adding the 6000 GeoTIFFs to our GeoNetwork Catalog.