### PR TITLE
Adds cache control header fields to keep returned data for 90 days

### DIFF
--- a/application.py
+++ b/application.py
@@ -24,7 +24,6 @@ def inject_date():
 def add_cache_control(response):
     # Set cache control headers here
     response.cache_control.max_age=7776000
-    response.cache_control.s_max_age=7776000
     return response
 
 

--- a/application.py
+++ b/application.py
@@ -23,7 +23,7 @@ def inject_date():
 @app.after_request
 def add_cache_control(response):
     # Set cache control headers here
-    response.cache_control.max_age=7776000
+    response.cache_control.max_age = 7776000
     return response
 
 
@@ -33,6 +33,6 @@ def index():
     return render_template("index.html")
 
 
-@app.route('/robots.txt')
+@app.route("/robots.txt")
 def static_from_root():
     return send_from_directory(app.static_folder, request.path[1:])

--- a/application.py
+++ b/application.py
@@ -20,6 +20,14 @@ def inject_date():
     return dict(year=year)
 
 
+@app.after_request
+def add_cache_control(response):
+    # Set cache control headers here
+    response.cache_control.max_age=7776000
+    response.cache_control.s_max_age=7776000
+    return response
+
+
 @app.route("/")
 def index():
     """Render index page"""

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -93,7 +93,8 @@ async def make_get_request(url, session):
     Returns:
         Query result, deocded differently depending on encoding argument.
     """
-    resp = await session.request(method="GET", url=url)
+    cache_header = {"Cache-Control": 'max-age=7776000, s-maxage=7776000'}
+    resp = await session.request(method="GET", url=url, headers=cache_header)
     resp.raise_for_status()
 
     # way of auto-detecting encoding from URL

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -93,7 +93,7 @@ async def make_get_request(url, session):
     Returns:
         Query result, deocded differently depending on encoding argument.
     """
-    cache_header = {"Cache-Control": 'max-age=7776000, s-maxage=7776000'}
+    cache_header = {"Cache-Control": "max-age=7776000"}
     resp = await session.request(method="GET", url=url, headers=cache_header)
     resp.raise_for_status()
 


### PR DESCRIPTION
This PR adds the cache-control headers to our site which can inform upstream caches of how long we would like to cache a file for future reference. When pointed at the Varnish cache for either Rasdaman (maps.earthmaps.io) or the data API (earthmaps.io), it is specifying a max age of 90 days and matches the length of cached time on the Varnish servers.

To test this, you can go to the updated development.earthmaps.io site and look at the returned headers for max age in the cache-control section of the response header: http://development.earthmaps.io/alfresco/veg_type/area/19080309

Closes #73 