### PR TITLE
del 4km GIPL; del unused luts/imports

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -398,28 +398,39 @@ def landfastice_csv(data):
 def permafrost_csv(data, source_metadata):
     filename_data_name = "Permafrost"
     sources = {
-        "gipl": {
+        "gipl_1km": {
             "coords": [
                 "source",
-                "era",
                 "model",
+                "year",
                 "scenario",
             ],
-            "values": ["magt", "alt"],
+            "values": [
+                "magt0.5m",
+                "magt1m",
+                "magt2m",
+                "magt3m",
+                "magt4m",
+                "magt5m",
+                "magtsurface",
+                "permafrostbase",
+                "permafrosttop",
+                "talikthickness",
+            ],
         },
         "jorg": {"coords": ["source"], "values": ["ice", "pfx"]},
         "obu_magt": {"coords": ["source"], "values": ["year", "depth", "temp"]},
         "obupfx": {"coords": ["source"], "values": ["pfx"]},
     }
 
-    metadata = "# alt is the active layer thickness in meters\n"
-    metadata += "# magt is the mean annual ground temperature in degrees Celsius\n"
+    metadata = "# magt*m is the mean annual ground temperature at a given depth (* meters) in degrees Celsius\n"
+    metadata += "# magtsurface is the mean annual ground temperature at the ground surface in degrees Celsius\n"
+    metadata += "# permafrost base is the lower boundary of the permafrost below the surface in meters\n"
+    metadata += "# permafrost top is the upper boundary of the permafrost below the surface in meters\n"
+    metadata += "# talikthickness is the thickness of the perennially unfrozen ground occurring in permafrost terrain in meters\n"
     metadata += "# ice is the estimated ground ice volume\n"
     metadata += "# pfx is the permafrost extent\n"
-    metadata += "# 2025 represents 2011 - 2040\n"
-    metadata += "# 2050 represents 2036 - 2065\n"
-    metadata += "# 2075 represents 2061 - 2090\n"
-    metadata += "# 2095 represents 2086 - 2100\n"
+
     metadata += "# gipl is the Geophysical Institute's Permafrost Laboratory\n"
 
     all_fields = []

--- a/luts.py
+++ b/luts.py
@@ -1,9 +1,5 @@
 """Module for look-up-table like objects"""
 import os
-import pickle
-import fiona
-import geopandas as gpd
-import pandas as pd
 
 host = os.environ.get("API_HOSTNAME") or "https://earthmaps.io"
 
@@ -52,24 +48,6 @@ snow_status = {
     3: "Sea ice",
     4: True,
     0: "No data at this location.",
-}
-
-permafrost_encodings = {
-    "eras": {0: "1995", 1: "2025", 2: "2050", 3: "2075", 4: "2095"},
-    "models": {
-        0: "cruts31",
-        1: "gfdlcm3",
-        2: "gisse2r",
-        3: "ipslcm5alr",
-        4: "mricgcm3",
-        5: "ncarccsm4",
-    },
-    "scenarios": {0: "historical", 1: "rcp45", 2: "rcp85"},
-    "rounding": {"magt": 1, "alt": 1},
-    "gipl_varnames": ["magt", "alt"],
-    "gipl_era_starts": ["1986", "2011", "2036", "2061", "2086"],
-    "gipl_era_ends": ["2005", "2040", "2065", "2090", "2100"],
-    "gipl_units_lu": {"magt": "°C", "alt": "m"},
 }
 
 place_type_labels = {

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -39,7 +39,7 @@ wfs_targets = {
 }
 
 titles = {
-    "gipl_1km": "GIPL 2.0 Mean Annual Ground Temperature (deg C), Permafrost Base, Permafrost Top, and Talik Thickness (m) 1 km Model Output",
+    "gipl_1km": "GIPL 2.0 1km Model Output: Mean Annual Ground Temperature (deg C) at Permafrost Base and Permafrost Top; Talik Thickness (m)",
     "jorg": "Jorgenson et al. (2008) Permafrost Extent and Ground Ice Volume",
     "obupfx": "Obu et al. (2018) Permafrost Extent",
 }

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -187,24 +187,6 @@ def package_gipl1km_point_data(gipl1km_point_resp, time_slice=None):
     return gipl1km_point_pkg
 
 
-def combine_gipl_poly_var_pkgs(magt_di, alt_di):
-    combined_gipl_di = {}
-    for era in magt_di.keys():
-        combined_gipl_di[era] = {}
-        for model in magt_di[era].keys():
-            combined_gipl_di[era][model] = {}
-            for scenario in magt_di[era][model].keys():
-                combined_gipl_di[era][model][scenario] = {}
-                combined_gipl_di[era][model][scenario]["magt"] = magt_di[era][model][
-                    scenario
-                ]
-                combined_gipl_di[era][model][scenario]["alt"] = alt_di[era][model][
-                    scenario
-                ]
-                combined_gipl_di[era][model][scenario]["statistic"] = "Zonal Mean"
-    return combined_gipl_di
-
-
 @routes.route("/permafrost/")
 @routes.route("/permafrost/abstract/")
 @routes.route("/permafrost/point/")

--- a/templates/documentation/permafrost.html
+++ b/templates/documentation/permafrost.html
@@ -15,14 +15,6 @@
 </p>
 
 <p>
-  Active layer thickness and mean annual ground temperature data are also provided as summarized means across
-  2011&ndash;2040, 2036&ndash;2065, 2061&ndash;2090, 2086&ndash;2100 vs. a historical baseline from 1995 at a resolution
-  of 4km. Data were provided by Melvin et al. using GIPL 2.0 model outputs. The historical baseline was derived from CRU
-  TS 3.1. Projections were derived from GFDL-CM3, GISS-E2R, IPSL-CM5A-LR, MRI-CGCM3, NCAR-CCSM4 model outputs, as well
-  as a 5-model average, under the RCP 4.5 and RCP 8.5 emissions scenarios.
-</p>
-
-<p>
   Permafrost extent and ground ice volume data from 2008 were provided by Jorgenson et al. Mean annual top of permafrost
   ground temperature and permafrost extent data from 2000&ndash;2016 were provided by Obu et al.
 </p>
@@ -210,18 +202,26 @@
 
 <pre>
 {
-  "gipl": {
-    "1995": {
-      "cruts31": {
-        "historical": {
-          "alt": 0.59,
-          "magt": -2.2
-        }
-      }
-    },
-    ...
-    "title": "Melvin et al. (2017) GIPL 2.0 Mean Annual Ground Temperature (&deg;C) and Active Layer Thickness (m) Model Output"
-  },
+  "gipl_1km": {
+    "5ModelAvg": {
+      "2021": {
+        "RCP 4.5": {
+          "magt0.5m": -2.8,
+          "magt1m": -3.1,
+          "magt2m": -3.4,
+          "magt3m": -3.5,
+          "magt4m": -3.6,
+          "magt5m": -3.6,
+          "magtsurface": -1.1,
+          "permafrostbase": 178.7,
+          "permafrosttop": 0.8,
+          "talikthickness": 0
+            }
+          }
+        },
+        ...
+        "title": "GIPL 2.0 1km Model Output: Mean Annual Ground Temperature (deg C) at Permafrost Base and Permafrost Top; Talik Thickness (m)"
+      },
   "jorg": {
     "ice": "Moderate",
     "pfx": "Discontinuous",
@@ -243,20 +243,27 @@
 <p>The above output is structured like this:</p>
 
 <pre>
-{
-  "gipl": {
-    &lt;era&gt;<sup>1</sup>: {
-      &lt;model&gt;: {
-        &lt;scenario&gt;: {
-          "alt": &lt;active layer thickness (m)&gt;,
-          "magt": &lt;mean annual ground temperature (&deg;C)&gt;
-        },
-        ...
+"gipl_1km": {
+  &lt;model&gt;: {
+    &lt;year&gt;:{
+      &lt;scenario&gt;: {
+        "magt0.5m": &lt;mean annual ground temperature value at 0.5 m depth (&deg;C)&gt;,
+        "magt1m": &lt;mean annual ground temperature value at 1 m depth (&deg;C)&gt;,
+        "magt2m": &lt;mean annual ground temperature value at 2 m depth (&deg;C)&gt;,
+        "magt3m": &lt;mean annual ground temperature value at 3 m depth (&deg;C)&gt;,
+        "magt4m": &lt;mean annual ground temperature value at 4 m depth (&deg;C)&gt;,
+        "magt5m": &lt;mean annual ground temperature value at 5 m depth (&deg;C)&gt;,
+        "magtsurface": &lt;mean annual ground temperature value at 0.01 m depth (&deg;C)&gt;,
+        "permafrostbase": &lt;depth of permafrost base (m)&gt;,
+        "permafrosttop": &lt;depth of permafrost top (m)&gt;,
+        "talikthickness": &lt;thickness of talik layer (m)&gt;
       },
       ...
     },
     ...
-    "title": &lt;title describing these results&gt;
+  },
+  ...
+  "title": &lt;title describing these results&gt;
   },
   "jorg": {
     "ice": &lt;estimated ground ice volume&gt;,
@@ -273,12 +280,8 @@
     "pfx": &lt;permafrost extent&gt;,
     "title": &lt;title describing these results&gt;
   }
-}
-</pre>
 
-<sup>1</sup> Note for GIPL eras: "1995" refers to the historical baseline. Otherwise these are 30 year eras surrounding
-the following center dates, except the last era is truncated at 2100: "2025" (2011-2040), "2050" (2036-2065), "2075"
-(2061&ndash;2090), "2095" (2086&ndash;2100).
+</pre>
 
 <h3>Source data</h3>
 
@@ -294,21 +297,32 @@ the following center dates, except the last era is truncated at 2100: "2025" (20
       <td><a
           href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/c24a957b-8a56-40bf-bc09-43a567182d36">GIPL
           2.0 1 km Model Outputs</a></td>
-      <td>Marchenko, S., Romanovsky, V., & Tipenko, G. (2008). Numerical modeling of spatial permafrost dynamics in Alaska.  <i>Ninth International Conference on Permafrost, Online Proceedings, Volume 2</i>, 1125&ndash;1130.  Accessed 2023-09-08 from <a href="https://www.permafrost.org/event/icop9/">https://www.permafrost.org/event/icop9/</a>
+      <td>Marchenko, S., Romanovsky, V., & Tipenko, G. (2008). Numerical modeling of spatial permafrost dynamics in
+        Alaska. <i>Ninth International Conference on Permafrost, Online Proceedings, Volume 2</i>, 1125&ndash;1130.
+        Accessed 2023-09-08 from <a
+          href="https://www.permafrost.org/event/icop9/">https://www.permafrost.org/event/icop9/</a>
       </td>
-      
+
     </tr>
     <tr>
       <td><a href="https://catalog.northslopescience.org/dataset/1725">Jorgenson Permafrost Characteristics</a></td>
-      <td>Jorgenson, M., Yoshikawa, K., Kanevskiy, M., Shur, Y., Romanovsky, V., Marchenko, S., & Jones, B. (2008). Permafrost Characteristics of Alaska + Map. <i>Ninth International Conference on Permafrost, Online Proceedings, Volume 1</i>, 121&ndash;122.  Accessed 2023-09-08 from <a href="https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf">https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf</a>
+      <td>Jorgenson, M., Yoshikawa, K., Kanevskiy, M., Shur, Y., Romanovsky, V., Marchenko, S., & Jones, B. (2008).
+        Permafrost Characteristics of Alaska + Map. <i>Ninth International Conference on Permafrost, Online Proceedings,
+          Volume 1</i>, 121&ndash;122. Accessed 2023-09-08 from <a
+          href="https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf">https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf</a>
       </td>
     </tr>
     <tr>
-      <td><a href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip">Mean
+      <td><a
+          href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip">Mean
           annual ground temperature dataset (ZIP file)</a>,<br />
         <a href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip">Permafrost
-          zones dataset (ZIP file)</a></td>
-      <td>Obu, J., Westermann, S., Kääb, A., & Bartsch, A. (2018). Ground Temperature Map, 2000-2016. <i>Northern Hemisphere Permafrost.</i> Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven, PANGAEA, <a href="https://doi.org/10.1594/PANGAEA.888600">https://doi.org/10.1594/PANGAEA.888600</a></td>
+          zones dataset (ZIP file)</a>
+      </td>
+      <td>Obu, J., Westermann, S., Kääb, A., & Bartsch, A. (2018). Ground Temperature Map, 2000-2016. <i>Northern
+          Hemisphere Permafrost.</i> Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research,
+        Bremerhaven, PANGAEA, <a
+          href="https://doi.org/10.1594/PANGAEA.888600">https://doi.org/10.1594/PANGAEA.888600</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR closes #297 by removing all references to the old 4km GIPL data. 

The `run_point_fetch_all_permafrost` function called by the `@routes.route("/permafrost/point/<lat>/<lon>")` endpoint now packages the new 1km GIPL data instead (see line 256 in `permafrost.py`).

To test, run the `flask` application as described in `README.md`, and try:

[http://127.0.0.1:5001/permafrost/point/64/-145](http://127.0.0.1:5001/permafrost/point/64/-145)

Try out some other coordinates to make sure you are seeing data (or errors) as expected. You should see the first point data package titled "gipl_1km" instead of "gipl", which indicates the return from the `package_gipl1km_point_data` function at line 263 in `permafrost.py`. 

**Note:** The default endpoint link from the permafrost template ([/permafrost/point/65.0628/-146.1627](http://127.0.0.1:5001/permafrost/point/65.0628/-146.1627)) does not return the "gipl_1km" point data...this return must be cached somehow? Any suggestions on how to fix that would be welcome!
