### PR TITLE
Uses GeoServer to cache local shapefiles for faster lookups

### DIFF
--- a/generate_urls.py
+++ b/generate_urls.py
@@ -34,11 +34,13 @@ def generate_wfs_search_url(workspace, lat, lon, hucs_pa_only=False):
     return wfs_url
 
 
-def generate_wfs_places_url(workspace, properties, filter=None):
+def generate_wfs_places_url(workspace, properties=None, filter=None):
     wfs_url = (
         GS_BASE_URL
-        + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName={workspace}&outputFormat=application%2Fjson&propertyName=({properties})"
+        + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName={workspace}&outputFormat=application%2Fjson"
     )
+    if properties:
+        wfs_url += f"& propertyName = ({properties})"
     if filter:
         wfs_url += f"&filter=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Etype%3C/PropertyName%3E%3CLiteral%3E{filter}%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
     return wfs_url

--- a/luts.py
+++ b/luts.py
@@ -93,6 +93,21 @@ json_types = {
     "game_management_units": "data/jsons/game_management_units.json",
 }
 
+shp_types = {
+    "communities": "data/shapefiles/ak_communities.shp",
+    "boroughs": "data/shapefiles/ak_boroughs.shp",
+    "census_areas": "data/shapefiles/ak_census_areas.shp",
+    "hucs": "data/shapefiles/ak_hucs.shp",
+    "huc12s": "data/shapefiles/ak_huc12s.shp",
+    "protected_areas": "data/shapefiles/ak_protected_areas.shp",
+    "fire_zones": "data/shapefiles/ak_fire_mgmt_zones.shp",
+    "corporations": "data/shapefiles/ak_native_corporations.shp",
+    "climate_divisions": "data/shapefiles/ak_climate_divisions.shp",
+    "ethnolinguistic_regions": "data/shapefiles/ethnolinguistic_regions.shp",
+    "first_nations": "data/shapefiles/canada_first_nations.shp",
+    "game_management_units": "data/shapefiles/game_management_units.shp",
+}
+
 place_type_labels = {
     "huc8s": "HUC",
     "protected_areas": "Protected Area",
@@ -163,58 +178,50 @@ with open("data/luts_pickles/akvegwetlandcomposite.pkl", "rb") as fp:
 
 try:
     # Below Polygons can be imported by various endpoints
-    # HUC-8 # note these are native WGS84 in the #geo-vector repo
-    hucs_src = "data/jsons/ak_hucs.json"
-    hucs_gdf = gpd.read_file(hucs_src).set_index("id").to_crs(3338)
+    # HUC-8 & HUC-10
+    hucs_gdf = gpd.read_file(shp_types["hucs"]).set_index("id").to_crs(3338)
 
-    print("HUCS")
     # HUC-12
-    huc12_src = "data/shapefiles/ak_huc12s.shp"
-    huc12_gdf = gpd.read_file(huc12_src).set_index("id").to_crs(3338)
-    print("HUCS12")
+    huc12_gdf = gpd.read_file(shp_types["huc12s"]).set_index("id").to_crs(3338)
+
     # AK Protected Areas
-    akpa_src = "data/jsons/ak_protected_areas.json"
-    with fiona.open(akpa_src) as src:
-        akpa_gdf = gpd.GeoDataFrame.from_features(src).set_index("id").to_crs(3338)
-    print("Protected Area")
+    akpa_gdf = gpd.read_file(shp_types["protected_areas"]).set_index("id").to_crs(3338)
+
     # AK Fire Management Zones
-    akfire_src = "data/jsons/ak_fire_mgmt_zones.json"
-    akfire_gdf = gpd.read_file(akfire_src).set_index("id").to_crs(3338)
-    print("Fire")
+    akfire_gdf = gpd.read_file(shp_types["fire_zones"]).set_index("id").to_crs(3338)
+
     # AK Corporations
-    akco_src = "data/jsons/ak_native_corporations.json"
-    akco_gdf = gpd.read_file(akco_src).set_index("id").to_crs(3338)
-    print("Corp")
+    akco_gdf = gpd.read_file(shp_types["corporations"]).set_index("id").to_crs(3338)
+
     # AK Climate Divisions
-    akclim_src = "data/jsons/ak_climate_divisions.json"
-    akclim_gdf = gpd.read_file(akclim_src).set_index("id").to_crs(3338)
-    print("Climate")
+    akclim_gdf = (
+        gpd.read_file(shp_types["climate_divisions"]).set_index("id").to_crs(3338)
+    )
+
     # Ethnolinguistic Regions
-    aketh_src = "data/jsons/ethnolinguistic_regions.json"
-    aketh_gdf = gpd.read_file(aketh_src).set_index("id").to_crs(3338)
-    print("Eth")
+    aketh_gdf = (
+        gpd.read_file(shp_types["ethnolinguistic_regions"]).set_index("id").to_crs(3338)
+    )
+
     # AK Game Management Units
-    akgmu_src = "data/jsons/game_management_units.json"
-    akgmu_gdf = gpd.read_file(akgmu_src).set_index("id").to_crs(3338)
-    print("GMU")
+    akgmu_gdf = (
+        gpd.read_file(shp_types["game_management_units"]).set_index("id").to_crs(3338)
+    )
+
     # Canadian First Nations
-    cafn_src = "data/jsons/canada_first_nations.json"
-    cafn_gdf = gpd.read_file(cafn_src).set_index("id").to_crs(3338)
-    print("CAFN")
+    cafn_gdf = gpd.read_file(shp_types["first_nations"]).set_index("id").to_crs(3338)
+
     # Alaska Boroughs
-    boro_src = "data/jsons/ak_boroughs.json"
-    boro_gdf = gpd.read_file(boro_src).set_index("id").to_crs(3338)
-    print("Boro")
+    boro_gdf = gpd.read_file(shp_types["boroughs"]).set_index("id").to_crs(3338)
+
     # Unorganized Borough Census Areas
-    akcensus_src = "data/jsons/ak_census_areas.json"
-    akcensus_gdf = gpd.read_file(akcensus_src).set_index("id").to_crs(3338)
-    print("Census")
+    akcensus_gdf = gpd.read_file(shp_types["census_areas"]).set_index("id").to_crs(3338)
+
     # join HUCs into same GeoDataFrame for easier lookup
     huc_gdf = pd.concat(
         [hucs_gdf.reset_index(), huc12_gdf.reset_index()], ignore_index=True
     ).set_index("id")
     valid_huc_ids = huc_gdf.index.values
-
 
     type_di = dict()
     type_di["huc"] = hucs_gdf
@@ -233,12 +240,11 @@ try:
 except fiona.errors.DriverError:
     # if this fails, give placeholders until all data can
     # be updated from vectordata.py
-    print("It needs to update?")
     update_needed = True
     (
         huc8_gdf,
         huc12_gdf,
-        # akpa_gdf,
+        akpa_gdf,
         akfire_gdf,
         akco_gdf,
         akclim_gdf,
@@ -259,12 +265,12 @@ shp_di["akhucs"] = {
     "prefix": "ak_hucs",
     "poly_type": "huc",
 }
-# shp_di["akhuc12s"] = {
-#     "src_dir": "alaska_hucs",
-#     "prefix": "ak_huc12s",
-#     "poly_type": "huc12",
-#     "retain": [],
-# }
+shp_di["akhuc12s"] = {
+    "src_dir": "alaska_hucs",
+    "prefix": "ak_huc12s",
+    "poly_type": "huc12",
+    "retain": [],
+}
 shp_di["ak_pa"] = {
     "src_dir": "protected_areas/ak_protected_areas",
     "prefix": "ak_protected_areas",

--- a/luts.py
+++ b/luts.py
@@ -149,14 +149,20 @@ areas_near = {
     "protected_area": "protected_areas_near",
 }
 
-# For the forest endpoint.  This file is just a generated pickle
-# from the `dbf` file that will be downloaded with the .zip that
-# is linked in the documentation page for the point query, including
-# only the columns we need for this lookup.
-with open("data/luts_pickles/akvegwetlandcomposite.pkl", "rb") as fp:
-    ak_veg_di = pickle.load(fp)
 
-try:
+def load_gdfs():
+    """
+    Simple function for creating GeoPandas GeoDataFrames out of
+    cached shapefiles on the API server. By calling it from a function,
+    we are able to update the underlying shapefiles and have the server
+    reload them into GDFs after.
+
+    Args:
+        None.
+    Returns:
+        A tuple containing a dictionary of all GDFs called type_di
+        and a list of valid_huc_ids.
+    """
     # Community Point Locations
     comms_gdf = gpd.read_file(shp_types["communities"]).to_crs(3338)
     # Below Polygons can be imported by various endpoints
@@ -219,6 +225,18 @@ try:
     type_di["borough"] = boro_gdf
     type_di["census_area"] = akcensus_gdf
 
+    return type_di, valid_huc_ids
+
+
+# For the forest endpoint.  This file is just a generated pickle
+# from the `dbf` file that will be downloaded with the .zip that
+# is linked in the documentation page for the point query, including
+# only the columns we need for this lookup.
+with open("data/luts_pickles/akvegwetlandcomposite.pkl", "rb") as fp:
+    ak_veg_di = pickle.load(fp)
+
+try:
+    type_di, valid_huc_ids = load_gdfs()
     update_needed = False
 except fiona.errors.DriverError:
     # if this fails, give placeholders until all data can
@@ -243,7 +261,7 @@ except fiona.errors.DriverError:
     type_di = dict()
 
 # look-up for updating place names and data via geo-vector GitHub repo
-shp_di = {}
+shp_di = dict()
 shp_di["akhucs"] = {
     "prefix": "ak_hucs",
     "poly_type": "huc",

--- a/luts.py
+++ b/luts.py
@@ -77,22 +77,6 @@ permafrost_encodings = {
     "gipl_units_lu": {"magt": "°C", "alt": "m"},
 }
 
-json_types = {
-    "communities": "data/jsons/ak_communities.json",
-    "boroughs": "data/jsons/ak_boroughs.json",
-    "census_areas": "data/jsons/ak_census_areas.json",
-    "hucs": "data/jsons/ak_hucs.json",
-    "huc8s": "data/jsons/ak_huc8.json",
-    "huc12s": "data/jsons/ak_huc12.json",
-    "protected_areas": "data/jsons/ak_protected_areas.json",
-    "fire_zones": "data/jsons/ak_fire_mgmt_zones.json",
-    "corporations": "data/jsons/ak_native_corporations.json",
-    "climate_divisions": "data/jsons/ak_climate_divisions.json",
-    "ethnolinguistic_regions": "data/jsons/ethnolinguistic_regions.json",
-    "first_nations": "data/jsons/canada_first_nations.json",
-    "game_management_units": "data/jsons/game_management_units.json",
-}
-
 shp_types = {
     "communities": "data/shapefiles/ak_communities.shp",
     "boroughs": "data/shapefiles/ak_boroughs.shp",
@@ -109,21 +93,17 @@ shp_types = {
 }
 
 place_type_labels = {
-    "huc8s": "HUC",
-    "protected_areas": "Protected Area",
-    "boroughs": "Borough",
-    "census_areas": "Census Area",
-    "fire_zones": "Fire Management Unit",
-    "corporations": "Corporation",
-    "climate_divisions": "Climate Division",
-    "ethnolinguistic_regions": "Ethnolinguistic Region",
-    "first_nations": "Canadian First Nation",
-    "game_management_units": "Game Management Unit",
+    "huc": "HUC",
+    "protected_area": "Protected Area",
+    "borough": "Borough",
+    "census_area": "Census Area",
+    "fire_zone": "Fire Management Unit",
+    "corporation": "Corporation",
+    "climate_division": "Climate Division",
+    "ethnolinguistic_region": "Ethnolinguistic Region",
+    "first_nation": "Canadian First Nation",
+    "game_management_unit": "Game Management Unit",
 }
-
-# Unused variable for now. Can be used by re-caching function to pre-cache
-# all HUC types listed below.
-huc_jsons = {json_types["huc8s"], json_types["huc12s"]}
 
 cached_urls = [
     "/alfresco/flammability/area/",
@@ -177,6 +157,8 @@ with open("data/luts_pickles/akvegwetlandcomposite.pkl", "rb") as fp:
     ak_veg_di = pickle.load(fp)
 
 try:
+    # Community Point Locations
+    comms_gdf = gpd.read_file(shp_types["communities"]).to_crs(3338)
     # Below Polygons can be imported by various endpoints
     # HUC-8 & HUC-10
     hucs_gdf = gpd.read_file(shp_types["hucs"]).set_index("id").to_crs(3338)
@@ -224,6 +206,7 @@ try:
     valid_huc_ids = huc_gdf.index.values
 
     type_di = dict()
+    type_di["community"] = comms_gdf
     type_di["huc"] = hucs_gdf
     type_di["huc12"] = huc12_gdf
     type_di["protected_area"] = akpa_gdf
@@ -242,7 +225,8 @@ except fiona.errors.DriverError:
     # be updated from vectordata.py
     update_needed = True
     (
-        huc8_gdf,
+        comms_gdf,
+        hucs_gdf,
         huc12_gdf,
         akpa_gdf,
         akfire_gdf,
@@ -255,13 +239,12 @@ except fiona.errors.DriverError:
         boro_gdf,
         akcensus_gdf,
         valid_huc_ids,
-    ) = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    ) = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     type_di = dict()
 
 # look-up for updating place names and data via geo-vector GitHub repo
 shp_di = {}
 shp_di["akhucs"] = {
-    "src_dir": "alaska_hucs",
     "prefix": "ak_hucs",
     "poly_type": "huc",
 }
@@ -272,49 +255,40 @@ shp_di["akhuc12s"] = {
     "retain": [],
 }
 shp_di["ak_pa"] = {
-    "src_dir": "protected_areas/ak_protected_areas",
     "prefix": "ak_protected_areas",
     "poly_type": "protected_area",
     "retain": "area_type",
 }
 shp_di["akfire"] = {
-    "src_dir": "fire",
     "prefix": "ak_fire_management",
     "poly_type": "fire_zone",
 }
 shp_di["akcorps"] = {
-    "src_dir": "corporation",
     "prefix": "ak_native_corporations",
     "poly_type": "corporation",
 }
 shp_di["akethno"] = {
-    "src_dir": "ethnolinguistic",
     "prefix": "ethnolinguistic_regions",
     "poly_type": "ethnolinguistic_region",
     "retain": "alt_name",
 }
 shp_di["akclimdivs"] = {
-    "src_dir": "climate_divisions",
     "prefix": "ak_climate_divisions",
     "poly_type": "climate_division",
 }
 shp_di["akgmus"] = {
-    "src_dir": "game_management_units",
     "prefix": "ak_gmu",
     "poly_type": "game_management_unit",
 }
 shp_di["cnfns"] = {
-    "src_dir": "first_nations",
     "prefix": "first_nation_traditional_territories",
     "poly_type": "first_nation",
 }
 shp_di["akboros"] = {
-    "src_dir": "boroughs",
     "prefix": "ak_boroughs",
     "poly_type": "borough",
 }
 shp_di["akcensusareas"] = {
-    "src_dir": "census_areas",
     "prefix": "ak_census_areas",
     "poly_type": "census_area",
 }

--- a/luts.py
+++ b/luts.py
@@ -167,6 +167,9 @@ try:
     huc8_src = "data/shapefiles/ak_huc8s.shp"
     huc8_gdf = gpd.read_file(huc8_src).set_index("id").to_crs(3338)
 
+    huc10_src = "data/shapefiles/ak_huc10s.shp"
+    huc10_gdf = gpd.read_file(huc10_src).set_index("id").to_crs(3338)
+
     # HUC-12
     huc12_src = "data/shapefiles/ak_huc12s.shp"
     huc12_gdf = gpd.read_file(huc12_src).set_index("id").to_crs(3338)
@@ -213,8 +216,10 @@ try:
     ).set_index("id")
     valid_huc_ids = huc_gdf.index.values
 
+    hucs_gdf = pd.concat([huc8_gdf.reset_index(), huc10_gdf.reset_index()], ignore_index=True).set_index("id")
+
     type_di = dict()
-    type_di["huc"] = huc8_gdf
+    type_di["huc"] = hucs_gdf
     type_di["huc12"] = huc12_gdf
     type_di["protected_area"] = akpa_gdf
     type_di["corporation"] = akco_gdf

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -25,7 +25,7 @@ from validate_data import (
     postprocess,
     place_name_and_type,
 )
-from luts import huc12_gdf, type_di
+from luts import type_di
 from config import WEST_BBOX, EAST_BBOX
 from . import routes
 
@@ -508,6 +508,7 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
     x, y = project_latlon(lat, lon, 3338)
     # intersct the point with the HUC-12 polygons
     point = Point(x, y)
+    huc12_gdf = type_di["huc12"]
     intersect = huc12_gdf["geometry"].intersection(point)
     # algorithm below to find the most qualified HUC, since we cannot
     # rely on a simply intersection because simplified HUC-12s are not mutually

--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -11,7 +11,15 @@ from shapely.geometry import Point, box
 
 # local imports
 from . import routes
-from luts import shp_types, shp_di, all_jsons, areas_near, type_di
+from luts import (
+    shp_types,
+    shp_di,
+    all_jsons,
+    areas_near,
+    type_di,
+    valid_huc_ids,
+    load_gdfs,
+)
 from config import GS_BASE_URL, EAST_BBOX, WEST_BBOX
 from validate_request import validate_latlon
 from generate_urls import generate_wfs_search_url, generate_wfs_places_url
@@ -272,6 +280,7 @@ def update_json_data():
          example: http://localhost:5000/update
     """
     update_data()
+    type_di, valid_huc_ids = load_gdfs()
     return Response(
         response='{ "success": "True" }', status=200, mimetype="application/json"
     )

--- a/validate_request.py
+++ b/validate_request.py
@@ -113,7 +113,7 @@ def validate_var_id(var_id):
     var_id_check_url = f"{GS_BASE_URL}/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries%3Aall_areas&outputFormat=application%2Fjson&propertyName=(type)&filter=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eid%3C/PropertyName%3E%3CLiteral%3E{var_id}%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
     var_id_check_resp = requests.get(var_id_check_url, allow_redirects=True)
     var_id_check = json.loads(var_id_check_resp.content)
-    print(var_id_check["numberMatched"])
+
     if var_id_check["numberMatched"] > 0:
         return var_id_check["features"][0]["properties"]["type"]
     return render_template("422/invalid_area.html"), 400

--- a/validate_request.py
+++ b/validate_request.py
@@ -116,6 +116,11 @@ def validate_var_id(var_id):
 
     if var_id_check["numberMatched"] > 0:
         return var_id_check["features"][0]["properties"]["type"]
+    elif var_id in valid_huc_ids:
+        if len(var_id) > 10:
+            return "huc12"
+        return "huc"
+
     return render_template("422/invalid_area.html"), 400
 
 


### PR DESCRIPTION
This PR takes returned GeoServer data for communities and areas of interest and converts them into local ESRI shapefiles on initial boot. This can also be redone via the /update endpoint. 

When this is run via the /update endpoint or initial start-up, it also refreshes the GeoPandas GeoDataFrames with the new data without requiring a restart of the application server. 

This makes the act of searching for polygon boundary extents and metadata such as name or ID much faster than requesting from GeoServer for all communities and areas.