### PR TITLE
Use Flask logger to write cache errors to STDERR instead of local file

### DIFF
--- a/routes/recache.py
+++ b/routes/recache.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, current_app as app, Response
 import asyncio
-import os
 import json
 import requests
 from . import routes
@@ -33,10 +32,7 @@ def log_error(url, status):
         url - The URL that caused the status
         status - Python requests status object
     """
-    # Stores log in data directory for now
-    log = open("data/error-log.txt", "a")
-    log.write(str(status) + ": " + url + "\n")
-    log.close()
+    app.logger.warning(str(status) + ": " + url)
 
 
 def get_endpoint(curr_route, curr_type, place):


### PR DESCRIPTION
Closes #99.

This PR changes the `log_error` function in `routes/recachep.py` to write recache errors as warnings via the logging module, which writes its output to STDERR. I figure STDERR is a more appropriate target than STDOUT, and the logging module defaults to STDERR as well.

Also, I think writing these types of errors as `warning`s (not `info` and not true `errors`) is appropriate since they are worth noting but not show-stopping. Please let me know if you disagree!

To test, run the API and visit the recache URL from your browser (e.g., http://localhost:5000/recache/true). After 10-20 minutes, you should see some recache warnings show up in the terminal via STDERR .