### PR TITLE
Revise permafrost mmm

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -267,7 +267,7 @@ def run_point_fetch_all_permafrost(lat, lon):
     Returns:
         JSON-like dict of permafrost data, or CSV of permafrost data if format=csv
     """
-    # validate request arguments if they exist; allow only format argument, otherwise throw an error
+    # validate request arguments if they exist; allow only format=csv argument, otherwise throw an error
     if len(request.args) == 0:
         pass
     elif "format" in request.args:
@@ -389,7 +389,7 @@ async def run_fetch_gipl_1km_point_data(
 
     x, y = project_latlon(lat, lon, 3338)
 
-    # CP: the next two code blocks that validate year and summary type selections could be in the `validate_request` module but the first does use a specific time index so that needs more thought
+    # year validation could be moved to `validate_request` module: need a function that uses the time index from rasdaman coverage to validate min/max years... could this be an API-wide function for all rasdaman coverages?
     if start_year is not None or end_year is not None:
         try:
             time_index = generate_gipl1km_time_index()

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -220,6 +220,18 @@ def gipl_1km_point_data(lat, lon, start_year=None, end_year=None):
             )
         )
 
+    elif all(key in request.args for key in ["summarize", "format"]):
+        if (request.args.get("summarize") == "mmm") & (
+            request.args.get("format") == "csv"
+        ):
+            return asyncio.run(
+                run_fetch_gipl_1km_point_data(
+                    lat, lon, start_year, end_year, summarize="mmm"
+                )
+            )
+        else:
+            return render_template("400/bad_request.html"), 400
+
     elif "summarize" in request.args:
         if request.args.get("summarize") == "mmm":
             return asyncio.run(

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -196,25 +196,76 @@ def pf_about():
 
 @routes.route("/permafrost/point/gipl/<lat>/<lon>")
 @routes.route("/permafrost/point/gipl/<lat>/<lon>/<start_year>/<end_year>")
-@routes.route("/permafrost/point/gipl/<lat>/<lon>/<start_year>/<end_year>/<summarize>")
-# add another synonym with /summarize/ and use that to break out the summary, may need to default the value of summary_operation to None which would make sense
-# add conditional to call correct packaging function
-def gipl_1km_point_data(lat, lon, start_year=None, end_year=None, summarize=None):
-    return asyncio.run(
-        run_fetch_gipl_1km_point_data(lat, lon, start_year, end_year, summarize)
-    )
+def gipl_1km_point_data(lat, lon, start_year=None, end_year=None):
+    """Run the async request for GIPL permafrost data at a single point.
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+        start_year (float): start year
+        end_year (float): end year
+
+    Optional request args:
+        summarize: summarization method; must be 'mmm' for min, mean, max summary (eg, '?summarize=mmm' appended to endpoint)
+        format: format for data export; must be 'csv' for CSV export (eg, '?format=csv' appended to endpoint)
+
+    Returns:
+        JSON-like dict of permafrost data, or CSV of permafrost data if format=csv
+    """
+    # validate request arguments if they exist; set summarize argument accordingly
+
+    if len(request.args) == 0:
+        return asyncio.run(
+            run_fetch_gipl_1km_point_data(
+                lat, lon, start_year, end_year, summarize=None
+            )
+        )
+
+    elif "summarize" in request.args:
+        if request.args.get("summarize") == "mmm":
+            return asyncio.run(
+                run_fetch_gipl_1km_point_data(
+                    lat, lon, start_year, end_year, summarize="mmm"
+                )
+            )
+        else:
+            return render_template("400/bad_request.html"), 400
+
+    elif "format" in request.args:
+        if request.args.get("format") == "csv":
+            return asyncio.run(
+                run_fetch_gipl_1km_point_data(
+                    lat, lon, start_year, end_year, summarize=None
+                )
+            )
+
+    else:
+        return render_template("400/bad_request.html"), 400
 
 
 @routes.route("/permafrost/point/<lat>/<lon>")
 def run_point_fetch_all_permafrost(lat, lon):
-    """Run the async request for permafrost data at a single point.
+    """Run the async request for all permafrost data at a single point.
     Args:
         lat (float): latitude
         lon (float): longitude
 
+    Optional request args:
+        format: format for data export; must be 'csv' for CSV export (eg, '?format=csv' appended to endpoint)
+
     Returns:
-        JSON-like dict of permafrost data
+        JSON-like dict of permafrost data, or CSV of permafrost data if format=csv
     """
