### PR TITLE
Removes trailing forward slash at the end of beetle point location URL.

### DIFF
--- a/routes/beetles.py
+++ b/routes/beetles.py
@@ -521,7 +521,7 @@ def about_beetles_area():
     return render_template("beetles/area.html")
 
 
-@routes.route("/beetles/point/<lat>/<lon>/")
+@routes.route("/beetles/point/<lat>/<lon>")
 def run_point_fetch_all_beetles(lat, lon):
     """Run the async request for beetle risk data at a single point.
     Args:


### PR DESCRIPTION
This PR simply removes the trailing forward slash of the beetle's point query that was causing issues with our NCR application due to the need to redirect from the requested URL without a trailing slash to the expected API URL with a trailing slash. Without the trailing slash, the correct URL is requested for point locations, and the CORS works without having to redirect. 

To test, ensure that you can access this community in Chrome, Firefox, and Safari through the NCR application: http://dev.northernclimatereports.org/report/community/AK300

This branch has already been uploaded to the development API at: http://development.earthmaps.io 