### PR TITLE
Uses invalid_year template for degree_days /mmm route

### DIFF
--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -13,11 +13,7 @@ from validate_request import (
     validate_latlon,
     project_latlon,
 )
-from validate_data import (
-    nullify_and_prune,
-    postprocess,
-    place_name_and_type
-)
+from validate_data import nullify_and_prune, postprocess, place_name_and_type
 from config import WEST_BBOX, EAST_BBOX
 from . import routes
 
@@ -512,7 +508,12 @@ def run_fetch_dd_point_data(var_ep, lat, lon, horp, start_year=None, end_year=No
     if None not in [start_year, end_year]:
         valid_years = validate_years(horp, int(start_year), int(end_year))
         if valid_years is not True:
-            return valid_years
+            return (
+                render_template(
+                    "422/invalid_year.html", min_year=start_year, max_year=end_year
+                ),
+                422,
+            )
 
     if var_ep in var_ep_lu.keys():
         cov_id_str = var_ep_lu[var_ep]["cov_id_str"]

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -506,14 +506,9 @@ def run_fetch_dd_point_data(var_ep, lat, lon, horp, start_year=None, end_year=No
     x, y = project_latlon(lat, lon, 3338)
 
     if None not in [start_year, end_year]:
-        valid_years = validate_years(horp, int(start_year), int(end_year))
-        if valid_years is not True:
-            return (
-                render_template(
-                    "422/invalid_year.html", min_year=start_year, max_year=end_year
-                ),
-                422,
-            )
+        valid_year = validate_years(horp, int(start_year), int(end_year))
+        if valid_year is not True:
+            return valid_year
 
     if var_ep in var_ep_lu.keys():
         cov_id_str = var_ep_lu[var_ep]["cov_id_str"]
@@ -620,7 +615,8 @@ def validate_years(horp, start_year, end_year):
             if year < min_year or year > max_year:
                 return (
                     render_template(
-                        "422/invalid_year.html", min_year=min_year, max_year=max_year
+                        "422/invalid_year.html", start_year=start_year, end_year=end_year, min_year=min_year,
+                        max_year=max_year
                     ),
                     422,
                 )

--- a/templates/422/invalid_year.html
+++ b/templates/422/invalid_year.html
@@ -5,6 +5,6 @@
   One or both of these provided years (<code>{{start_year}}</code> &ndash; <code>{{end_year}}</code>) are outside of the valid range.
 </p>
 <p>
-  Valid years for this endpoint are <code>{{ min_year }}</code> - <code>{{ max_year }}</code>.
+  Valid years for this endpoint are <code>{{ min_year }}</code> &ndash; <code>{{ max_year }}</code>.
 </p>
 {% endblock %}

--- a/templates/422/invalid_year.html
+++ b/templates/422/invalid_year.html
@@ -2,7 +2,9 @@
 {% block content %}
 <h3>Invalid year</h3>
 <p>
-  One or both of the provided years are outside of the valid range. Valid years
-  for this endpoint are <code>{{ min_year }}</code> - <code>{{ max_year }}</code>.
+  One or both of these provided years (<code>{{start_year}}</code> &ndash; <code>{{end_year}}</code>) are outside of the valid range.
+</p>
+<p>
+  Valid years for this endpoint are <code>{{ min_year }}</code> - <code>{{ max_year }}</code>.
 </p>
 {% endblock %}


### PR DESCRIPTION
If min and max years are given for /mmm/degree_days endpoint, it will give a 422 error and use the invalid_year template.

To test this PR, try this endpoint:

http://localhost:5000/mmm/degree_days/freezing/hp/60/-156/1800/2099

Closes #191 