### PR TITLE
GIPL Permafrost updates

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -148,12 +148,13 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp, package_type):
     summary_methods = ["min", "mean", "max"]
     if package_type == "historical":
         gipl1km_wcps_point_pkg["Historical"] = dict()
+        gipl1km_wcps_point_pkg["Historical"]["Historical"] = dict()
         for resp, stat_type in zip(gipl1km_wcps_resp[0], summary_methods):
-            gipl1km_wcps_point_pkg["Historical"][f"gipl1km{stat_type}"] = dict()
+            gipl1km_wcps_point_pkg["Historical"]["Historical"][f"gipl1km{stat_type}"] = dict()
             for k, v in zip(
                 gipl1km_historical_dim_encodings["variable"].values(), resp
             ):
-                gipl1km_wcps_point_pkg["Historical"][f"gipl1km{stat_type}"][k] = round(
+                gipl1km_wcps_point_pkg["Historical"]["Historical"][f"gipl1km{stat_type}"][k] = round(
                     v, 1
                 )
     else:
@@ -213,8 +214,9 @@ def package_gipl1km_point_data(gipl1km_point_resp, time_slice=None):
         for t in tx:
             year = t.date().strftime("%Y")
             gipl1km_point_pkg["Historical"][year] = dict()
+            gipl1km_point_pkg["Historical"][year]["Historical"] = dict()
             for gipl_var_name in gipl1km_historical_dim_encodings["variable"].values():
-                gipl1km_point_pkg["Historical"][year][gipl_var_name] = round(
+                gipl1km_point_pkg["Historical"][year]["Historical"][gipl_var_name] = round(
                     flat_list[i], 1
                 )
                 i += 1
@@ -246,8 +248,9 @@ def package_gipl1km_point_data(gipl1km_point_resp, time_slice=None):
         for t in tx:
             year = t.date().strftime("%Y")
             gipl1km_point_pkg["Historical"][year] = dict()
+            gipl1km_point_pkg["Historical"][year]["Historical"] = dict()
             for gipl_var_name in gipl1km_historical_dim_encodings["variable"].values():
-                gipl1km_point_pkg["Historical"][year][gipl_var_name] = round(
+                gipl1km_point_pkg["Historical"][year]["Historical"][gipl_var_name] = round(
                     flat_list[i], 1
                 )
                 i += 1

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -147,14 +147,14 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp, package_type):
     gipl1km_wcps_point_pkg = dict()
     summary_methods = ["min", "mean", "max"]
     if package_type == "historical":
-        gipl1km_wcps_point_pkg["Historical"] = dict()
-        gipl1km_wcps_point_pkg["Historical"]["Historical"] = dict()
+        gipl1km_wcps_point_pkg["CRU-TS 4.0"] = dict()
+        gipl1km_wcps_point_pkg["CRU-TS 4.0"]["Historical"] = dict()
         for resp, stat_type in zip(gipl1km_wcps_resp[0], summary_methods):
-            gipl1km_wcps_point_pkg["Historical"]["Historical"][f"gipl1km{stat_type}"] = dict()
+            gipl1km_wcps_point_pkg["CRU-TS 4.0"]["Historical"][f"gipl1km{stat_type}"] = dict()
             for k, v in zip(
                 gipl1km_historical_dim_encodings["variable"].values(), resp
             ):
-                gipl1km_wcps_point_pkg["Historical"]["Historical"][f"gipl1km{stat_type}"][k] = round(
+                gipl1km_wcps_point_pkg["CRU-TS 4.0"]["Historical"][f"gipl1km{stat_type}"][k] = round(
                     v, 1
                 )
     else:
@@ -207,16 +207,16 @@ def package_gipl1km_point_data(gipl1km_point_resp, time_slice=None):
     gipl1km_point_pkg = {}
 
     if time_slice is not None and int(time_slice[1]) <= 2015:
-        gipl1km_point_pkg["Historical"] = dict()
+        gipl1km_point_pkg["CRU-TS 4.0"] = dict()
         start, stop = time_slice
         tx = generate_gipl1km_time_index()
         tx = tx[tx.slice_indexer(f"{start}-01-01", f"{stop}-01-01")]
         for t in tx:
             year = t.date().strftime("%Y")
-            gipl1km_point_pkg["Historical"][year] = dict()
-            gipl1km_point_pkg["Historical"][year]["Historical"] = dict()
+            gipl1km_point_pkg["CRU-TS 4.0"][year] = dict()
+            gipl1km_point_pkg["CRU-TS 4.0"][year]["Historical"] = dict()
             for gipl_var_name in gipl1km_historical_dim_encodings["variable"].values():
-                gipl1km_point_pkg["Historical"][year]["Historical"][gipl_var_name] = round(
+                gipl1km_point_pkg["CRU-TS 4.0"][year]["Historical"][gipl_var_name] = round(
                     flat_list[i], 1
                 )
                 i += 1
@@ -242,15 +242,15 @@ def package_gipl1km_point_data(gipl1km_point_resp, time_slice=None):
 
         return gipl1km_point_pkg
     else:
-        gipl1km_point_pkg["Historical"] = dict()
+        gipl1km_point_pkg["CRU-TS 4.0"] = dict()
         tx = generate_gipl1km_time_index()
         tx = tx[tx.slice_indexer("1902-01-01", "2015-01-01")]
         for t in tx:
             year = t.date().strftime("%Y")
-            gipl1km_point_pkg["Historical"][year] = dict()
-            gipl1km_point_pkg["Historical"][year]["Historical"] = dict()
+            gipl1km_point_pkg["CRU-TS 4.0"][year] = dict()
+            gipl1km_point_pkg["CRU-TS 4.0"][year]["Historical"] = dict()
             for gipl_var_name in gipl1km_historical_dim_encodings["variable"].values():
-                gipl1km_point_pkg["Historical"][year]["Historical"][gipl_var_name] = round(
+                gipl1km_point_pkg["CRU-TS 4.0"][year]["Historical"][gipl_var_name] = round(
                     flat_list[i], 1
                 )
                 i += 1

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -563,4 +563,7 @@ async def run_ncr_requests(lat, lon):
 
 @routes.route("/ncr/permafrost/point/<lat>/<lon>")
 def permafrost_ncr_request(lat, lon):
-    return asyncio.run(run_ncr_requests(lat, lon))
+    permafrostData = asyncio.run(run_ncr_requests(lat, lon))
+    if type(permafrostData[0]) is tuple:
+        return render_template("404/no_data.html"), 404
+    return permafrostData

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -667,7 +667,7 @@ async def run_ncr_requests(lat, lon):
     tasks = [
         asyncio.create_task(
             run_fetch_gipl_1km_point_data(
-                lat, lon, start_year=1902, end_year=2015, summarize="mmm"
+                lat, lon, start_year=1950, end_year=2015, summarize="mmm"
             )
         ),
         asyncio.create_task(

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -92,7 +92,7 @@ def package_obu_vector(obu_vector_resp):
     return di
 
 
-def make_gipl1km_wcps_request_str(x, y, years, model, scenario, summary_operation ):
+def make_gipl1km_wcps_request_str(x, y, years, model, scenario, summary_operation):
     """Generate a WCPS query string specific the to GIPL 1 km coverage.
 
     Arguments:
@@ -129,14 +129,18 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp):
     models = ["5ModelAvg", "GFDL-CM3", "NCAR-CCSM4"]
     for all_resp, model in zip(gipl1km_wcps_resp, models):
         gipl1km_wcps_point_pkg[model] = dict()
-        scenarios = ["rcp45","rcp85"]
+        scenarios = ["rcp45", "rcp85"]
         for scenario_resp, scenario in zip(all_resp, scenarios):
             gipl1km_wcps_point_pkg[model][scenario] = dict()
             summary_methods = ["min", "mean", "max"]
             for resp, stat_type in zip(scenario_resp, summary_methods):
                 gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"] = dict()
-                for k, v in zip(gipl1km_dim_encodings["variable"].values(), scenario_resp):
-                    gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][k] = round(v, 1)
+                for k, v in zip(
+                    gipl1km_dim_encodings["variable"].values(), scenario_resp
+                ):
+                    gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
+                        k
+                    ] = round(v, 1)
     return gipl1km_wcps_point_pkg
 
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -143,7 +143,6 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp, package_type):
     if package_type == 'historical':
         gipl1km_wcps_point_pkg['Historical'] = dict()
         for resp, stat_type in zip(gipl1km_wcps_resp[0], summary_methods):
-            print(resp)
             gipl1km_wcps_point_pkg['Historical'][f"gipl1km{stat_type}"] = dict()
             for k, v in zip(
                 gipl1km_historical_dim_encodings["variable"].values(), resp
@@ -640,6 +639,11 @@ async def run_fetch_gipl_1km_point_data(
 async def run_ncr_requests(lat, lon):
 
     tasks = [
+        asyncio.create_task(
+            run_fetch_gipl_1km_point_data(
+                lat, lon, start_year=1902, end_year=2015, summarize="mmm"
+            )
+        ),
         asyncio.create_task(
             run_fetch_gipl_1km_point_data(
                 lat, lon, start_year=2021, end_year=2039, summarize="mmm"

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -195,6 +195,7 @@ def create_gipl1km_csv(data_pkg, lat=None, lon=None, summary=None):
     """
     if summary is not None:
         fieldnames = [
+            "model",
             "summary",
             "variable",
             "value",

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -107,9 +107,18 @@
   <code>?format=csv</code> to the URL.
 </p>
 <p>
-  Example:
+  Examples:
+  <br />
   <a href="/permafrost/point/gipl/63.0628/-146.1627?format=csv"
     >/permafrost/point/gipl/63.0628/-146.1627?format=csv</a
+  >
+  <br />
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050?format=csv"
+    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050?format=csv</a
+  >
+  <br />
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm?format=csv"
+    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm?format=csv</a
   >
 </p>
 <h3>Permafrost point query</h3>

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -15,6 +15,11 @@
   for ten variables for a single point specified by latitude and longitude.
 </p>
 <p>
+  <strong>NOTE: </strong>The time range for historical data is <strong>1902-2015</strong>
+  and the time range for projected data is from <strong>2021-2120</strong>. There is no
+  available data for <strong>2015-2020</strong>.
+</p>
+<p>
   Example:
   <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050"
     >/permafrost/point/gipl/63.0628/-146.1627/2040/2050</a

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -47,13 +47,13 @@
   &ltmodel>: {
     &ltyear>:{
       &ltscenario>: {
-        "magt0.5m": &ltmean annual ground temperature value at 0.5 m depth (°C)>,
-        "magt1m": &ltmean annual ground temperature value at 1 m depth (°C)>,
-        "magt2m": &ltmean annual ground temperature value at 2 m depth (°C)>,
-        "magt3m": &ltmean annual ground temperature value at 3 m depth (°C)>,
-        "magt4m": &ltmean annual ground temperature value at 4 m depth (°C)>,
-        "magt5m": &ltmean annual ground temperature value at 5 m depth (°C)>,
-        "magtsurface": &ltmean annual ground temperature value at 0.01 m depth (°C)>,
+        "magt0.5m": &ltmean annual ground temperature value at 0.5 m depth (&deg;C)>,
+        "magt1m": &ltmean annual ground temperature value at 1 m depth (&deg;C)>,
+        "magt2m": &ltmean annual ground temperature value at 2 m depth (&deg;C)>,
+        "magt3m": &ltmean annual ground temperature value at 3 m depth (&deg;C)>,
+        "magt4m": &ltmean annual ground temperature value at 4 m depth (&deg;C)>,
+        "magt5m": &ltmean annual ground temperature value at 5 m depth (&deg;C)>,
+        "magtsurface": &ltmean annual ground temperature value at 0.01 m depth (&deg;C)>,
         "permafrostbase": &ltdepth of permafrost base (m)>,
         "permafrosttop": &ltdepth of permafrost top (m)>,
         "talikthickness": &ltthickness of talik layer (m)>
@@ -71,7 +71,7 @@
   for ten variables for a single point specified by latitude and longitude.
   Summarize the results by computing the minimum, mean, and maximum values for
   each of the ten variables for the duration of the time slice. Statistics are
-  computed for all models and scenarios.
+  computed separately for each model, but include all scenarios.
 </p>
 <p>
   Example:
@@ -82,17 +82,23 @@
 <h4>Results from the above summary query will look like this:</h4>
 <pre>
 {
-  "gipl1kmmax": {...},
-  gipl1kmmean": {...},
-  gipl1kmmin": {...},
+  "5ModelAvg": {
+    "gipl1kmmax": {...},
+    "gipl1kmmean": {...},
+    "gipl1kmmin": {...},
+  }
+  ...
 }
 </pre>
 <b>The above output is structured like this:</b>
 <pre>
 {
-    "gipl1kmmax": &ltmax values for all ten variables across all models, scenarios, and years>,
-    "gipl1kmmean": &ltmean values for all ten variables across all models, scenarios, and years>,
-    "gipl1kmmin": &ltmin values for all ten variables across all models, scenarios, and years>
+  &ltmodel>: 
+  {
+    "gipl1kmmax": &ltmax values for all ten variables across all scenarios and years in the time slice>,
+    "gipl1kmmean": &ltmean values for all ten variables across all scenarios and years in the time slice>,
+    "gipl1kmmin": &ltmin values for all ten variables across all scenarios and years in the time slice>
+  }...
 }
 </pre>
 <h4>CSV Export</h4>
@@ -130,7 +136,7 @@
       }
     },
     ...
-    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (°C) and Active Layer Thickness (m) Model Output"
+    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (&deg;C) and Active Layer Thickness (m) Model Output"
   },
   "jorg": {
     "ice": "Moderate",
@@ -140,7 +146,7 @@
   "obu_magt": {
     "depth": "Top of Permafrost",
     "temp": 0.2,
-    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (°C)",
+    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (&deg;C)",
     "year": "2000-2016"
   },
   "obupfx": {
@@ -263,7 +269,38 @@
   </thead>
   <tbody>
     <tr>
-      <td>GIPL Model Ouputs</td>
+      <td>GIPL 2.0 1 km Model Outputs</td>
+      <td>
+        Mean Annual Ground Temperature at 0.5, 1, 2, 3, 4, 5 m below the surface
+        (&deg;C), Mean Annual Surface (i.e., 0.01 m depth) Temperature (&deg;C),
+        Permafrost top (upper boundary of the permafrost, depth below the
+        surface in m), Permafrost base (lower boundary of the permafrost, depth
+        below the surface in m), Talik thickness (perennially unfrozen ground
+        occurring in permafrost terrain, m)
+      </td>
+      <td>
+        <a href="http://data.snap.uaf.edu/data/Base/AK_1km/GIPL/"
+          >Data Directory</a
+        >
+      </td>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/c24a957b-8a56-40bf-bc09-43a567182d36"
+          >SNAP GeoNetwork Data Catalog</a
+        >
+      </td>
+      <td>
+        Funded by the Broad Agency Announcement Program and the U.S. Army
+        Engineer Research and Development Center and Cold Regions Research and
+        Engineering Laboratory (ERDC-CRREL) under Contract No. W913E521C0010.
+        The GIPL2-MPI/GCM simulations were supported in part by the
+        high-performance computing and data storage resources operated by the
+        Research Computing Systems Group at the University of Alaska Fairbanks
+        Geophysical Institute.
+      </td>
+    </tr>
+    <tr>
+      <td>Melvin 4 km GIPL Model Outputs</td>
       <td>Mean Annual Ground Temperature, Active Layer Thickness</td>
       <td>
         <a
@@ -276,7 +313,10 @@
           >Melvin et al. (2017)</a
         >
       </td>
-      <td>MAGT is modeled for the depth of the active layer.</td>
+      <td>
+        MAGT is modeled for the depth of the active layer. This dataset will
+        eventually be deprecated from the API.
+      </td>
     </tr>
     <tr>
       <td>Jorgenson Permafrost Characteristics</td>

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -21,8 +21,8 @@
 </p>
 <p>
   Example:
-  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050"
-    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050</a
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2021/2050"
+    >/permafrost/point/gipl/63.0628/-146.1627/2021/2050</a
   >
 </p>
 <h4>Results from the above queries will look like this:</h4>


### PR DESCRIPTION
Updates GIPL Permafrost formatting for the summarized variables over a time range and creates an endpoint for gathering all of the time ranges desired by NCR. 

This PR will split out the summarized GIPL permafrost data out into each models min, mean, and maximum in the returned JSON.

You can see this in: http://localhost:5000/permafrost/point/gipl/65/-156/2021/2039/mmm

Additionally, this adds a new /ncr endpoint that combines all of the required data for the NCR Permafrost section from a single call to the API.

This can be seen here: http://localhost:5000/ncr/permafrost/point/65/-156