### PR TITLE
Remove historical data from gipl_ncr_request branch, add aggregate CSV support to GIPL era queries, etc.

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -278,7 +278,6 @@ def summarize_within_poly(ds, poly, dim_encodings, varname="Gray", roundkey="Gra
 
 
 def geotiff_zonal_stats(poly, arr, nodata_value, transform, stat_list):
-
     poly_mask_arr = zonal_stats(
         poly,
         arr,
@@ -527,7 +526,7 @@ def write_csv(csv_dicts, fieldnames, filename, metadata=None):
     return response
 
 
-def csv_metadata(place_name, place_id, place_type, lat=None, lon=None):
+def csv_metadata(place_name=None, place_id=None, place_type=None, lat=None, lon=None):
     """
     Creates metadata string to add to beginning of CSV file.
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -563,4 +563,7 @@ async def run_ncr_requests(lat, lon):
 
 @routes.route("/ncr/permafrost/point/<lat>/<lon>")
 def permafrost_ncr_request(lat, lon):
-    return asyncio.run(run_ncr_requests(lat, lon))
+    permafrostData = asyncio.run(run_ncr_requests(lat, lon))
+    if type(permafrostData[0]) is tuple:
+        return render_template("404/no_data.html"), 404
+    return permafrostData

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -92,7 +92,7 @@ def package_obu_vector(obu_vector_resp):
     return di
 
 
-def make_gipl1km_wcps_request_str(x, y, years, model, scenario, summary_operation ):
+def make_gipl1km_wcps_request_str(x, y, years, model, scenario, summary_operation):
     """Generate a WCPS query string specific the to GIPL 1 km coverage.
 
     Arguments:
@@ -129,14 +129,18 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp):
     models = ["5ModelAvg", "GFDL-CM3", "NCAR-CCSM4"]
     for all_resp, model in zip(gipl1km_wcps_resp, models):
         gipl1km_wcps_point_pkg[model] = dict()
-        scenarios = ["rcp45","rcp85"]
+        scenarios = ["rcp45", "rcp85"]
         for scenario_resp, scenario in zip(all_resp, scenarios):
             gipl1km_wcps_point_pkg[model][scenario] = dict()
             summary_methods = ["min", "mean", "max"]
             for resp, stat_type in zip(scenario_resp, summary_methods):
                 gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"] = dict()
-                for k, v in zip(gipl1km_dim_encodings["variable"].values(), scenario_resp):
-                    gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][k] = round(v, 1)
+                for k, v in zip(
+                    gipl1km_dim_encodings["variable"].values(), scenario_resp
+                ):
+                    gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
+                        k
+                    ] = round(v, 1)
     return gipl1km_wcps_point_pkg
 
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -195,6 +195,7 @@ def create_gipl1km_csv(data_pkg, lat=None, lon=None, summary=None):
     """
     if summary is not None:
         fieldnames = [
+            "model",
             "summary",
             "variable",
             "value",

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -107,9 +107,18 @@
   <code>?format=csv</code> to the URL.
 </p>
 <p>
-  Example:
+  Examples:
+  <br />
   <a href="/permafrost/point/gipl/63.0628/-146.1627?format=csv"
     >/permafrost/point/gipl/63.0628/-146.1627?format=csv</a
+  >
+  <br />
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050?format=csv"
+    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050?format=csv</a
+  >
+  <br />
+  <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm?format=csv"
+    >/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm?format=csv</a
   >
 </p>
 <h3>Permafrost point query</h3>

--- a/templates/permafrost/point.html
+++ b/templates/permafrost/point.html
@@ -47,13 +47,13 @@
   &ltmodel>: {
     &ltyear>:{
       &ltscenario>: {
-        "magt0.5m": &ltmean annual ground temperature value at 0.5 m depth (°C)>,
-        "magt1m": &ltmean annual ground temperature value at 1 m depth (°C)>,
-        "magt2m": &ltmean annual ground temperature value at 2 m depth (°C)>,
-        "magt3m": &ltmean annual ground temperature value at 3 m depth (°C)>,
-        "magt4m": &ltmean annual ground temperature value at 4 m depth (°C)>,
-        "magt5m": &ltmean annual ground temperature value at 5 m depth (°C)>,
-        "magtsurface": &ltmean annual ground temperature value at 0.01 m depth (°C)>,
+        "magt0.5m": &ltmean annual ground temperature value at 0.5 m depth (&deg;C)>,
+        "magt1m": &ltmean annual ground temperature value at 1 m depth (&deg;C)>,
+        "magt2m": &ltmean annual ground temperature value at 2 m depth (&deg;C)>,
+        "magt3m": &ltmean annual ground temperature value at 3 m depth (&deg;C)>,
+        "magt4m": &ltmean annual ground temperature value at 4 m depth (&deg;C)>,
+        "magt5m": &ltmean annual ground temperature value at 5 m depth (&deg;C)>,
+        "magtsurface": &ltmean annual ground temperature value at 0.01 m depth (&deg;C)>,
         "permafrostbase": &ltdepth of permafrost base (m)>,
         "permafrosttop": &ltdepth of permafrost top (m)>,
         "talikthickness": &ltthickness of talik layer (m)>
@@ -71,7 +71,7 @@
   for ten variables for a single point specified by latitude and longitude.
   Summarize the results by computing the minimum, mean, and maximum values for
   each of the ten variables for the duration of the time slice. Statistics are
-  computed for all models and scenarios.
+  computed separately for each model, but include all scenarios.
 </p>
 <p>
   Example:
@@ -82,17 +82,23 @@
 <h4>Results from the above summary query will look like this:</h4>
 <pre>
 {
-  "gipl1kmmax": {...},
-  gipl1kmmean": {...},
-  gipl1kmmin": {...},
+  "5ModelAvg": {
+    "gipl1kmmax": {...},
+    "gipl1kmmean": {...},
+    "gipl1kmmin": {...},
+  }
+  ...
 }
 </pre>
 <b>The above output is structured like this:</b>
 <pre>
 {
-    "gipl1kmmax": &ltmax values for all ten variables across all models, scenarios, and years>,
-    "gipl1kmmean": &ltmean values for all ten variables across all models, scenarios, and years>,
-    "gipl1kmmin": &ltmin values for all ten variables across all models, scenarios, and years>
+  &ltmodel>: 
+  {
+    "gipl1kmmax": &ltmax values for all ten variables across all scenarios and years in the time slice>,
+    "gipl1kmmean": &ltmean values for all ten variables across all scenarios and years in the time slice>,
+    "gipl1kmmin": &ltmin values for all ten variables across all scenarios and years in the time slice>
+  }...
 }
 </pre>
 <h4>CSV Export</h4>
@@ -130,7 +136,7 @@
       }
     },
     ...
-    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (°C) and Active Layer Thickness (m) Model Output"
+    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (&deg;C) and Active Layer Thickness (m) Model Output"
   },
   "jorg": {
     "ice": "Moderate",
@@ -140,7 +146,7 @@
   "obu_magt": {
     "depth": "Top of Permafrost",
     "temp": 0.2,
-    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (°C)",
+    "title": "Obu et al. (2018) 2000-2016 Mean Annual Top of Permafrost Ground Temperature (&deg;C)",
     "year": "2000-2016"
   },
   "obupfx": {
@@ -263,7 +269,38 @@
   </thead>
   <tbody>
     <tr>
-      <td>GIPL Model Ouputs</td>
+      <td>GIPL 2.0 1 km Model Outputs</td>
+      <td>
+        Mean Annual Ground Temperature at 0.5, 1, 2, 3, 4, 5 m below the surface
+        (&deg;C), Mean Annual Surface (i.e., 0.01 m depth) Temperature (&deg;C),
+        Permafrost top (upper boundary of the permafrost, depth below the
+        surface in m), Permafrost base (lower boundary of the permafrost, depth
+        below the surface in m), Talik thickness (perennially unfrozen ground
+        occurring in permafrost terrain, m)
+      </td>
+      <td>
+        <a href="http://data.snap.uaf.edu/data/Base/AK_1km/GIPL/"
+          >Data Directory</a
+        >
+      </td>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/c24a957b-8a56-40bf-bc09-43a567182d36"
+          >SNAP GeoNetwork Data Catalog</a
+        >
+      </td>
+      <td>
+        Funded by the Broad Agency Announcement Program and the U.S. Army
+        Engineer Research and Development Center and Cold Regions Research and
+        Engineering Laboratory (ERDC-CRREL) under Contract No. W913E521C0010.
+        The GIPL2-MPI/GCM simulations were supported in part by the
+        high-performance computing and data storage resources operated by the
+        Research Computing Systems Group at the University of Alaska Fairbanks
+        Geophysical Institute.
+      </td>
+    </tr>
+    <tr>
+      <td>Melvin 4 km GIPL Model Outputs</td>
       <td>Mean Annual Ground Temperature, Active Layer Thickness</td>
       <td>
         <a
@@ -276,7 +313,10 @@
           >Melvin et al. (2017)</a
         >
       </td>
-      <td>MAGT is modeled for the depth of the active layer.</td>
+      <td>
+        MAGT is modeled for the depth of the active layer. This dataset will
+        eventually be deprecated from the API.
+      </td>
     </tr>
     <tr>
       <td>Jorgenson Permafrost Characteristics</td>


### PR DESCRIPTION
This PR builds off of the `gipl_ncr_request` branch and:

- Drops some commits in the git history that had attempted to incorporate a historical baseline into the GIPL responses, before it was decided that this was an apples-to-oranges comparison. This PR includes only projected data in GIPL responses.
- Adds CSV and community ID support to the `/ncr/permafrost` endpoint, so URLs like this work as expected: http://localhost:5000/ncr/permafrost/point/64.8378/-147.716?format=csv&community=AK124 This means we now have era-summary CSV download buttons in the NCR app (in the `gipl_updates` branch) that matches the data displayed in the permafrost charts, consistent with the CSV download buttons in other sections of the app.
- Adds more error handling to pick up HTTP status codes from the era-summary subqueries and returns the corresponding HTTP code from the `/ncr/permafrost` aggregate endpoint, so the NCR web app is able to react correctly according to the HTTP code it receives.
- Uses date ranges as the JSON keys for the data, similar to our other endpoints.

Unfortunately, I did not notice PR #262 until just now while I was creating this PR, so this PR does not include any work to reduce Rasdaman queries. I suggest we tackle that work separately if needed.

To test, run the `gipl_updates` branch of the iem-webapp repo against this branch (`gipl_ncr_request_csv`) of the API, using Apollo as the Rasdaman server.

Xref: https://github.com/ua-snap/iem-webapp/pull/509