### PR TITLE
Integrates HUC12 boundary calls and ALFRESCO local requests to Geoserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,6 @@ Example Geology Query
 Example Physiography Query
  - http://localhost:5000/physiography/point/64.606/-147.345
 
-## Updating the JSON data on the API
-
-We have an endpoint specifically meant to pull down data
-from our geospatial truth repository. This will automatically
-generate GeoJSON files based on those CSVs and shapefiles.
-
-To get the latest data, go to:
-
- - http://localhost:5000/update/
-
 ## Updating Production API + Varnish Cache
 
 Due to the configuration of our services, we need to both update

--- a/application.py
+++ b/application.py
@@ -1,12 +1,6 @@
 from datetime import datetime
 from flask import Flask, render_template
 from flask_cors import CORS
-from luts import update_needed
-
-if update_needed:
-    from routes.vectordata import update_data
-
-    update_data()
 
 from routes import *
 

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -49,6 +49,15 @@ def generate_wfs_places_url(
     return wfs_url
 
 
+def generate_wfs_huc12_intersection_url(lat, lon):
+    wfs_url = (
+        GS_BASE_URL
+        + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=all_boundaries:ak_huc12&propertyName=(id)&outputFormat=application/json&cql_filter=INTERSECTS(the_geom, POINT({lon} {lat}))"
+    )
+    return wfs_url
+
+
+
 def generate_wcs_query_url(request_str, backend=RAS_BASE_URL):
     """Make a WCS URL by plugging a request substring into a base WCS URL.
 

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -57,7 +57,6 @@ def generate_wfs_huc12_intersection_url(lat, lon):
     return wfs_url
 
 
-
 def generate_wcs_query_url(request_str, backend=RAS_BASE_URL):
     """Make a WCS URL by plugging a request substring into a base WCS URL.
 

--- a/luts.py
+++ b/luts.py
@@ -135,24 +135,3 @@ areas_near = {
 # only the columns we need for this lookup.
 with open("data/luts_pickles/akvegwetlandcomposite.pkl", "rb") as fp:
     ak_veg_di = pickle.load(fp)
-
-try:
-    # HUC-12
-    huc12_src = "data/shapefiles/ak_huc12s.shp"
-    huc12_gdf = gpd.read_file(huc12_src).set_index("id").to_crs(3338)
-
-    update_needed = False
-except fiona.errors.DriverError:
-    # if this fails, give placeholders until all data can
-    # be updated from vectordata.py
-    update_needed = True
-    huc12_gdf = 0
-
-# look-up for updating place names and data via geo-vector GitHub repo
-shp_di = dict()
-shp_di["akhuc12s"] = {
-    "src_dir": "alaska_hucs",
-    "prefix": "ak_huc12s",
-    "poly_type": "huc12",
-    "retain": ["states"],
-}

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -10,7 +10,6 @@ from flask import (
     request,
     current_app as app,
 )
-from shapely.geometry import Point
 
 # local imports
 from generate_requests import *

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -507,6 +507,9 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
         fetch_data([generate_wfs_huc12_intersection_url(lat, lon)])
     )["features"]
 
+    if len(huc12_features) < 1:
+        return render_template("404/no_data.html"), 404
+
     huc12_gdf = gpd.GeoDataFrame.from_features(huc12_features)
 
     # Collect the HUC12 ID for the returned nearest HUC12

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -2,8 +2,6 @@ import asyncio
 import itertools
 import geopandas as gpd
 import numpy as np
-import requests
-import json
 from flask import (
     Blueprint,
     render_template,
@@ -505,12 +503,9 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
         )
 
     # Requests for HUC12s that intersect
-    huc12_resp = requests.get(
-        generate_wfs_huc12_intersection_url(lat, lon),
-        allow_redirects=True,
-    )
-    huc12_json = json.loads(huc12_resp.content)
-    huc12_features = huc12_json["features"]
+    huc12_features = asyncio.run(
+        fetch_data([generate_wfs_huc12_intersection_url(lat, lon)])
+    )["features"]
 
     huc12_gdf = gpd.GeoDataFrame.from_features(huc12_features)
 

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -2,6 +2,8 @@ import asyncio
 import itertools
 import geopandas as gpd
 import numpy as np
+import requests
+import json
 from flask import (
     Blueprint,
     render_template,
@@ -12,7 +14,7 @@ from shapely.geometry import Point
 
 # local imports
 from generate_requests import *
-from generate_urls import generate_wcs_query_url
+from generate_urls import generate_wcs_query_url, generate_wfs_huc12_intersection_url
 from fetch_data import *
 from validate_request import (
     validate_latlon,
@@ -25,7 +27,6 @@ from validate_data import (
     postprocess,
     place_name_and_type,
 )
-from luts import huc12_gdf
 from config import WEST_BBOX, EAST_BBOX
 from . import routes
 
@@ -504,41 +505,18 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
             422,
         )
 
-    # create Point object from coordinates
-    x, y = project_latlon(lat, lon, 3338)
-    # intersct the point with the HUC-12 polygons
-    point = Point(x, y)
-    intersect = huc12_gdf["geometry"].intersection(point)
-    # algorithm below to find the most qualified HUC, since we cannot
-    # rely on a simply intersection because simplified HUC-12s are not mutually
-    # exclusive and exhaustive over AK
-    # (because the simplifying algorithm does not preserve topology of the orginal shapefile)
-    idx_arr = np.where(~np.array([poly.is_empty for poly in intersect]))[0]
-    if len(idx_arr) == 1:
-        # ideal case (and probably most common) - point intersects a single HUC
-        huc_id = huc12_gdf.iloc[idx_arr[0]].name
-    elif len(idx_arr) > 1:
-        # case where multiple polygons intersect the point
-        overlap_gs = gpd.GeoSeries([huc12_gdf["geometry"][idx] for idx in idx_arr])
-        distance = np.array(
-            [gpd.GeoSeries(point).distance(geom.boundary) for geom in overlap_gs]
-        )
-        # whichever polygon has the largest distance to the point is
-        # actually overlapping it the most, so select that one
-        huc_idx = idx_arr[np.argmax(distance)]
-        huc_id = huc12_gdf.iloc[huc_idx].name
-    else:
-        # no intersection, see if a HUC poly is near, within 100m
-        distance = huc12_gdf["geometry"].distance(point)
-        idx_arr = np.where(distance < 100)[0]
-        near_distances = [distance[idx] for idx in idx_arr]
-        if len(idx_arr) == 0:
-            # if still no luck, assume miss
-            return render_template("422/invalid_huc.html"), 422
-        else:
-            # otherwise take nearest HUC within 100m
-            huc_id = huc12_gdf.iloc[idx_arr[np.argmin(near_distances)]].name
+    # Requests for HUC12s that intersect
+    huc12_resp = requests.get(
+        generate_wfs_huc12_intersection_url(lat, lon),
+        allow_redirects=True,
+    )
+    huc12_json = json.loads(huc12_resp.content)
+    huc12_features = huc12_json["features"]
 
+    huc12_gdf = gpd.GeoDataFrame.from_features(huc12_features)
+
+    # Collect the HUC12 ID for the returned nearest HUC12
+    huc_id = huc12_gdf.loc[0, 'id']
     huc12_pkg = run_fetch_alf_area_data(var_ep, huc_id, ignore_csv=True)
 
     if request.args.get("format") == "csv":

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -516,7 +516,7 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
     huc12_gdf = gpd.GeoDataFrame.from_features(huc12_features)
 
     # Collect the HUC12 ID for the returned nearest HUC12
-    huc_id = huc12_gdf.loc[0, 'id']
+    huc_id = huc12_gdf.loc[0, "id"]
     huc12_pkg = run_fetch_alf_area_data(var_ep, huc_id, ignore_csv=True)
 
     if request.args.get("format") == "csv":

--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -2,12 +2,8 @@ from flask import Blueprint, render_template, Response
 
 import geopandas as gpd
 import json
-import os
-import shutil
-import numpy as np
 import pandas as pd
 import requests
-from shapely.geometry import Point, box
 
 # local imports
 from . import routes
@@ -15,7 +11,7 @@ from luts import (
     all_jsons,
     areas_near,
 )
-from config import GS_BASE_URL, EAST_BBOX, WEST_BBOX
+from config import EAST_BBOX, WEST_BBOX
 from validate_request import validate_latlon
 from generate_urls import generate_wfs_search_url, generate_wfs_places_url
 

--- a/validate_data.py
+++ b/validate_data.py
@@ -180,11 +180,18 @@ def get_poly_3338_bbox(poly_id, crs=3338):
             poly = gpd.GeoDataFrame.from_features(geometry).set_crs(4326)
         return poly
     except:
+        url = generate_wfs_places_url(
+            "all_boundaries:ak_huc12", "the_geom", poly_id, "id"
+        )
+        url_resp = requests.get(url, allow_redirects=True)
+        geometry = json.loads(url_resp.content)
         if crs == 3338:
-            poly_gdf = huc12_gdf.loc[[poly_id]][["geometry"]].to_crs(crs)
+            poly_gdf = (
+                gpd.GeoDataFrame.from_features(geometry).set_crs(4326).to_crs(crs)
+            )
             poly = poly_gdf.iloc[0]["geometry"]
         else:
-            poly = huc12_gdf.loc[[poly_id]].to_crs(4326)
+            poly = gpd.GeoDataFrame.from_features(geometry).set_crs(4326)
         return poly
 
 

--- a/validate_data.py
+++ b/validate_data.py
@@ -4,7 +4,6 @@ import re
 import geopandas as gpd
 import requests
 from flask import render_template
-from luts import huc12_gdf
 
 from fetch_data import add_titles
 from generate_urls import generate_wfs_places_url

--- a/validate_request.py
+++ b/validate_request.py
@@ -9,7 +9,7 @@ import json
 from flask import render_template
 from pyproj import Transformer
 import numpy as np
-from config import GS_BASE_URL, WEST_BBOX, EAST_BBOX, SEAICE_BBOX
+from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX
 import requests
 from generate_urls import generate_wfs_places_url
 

--- a/validate_request.py
+++ b/validate_request.py
@@ -119,9 +119,17 @@ def validate_var_id(var_id):
 
     if var_id_check["numberMatched"] > 0:
         return var_id_check["features"][0]["properties"]["type"]
-    elif var_id in huc12_gdf.index.values:
-        return "huc12"
-    return render_template("422/invalid_area.html"), 400
+    else:
+        # Search for HUC12 ID if not found in other areas
+        var_id_check_url = generate_wfs_places_url(
+            "all_boundaries:ak_huc12", "type", var_id, "id"
+        )
+        var_id_check_resp = requests.get(var_id_check_url, allow_redirects=True)
+        var_id_check = json.loads(var_id_check_resp.content)
+        if var_id_check["numberMatched"] > 0:
+            return "huc12"
+        else:
+            return render_template("422/invalid_area.html"), 400
 
 
 def project_latlon(lat1, lon1, dst_crs, lat2=None, lon2=None):

--- a/validate_request.py
+++ b/validate_request.py
@@ -3,15 +3,15 @@ A module to validate latitude and longitude, contains
 other functions that could be used across multiple endpoints.
 """
 
+import asyncio
 import os
 import re
-import json
 from flask import render_template
 from pyproj import Transformer
 import numpy as np
 from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX
-import requests
 from generate_urls import generate_wfs_places_url
+from fetch_data import fetch_data
 
 
 def validate_latlon(lat, lon):
@@ -110,21 +110,26 @@ def validate_year(start_year, end_year):
 def validate_var_id(var_id):
     if re.search("[^A-Za-z0-9]", var_id):
         return render_template("400/bad_request.html"), 400
-    var_id_check_url = generate_wfs_places_url(
-        "all_boundaries:all_areas", "type", var_id, "id"
+
+    var_id_check = asyncio.run(
+        fetch_data(
+            [generate_wfs_places_url("all_boundaries:all_areas", "type", var_id, "id")]
+        )
     )
-    var_id_check_resp = requests.get(var_id_check_url, allow_redirects=True)
-    var_id_check = json.loads(var_id_check_resp.content)
 
     if var_id_check["numberMatched"] > 0:
         return var_id_check["features"][0]["properties"]["type"]
     else:
         # Search for HUC12 ID if not found in other areas
-        var_id_check_url = generate_wfs_places_url(
-            "all_boundaries:ak_huc12", "type", var_id, "id"
+        var_id_check = asyncio.run(
+            fetch_data(
+                [
+                    generate_wfs_places_url(
+                        "all_boundaries:ak_huc12", "type", var_id, "id"
+                    )
+                ]
+            )
         )
-        var_id_check_resp = requests.get(var_id_check_url, allow_redirects=True)
-        var_id_check = json.loads(var_id_check_resp.content)
         if var_id_check["numberMatched"] > 0:
             return "huc12"
         else:

--- a/validate_request.py
+++ b/validate_request.py
@@ -12,7 +12,6 @@ import numpy as np
 from config import GS_BASE_URL, WEST_BBOX, EAST_BBOX, SEAICE_BBOX
 import requests
 from generate_urls import generate_wfs_places_url
-from luts import huc12_gdf
 
 
 def validate_latlon(lat, lon):


### PR DESCRIPTION
This PR changes the last of the remnants of our old process for downloading shapefiles locally and opening them via GeoPandas for analysis. This points the calls for the old HUC12 GDF to Geoserver WFS responses that are then loaded into a temporary GDF for analysis. In some cases, we are letting Geoserver do all of the work that was originally required such as finding the nearest HUC12 that intersects with a given lat / lon for the ALFRESCO local requests. 

Let me know if you have any questions, and please let me know if you spy anything that isn't right and should be changed.

Things to check:

- Ensure the ALFRESCO code works for any of the local endpoints for flammability and veg_change
- Ensure you don't see any outstanding areas where the GDFs are called from luts.py
- Any code that could be improved using your knowledge of Geopandas