### PR TITLE
[draft] Read and serve units from Rasdaman coverage metadata

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -452,6 +452,10 @@ def parse_meta_xml_str(meta_xml_str):
     for dim in encoding_el.iter():
         if not dim.text.isspace():
             encoding_di = eval(dim.text)
+            if dim.tag == "other":
+                for key, value in encoding_di.items():
+                    dim_encodings[key] = value
+                continue
             for key, value in encoding_di.items():
                 if isinstance(value, dict):
                     dim_encodings[key] = {int(k): v for k, v in value.items()}

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -221,6 +221,8 @@ def package_dd_point_data(point_data, var_ep, horp):
             point_pkg["projected"]["ddmean"] = round(projected_mean)
             point_pkg["projected"]["ddmax"] = round(projected_max)
 
+        point_pkg["units"] = dd_dim_encodings["units"]
+
     return point_pkg
 
 


### PR DESCRIPTION
Xref #228.

This is a proof-of-concept draft PR that demonstrates one approach to packaging and reading a coverage's units from Rasdaman's metadata object. Since this one small change impacts many things (ingest scripts, webapps) I will plan to demonstrate this at our next tech meeting to get some opinions about this approach before proceeding further.