+    # validate request arguments if they exist; allow only format argument, otherwise throw an error
+    if len(request.args) == 0:
+        pass
+    elif "format" in request.args:
+        if request.args.get("format") == "csv":
+            pass
+        else:
+            return render_template("400/bad_request.html"), 400
+    else:
+        return render_template("400/bad_request.html"), 400
+
     validation = validate_latlon(lat, lon)
     if validation == 400:
         return render_template("400/bad_request.html"), 400
@@ -260,6 +311,26 @@ async def fetch_gipl_1km_point_data(x, y, start_year, end_year, summarize):
         timestring = (
             f'"{start_year}-01-01T00:00:00.000Z":"{end_year}-01-01T00:00:00.000Z"'
         )
+        for model_num in range(3):
+            model = list()
+            for scenario in range(2):
+                for summary_operation in ["min", "avg", "max"]:
+                    wcps_request_str = make_gipl1km_wcps_request_str(
+                        x, y, timestring, model_num, scenario, summary_operation
+                    )
+                    model.append(
+                        await fetch_data([generate_wcs_query_url(wcps_request_str)])
+                    )
+            wcps_response_data.append(model)
+        return wcps_response_data
+
+    if start_year is None and end_year is None and summarize is not None:
+        wcps_response_data = list()
+        # in lieu of start/end dates but requesting a summary, use min and max years of dataset to summarize entire dataset
+        time_index = generate_gipl1km_time_index()
+        minyear = str(time_index.min())[:4]
+        maxyear = str(time_index.max())[:4]
+        timestring = f'"{minyear}-01-01T00:00:00.000Z":"{maxyear}-01-01T00:00:00.000Z"'
         for model_num in range(3):
             model = list()
             for scenario in range(2):
