### PR TITLE
Permafrost WCPS Update

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -346,7 +346,7 @@ def flammability_csv(data):
 
 def gipl_csv(data, endpoint):
     if endpoint == "gipl_summary":
-        coords = ["model", "scenario", "summary"]
+        coords = ["summary"]
     elif endpoint == "gipl":
         coords = ["model", "year", "scenario"]
     values = [

--- a/templates/documentation/permafrost.html
+++ b/templates/documentation/permafrost.html
@@ -16,9 +16,9 @@
 </p>
 
 <p>
-  Permafrost extent and ground ice volume data from 2008 were provided by
-  Jorgenson et al. Mean annual top of permafrost ground temperature and
-  permafrost extent data from 2000&ndash;2016 were provided by Obu et al.
+  Permafrost extent and ground ice volume data (Jorgenson et al., 2008) and mean
+  annual top of permafrost ground temperature and modeled permafrost extent data
+  spanning 2000&ndash;2016 (Obu et al., 2018) are also available.
 </p>
 
 <p>
@@ -172,12 +172,9 @@
 
 <pre>
 {
-  "5ModelAvg": {
-    "gipl1kmmax": {...},
-    "gipl1kmmean": {...},
-    "gipl1kmmin": {...},
-  },
-  ...
+  "gipl1kmmax": {...},
+  "gipl1kmmean": {...},
+  "gipl1kmmin": {...},
 }
 </pre>
 
@@ -185,12 +182,9 @@
 
 <pre>
 {
-  &lt;model&gt;: {
-    "gipl1kmmax": &lt;max values for all ten variables across all scenarios and years in the time slice&gt;,
-    "gipl1kmmean": &lt;mean values for all ten variables across all scenarios and years in the time slice&gt;,
-    "gipl1kmmin": &lt;min values for all ten variables across all scenarios and years in the time slice&gt;
-  },
-  ...
+    "gipl1kmmax": &lt;max values for all ten variables across all models and scenarios and years in the time slice&gt;,
+    "gipl1kmmean": &lt;mean values for all ten variables across all models and scenarios and years in the time slice&gt;,
+    "gipl1kmmin": &lt;min values for all ten variables across all models and scenarios and years in the time slice&gt;
 }
 </pre>
 


### PR DESCRIPTION
This PR updates the logic in the WCPS request that generates the `mmm` summaries of the GIPL model output. The prior behavior was such that the only axis of the hypercube being summarized was time, and a summary was created for each climate future. Now time, model, and scenario are all summarized yielding a single `mmm` summary returned by the request. This also dramatically cuts down the overall number of WCPS requests required (from something like 18 to 3).

To test this PR visit the following routes and observe that all ten variables are summarized three times, one per summary statistic (min, mean, max):

Full time series (this route will summarize the entire time series because the summary arg is passed, but no year range is provided). Observe some compelling deltas between the min and max values.

http://127.0.0.1:5000/permafrost/point/gipl/65.1/-146.2?summarize=mmm

As above, but for 2050-2060. Observe less compelling deltas, but still non-duplicate results.

http://127.0.0.1:5000/permafrost/point/gipl/65.1/-146.2/2050/2060?summarize=mmm

As above, but in CSV. Observe that model / scenario are now omitted from the mmm summary CSV.

http://127.0.0.1:5000/permafrost/point/gipl/65.1/-146.2/2050/2060?summarize=mmm&format=csv

