### PR TITLE
Simplify input validation

### DIFF
--- a/validate_data.py
+++ b/validate_data.py
@@ -1,5 +1,4 @@
 """A module to validate fetched data values."""
-import re
 import asyncio
 from config import RAS_BASE_URL, WEB_APP_URL
 from generate_requests import *
@@ -23,7 +22,7 @@ def place_name_and_type(place_id):
         return None, None
 
     # HUC12s, not getting names from them below
-    if (not re.search("[^0-9]", place_id)) and (len(place_id) == 12):
+    if place_id.isdigit() and len(place_id) == 12:
         return None, "huc12"
 
     place = asyncio.run(

--- a/validate_request.py
+++ b/validate_request.py
@@ -4,8 +4,6 @@ other functions that could be used across multiple endpoints.
 """
 
 import asyncio
-import os
-import re
 from flask import render_template
 from pyproj import Transformer
 import numpy as np
@@ -108,7 +106,7 @@ def validate_year(start_year, end_year):
 
 
 def validate_var_id(var_id):
-    if re.search("[^A-Za-z0-9]", var_id):
+    if not var_id.isalnum():
         return render_template("400/bad_request.html"), 400
 
     var_id_check = asyncio.run(


### PR DESCRIPTION
Closes #82.

For this PR, I looked into using third-party validation modules for input validation. I looked into Pydantic and Cerberus specifically. I discovered that these third-party modules are designed to perform validation on complex objects like dicts or classes, not simple strings, and offer nothing for simple string validation that is not already built in to Python.

I also realized after reading these documents that Python provides some simple methods to help with string validation that we can use instead of regular expressions, and went ahead and made these changes to simplify the code.

To test:

- Make sure that HUC-12 queries (and/or ALFRESCO point queries that query HUC-12s behind the scenes) and custom SNAP polygon queries (e..g, `FIRE2`, `BORO3`, `CENS4`) still work as expected
- Verify that adding bogus non-alphanumeric characters to SNAP polygon indentifiers (e.g., `FIRE-2`) fails elegantly by showing a proper error page (Flask template, not just a white page with an error).