@@ -319,15 +390,6 @@ async def run_fetch_gipl_1km_point_data(
         if years_valid != True:
             return render_template("400/bad_request.html"), 400
 
-    # validate the summarize option
-    if summarize is not None:
-        try:
-            summarize_valid = summarize in ["summary", "mmm"]
-        except:
-            return render_template("400/bad_request.html"), 400
-        if summarize_valid != True:
-            return render_template("400/bad_request.html"), 400
-
     try:
         gipl_1km_point_data = await asyncio.create_task(
             fetch_gipl_1km_point_data(x, y, start_year, end_year, summarize)
@@ -338,6 +400,9 @@ async def run_fetch_gipl_1km_point_data(
         return render_template("500/server_error.html"), 500
 
     if all(val != None for val in [start_year, end_year, summarize]):
+        gipl_1km_point_package = package_gipl1km_wcps_data(gipl_1km_point_data)
+
+    elif start_year is None and end_year is None and summarize is not None:
         gipl_1km_point_package = package_gipl1km_wcps_data(gipl_1km_point_data)
 
     elif start_year is not None and end_year is not None and summarize is None:

--- a/templates/documentation/permafrost.html
+++ b/templates/documentation/permafrost.html
@@ -1,70 +1,37 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h2>Permafrost Data</h2>
 
 <p>
-  These endpoints provide access to permafrost information for Alaska, including outputs from academic research on
-  permafrost type and extent as well as ground temperatures.
+  These endpoints provide access to permafrost information for Alaska, including
+  outputs from academic research on permafrost type and extent as well as ground
+  temperatures.
 </p>
 
 <p>
-  Annual projections of permafrost top and base depths, talik thickness, and mean annual ground temperature at seven
-  different depths were provided by the GIPL 2.0 model at a resolution of 1km for years 2021&ndash;2120. These
-  projections are provided for GFDL-CM3 and NCAR-CCSM4 model outputs, as well as a 5-model average, under the RCP
-  4.5 and RCP 8.5 emissions scenarios.
+  Annual projections of permafrost top and base depths, talik thickness, and
+  mean annual ground temperature at seven different depths were provided by the
+  GIPL 2.0 model at a resolution of 1km for years 2021&ndash;2120. These
+  projections are provided for GFDL-CM3 and NCAR-CCSM4 model outputs, as well as
+  a 5-model average, under the RCP 4.5 and RCP 8.5 emissions scenarios.
 </p>
 
 <p>
-  Permafrost extent and ground ice volume data from 2008 were provided by Jorgenson et al. Mean annual top of permafrost
-  ground temperature and permafrost extent data from 2000&ndash;2016 were provided by Obu et al.
+  Permafrost extent and ground ice volume data from 2008 were provided by
+  Jorgenson et al. Mean annual top of permafrost ground temperature and
+  permafrost extent data from 2000&ndash;2016 were provided by Obu et al.
 </p>
 
-<p>Links to academic references and source datasets are included at the bottom of this page.</p>
+<p>
+  Links to academic references and source datasets are included at the bottom of
+  this page.
+</p>
 
 <h3>Service endpoints</h3>
 
 <h4>Geophysical Institute Permafrost Lab (GIPL) model output (point query)</h4>
 
 <p>
-  Query GIPL 2.0 model outputs (1 km spatial resolution) for ten variables for a single point specified by latitude and
-  longitude.
-</p>
-
-<table class="endpoints">
-  <thead>
-    <tr>
-      <th class="endpoint-label">Endpoint</th>
-      <th class="endpoint-url">Example URL</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GIPL point query of entire time series</td>
-      <td><a href="/permafrost/point/gipl/63.0628/-146.1627">/permafrost/point/gipl/63.0628/-146.1627</a>
-      </td>
-    </tr>
-    <tr>
-      <td>GIPL point query within year range</td>
-      <td><a
-          href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050">/permafrost/point/gipl/63.0628/-146.1627/2040/2050</a>
-      </td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="2">Min/mean/max summaries of projected years are available by appending
-        <code>?summarize=mmm</code> to the URL. <br> CSV output is also available by appending <code>?format=csv</code>
-        to
-        the URL.
-      </td>
-    </tr>
-  </tfoot>
-</table>
-
-<!-- <h4>Geophysical Institute Permafrost Lab (GIPL) min/mean/max summaries (point query)</h4>
-
-<p>
-  Query minimum, mean, and maximum summaries of GIPL 2.0 model outputs (1 km spatial resolution) for ten variables for a
+  Query GIPL 2.0 model outputs (1 km spatial resolution) for ten variables for a
   single point specified by latitude and longitude.
 </p>
 
@@ -77,22 +44,40 @@
   </thead>
   <tbody>
     <tr>
-      <td>GIPL point query within year range min/mean/max summary</td>
-      <td><a
-          href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm">/permafrost/point/gipl/63.0628/-146.1627/2040/2050/mmm</a>
+      <td>GIPL point query of entire time series</td>
+      <td>
+        <a href="/permafrost/point/gipl/63.0628/-146.1627"
+          >/permafrost/point/gipl/63.0628/-146.1627</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>GIPL point query within year range</td>
+      <td>
+        <a href="/permafrost/point/gipl/63.0628/-146.1627/2040/2050"
+          >/permafrost/point/gipl/63.0628/-146.1627/2040/2050</a
+        >
       </td>
     </tr>
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
+      <td colspan="2">
+        Min/mean/max summaries of projected years are available by appending
+        <code>?summarize=mmm</code> to the URL. <br />
+        CSV output is also available by appending <code>?format=csv</code>
+        to the URL.
+      </td>
     </tr>
   </tfoot>
-</table> -->
+</table>
 
 <h4>Permafrost model output summaries from multiple sources (point query)</h4>
 
-<p>Query permafrost model outputs (e.g. extent, ground temperatures) from multiple sources.</p>
+<p>
+  Query permafrost model outputs (e.g. extent, ground temperatures) from
+  multiple sources.
+</p>
 
 <table class="endpoints">
   <thead>
@@ -104,13 +89,18 @@
   <tbody>
     <tr>
       <td>Multiple permafrost data sources point query summary</td>
-      <td><a href="/permafrost/point/65.0628/-146.1627">/permafrost/point/65.0628/-146.1627</a>
+      <td>
+        <a href="/permafrost/point/65.0628/-146.1627"
+          >/permafrost/point/65.0628/-146.1627</a
+        >
       </td>
     </tr>
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.
+      <td colspan="2">
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL.
       </td>
     </tr>
   </tfoot>
@@ -120,7 +110,9 @@
 
 <h4>Geophysical Institute Permafrost Lab (GIPL) model output</h4>
 
-<p>Results from GIPL entire series or time slice queries will look like this:</p>
+<p>
+  Results from GIPL entire series or time slice queries will look like this:
+</p>
 
 <pre>
 {
@@ -301,35 +293,64 @@
   </thead>
   <tbody>
     <tr>
-      <td><a
-          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/c24a957b-8a56-40bf-bc09-43a567182d36">GIPL
-          2.0 1 km Model Outputs</a></td>
-      <td>Marchenko, S., Romanovsky, V., & Tipenko, G. (2008). Numerical modeling of spatial permafrost dynamics in
-        Alaska. <i>Ninth International Conference on Permafrost, Online Proceedings, Volume 2</i>, 1125&ndash;1130.
-        Accessed 2023-09-08 from <a
-          href="https://www.permafrost.org/event/icop9/">https://www.permafrost.org/event/icop9/</a>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/c24a957b-8a56-40bf-bc09-43a567182d36"
+          >GIPL 2.0 1 km Model Outputs</a
+        >
       </td>
-
+      <td>
+        Marchenko, S., Romanovsky, V., & Tipenko, G. (2008). Numerical modeling
+        of spatial permafrost dynamics in Alaska.
+        <i
+          >Ninth International Conference on Permafrost, Online Proceedings,
+          Volume 2</i
+        >, 1125&ndash;1130. Accessed 2023-09-08 from
+        <a href="https://www.permafrost.org/event/icop9/"
+          >https://www.permafrost.org/event/icop9/</a
+        >
+      </td>
     </tr>
     <tr>
-      <td><a href="https://catalog.northslopescience.org/dataset/1725">Jorgenson Permafrost Characteristics</a></td>
-      <td>Jorgenson, M., Yoshikawa, K., Kanevskiy, M., Shur, Y., Romanovsky, V., Marchenko, S., & Jones, B. (2008).
-        Permafrost Characteristics of Alaska + Map. <i>Ninth International Conference on Permafrost, Online Proceedings,
-          Volume 1</i>, 121&ndash;122. Accessed 2023-09-08 from <a
-          href="https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf">https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf</a>
+      <td>
+        <a href="https://catalog.northslopescience.org/dataset/1725"
+          >Jorgenson Permafrost Characteristics</a
+        >
+      </td>
+      <td>
+        Jorgenson, M., Yoshikawa, K., Kanevskiy, M., Shur, Y., Romanovsky, V.,
+        Marchenko, S., & Jones, B. (2008). Permafrost Characteristics of Alaska
+        + Map.
+        <i
+          >Ninth International Conference on Permafrost, Online Proceedings,
+          Volume 1</i
+        >, 121&ndash;122. Accessed 2023-09-08 from
+        <a
+          href="https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf"
+          >https://www.researchgate.net/profile/Sergey-Marchenko-3/publication/334524021_Permafrost_Characteristics_of_Alaska_Map/links/5d2f7672a6fdcc2462e86fae/Permafrost-Characteristics-of-Alaska-Map.pdf</a
+        >
       </td>
     </tr>
     <tr>
-      <td><a
-          href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip">Mean
-          annual ground temperature dataset (ZIP file)</a>,<br />
-        <a href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip">Permafrost
-          zones dataset (ZIP file)</a>
+      <td>
+        <a
+          href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_MAGTM_5.0_20181127_2000_2016_NH.zip"
+          >Mean annual ground temperature dataset (ZIP file)</a
+        >,<br />
+        <a
+          href="https://store.pangaea.de/Publications/ObuJ-etal_2018/UiO_PEX_PERZONES_5.0_20181128_2000_2016_NH.zip"
+          >Permafrost zones dataset (ZIP file)</a
+        >
       </td>
-      <td>Obu, J., Westermann, S., Kääb, A., & Bartsch, A. (2018). Ground Temperature Map, 2000-2016. <i>Northern
-          Hemisphere Permafrost.</i> Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research,
-        Bremerhaven, PANGAEA, <a
-          href="https://doi.org/10.1594/PANGAEA.888600">https://doi.org/10.1594/PANGAEA.888600</a></td>
+      <td>
+        Obu, J., Westermann, S., Kääb, A., & Bartsch, A. (2018). Ground
+        Temperature Map, 2000-2016.
+        <i>Northern Hemisphere Permafrost.</i> Alfred Wegener Institute,
+        Helmholtz Centre for Polar and Marine Research, Bremerhaven, PANGAEA,
+        <a href="https://doi.org/10.1594/PANGAEA.888600"
+          >https://doi.org/10.1594/PANGAEA.888600</a
+        >
+      </td>
     </tr>
   </tbody>
 </table>

--- a/templates/documentation/permafrost.html
+++ b/templates/documentation/permafrost.html
@@ -52,12 +52,16 @@
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
+      <td colspan="2">Min/mean/max summaries of projected years are available by appending
+        <code>?summarize=mmm</code> to the URL. <br> CSV output is also available by appending <code>?format=csv</code>
+        to
+        the URL.
+      </td>
     </tr>
   </tfoot>
 </table>
 
-<h4>Geophysical Institute Permafrost Lab (GIPL) min/mean/max summaries (point query)</h4>
+<!-- <h4>Geophysical Institute Permafrost Lab (GIPL) min/mean/max summaries (point query)</h4>
 
 <p>
   Query minimum, mean, and maximum summaries of GIPL 2.0 model outputs (1 km spatial resolution) for ten variables for a
@@ -84,7 +88,7 @@
       <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
     </tr>
   </tfoot>
-</table>
+</table> -->
 
 <h4>Permafrost model output summaries from multiple sources (point query)</h4>
 

--- a/templates/documentation/permafrost.html
+++ b/templates/documentation/permafrost.html
@@ -65,8 +65,10 @@
       <td colspan="2">
         Min/mean/max summaries of projected years are available by appending
         <code>?summarize=mmm</code> to the URL. <br />
-        CSV output is also available by appending <code>?format=csv</code>
-        to the URL.
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL. <br />
+        Chaining of multiple arguments is supported (e.g.,
+        <code>?summarize=mmm&format=csv</code>).
       </td>
     </tr>
   </tfoot>


### PR DESCRIPTION
This PR:

- removes the `<summarize>` endpoint in `permafrost.py` and replaces it with a request argument `?summarize=mmm`. The `summarize` argument is left unchanged in the `fetch_gipl…()`, `run_fetch_gipl…()` functions, so the `run_ncr_requests()` function should work as usual.
- Adds explicit validation of any `?summarize=` and `?format=` args. Previously, bad arguments would default to None which continued to produce data (eg, `?summarize=mean` would still produce a non-summarized JSON result, which was confusing). This addresses issue #337 but only for the `permafrost.py` route. Explicit validation like this, if repeated in every `route/*.py` module, could become very redundant and could perhaps be moved to its own module specifically for validating request arguments (see issue #339). 
- Adds a default to summarize all years in the dataset if a date range is not provided in the endpoint but `?summarize=mmm` is present. For example, `/permafrost/point/gipl/62/-145?summarize=mmm` will now return min/mean/max summaries across all years in the coverage. Previously, this request would produce a non-summarized JSON result, which was confusing. This leads directly to issue #338, which would provide more information in the CSV output so the user knows what dates have been summarized, which is especially important for implicit cases like this.
- Updates the template documentation `permafrost.html` by removing the MMM section and including a note about the `?summarize=mmm` argument. JSON structure examples at the bottom of the template were left unchanged.




To test, run the `flask` application as described in `README.md`, and try:


Standard endpoints like:

	/permafrost/point/gipl/62/-145
	/permafrost/point/gipl/62/-145/2030/2040
	/permafrost/point/62/-145

GIPL endpoints with `?summarize=mmm` argument, `?format=csv` argument, and combined `?summarize=mmm&format=csv` arguments:

	/permafrost/point/gipl/62/-145?summarize=mmm
	/permafrost/point/gipl/62/-145/2030/2040?summarize=mmm	
	/permafrost/point/gipl/62/-145?format=csv
	/permafrost/point/gipl/62/-145/2030/2040?format=csv
	/permafrost/point/gipl/62/-145?summarize=mmm&format=csv
	/permafrost/point/gipl/62/-145/2030/2040?summarize=mmm&format=csv

Bogus arguments to make sure they don’t return any data:

	/permafrost/point/gipl/62/-145?foo=bar
	/permafrost/point/gipl/62/-145?summarize=mean
	/permafrost/point/gipl/62/-145/2030/2040?summarize=mean
	/permafrost/point/gipl/62/-145?format=xlsx
	/permafrost/point/gipl/62/-145/2030/2040?format=xlsx
	/permafrost/point/gipl/62/-145?summarize=mean&format=csv
	/permafrost/point/gipl/62/-145/2030/2040?summarize=mmm&format=xlsx
