### PR TITLE
Remove "min/mean/max" from January/July endpoint names

### DIFF
--- a/templates/documentation/taspr.html
+++ b/templates/documentation/taspr.html
@@ -178,19 +178,13 @@
       </td>
     </tr>
     <tr>
-      <td>January temperature min/mean/max</td>
-      <td>
-        <a href="/temperature/jan/65.0628/-146.1627"
-          >/temperature/jan/65.0628/-146.1627</a
-        >
+      <td>January temperature</td>
+      <td><a href="/temperature/jan/65.0628/-146.1627">/temperature/jan/65.0628/-146.1627</a>
       </td>
     </tr>
     <tr>
-      <td>July temperature min/mean/max</td>
-      <td>
-        <a href="/temperature/july/65.0628/-146.1627"
-          >/temperature/july/65.0628/-146.1627</a
-        >
+      <td>July temperature</td>
+      <td><a href="/temperature/july/65.0628/-146.1627">/temperature/july/65.0628/-146.1627</a>
       </td>
     </tr>
   </tbody>
@@ -239,19 +233,13 @@
       </td>
     </tr>
     <tr>
-      <td>January temperature min/mean/max within year range</td>
-      <td>
-        <a href="/temperature/jan/65.0628/-146.1627/1940/2060"
-          >/temperature/jan/65.0628/-146.1627/1940/2060</a
-        >
+      <td>January temperature within year range</td>
+      <td><a href="/temperature/jan/65.0628/-146.1627/1940/2060">/temperature/jan/65.0628/-146.1627/1940/2060</a>
       </td>
     </tr>
     <tr>
-      <td>July temperature min/mean/max within year range</td>
-      <td>
-        <a href="/temperature/july/65.0628/-146.1627/1940/2060"
-          >/temperature/july/65.0628/-146.1627/1940/2060</a
-        >
+      <td>July temperature within year range</td>
+      <td><a href="/temperature/july/65.0628/-146.1627/1940/2060">/temperature/july/65.0628/-146.1627/1940/2060</a>
       </td>
     </tr>
   </tbody>
@@ -483,12 +471,9 @@
 }
 </pre>
 
-<h4>January/July yearly min/mean/max summaries</h4>
+<h4>January/July temperature</h4>
 
-<p>
-  Results from yearly January/July temperature min/mean/max queries will look
-  like this:
-</p>
+<p>Results from January/July temperature queries will look like this:</p>
 
 <pre>
 {
@@ -607,22 +592,13 @@
   </thead>
   <tbody>
     <tr>
-      <td>
-        <a
-          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/3b2b24ff-4916-4d92-95b7-c6b2fcefd381"
-          >Historical Monthly and Derived Temperature Products - 2km CRU TS
-          4.0</a
-        >
-      </td>
-      <td rowspan="4" style="vertical-align: middle; border-bottom: none">
-        Walsh J.E., Bhatt U.S., Littell J. S., Leonawicz M., Lindgren M.,
-        Kurkowski T. A., Bieniek P. A., Gray S., & Rupp T. S. (2018).
-        Downscaling of climate model output for Alaskan stakeholders,
-        <i>Environmental Modelling & Software, 110</i>, 38&ndash;51. DOI
-        <a href="https://doi.org/10.1016/j.envsoft.2018.03.021"
-          >10.1016/j.envsoft.2018.03.021</a
-        >
-      </td>
+      <td><a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/3b2b24ff-4916-4d92-95b7-c6b2fcefd381">Historical
+          Monthly and Derived Temperature Products - 2km CRU TS 4.0</a></td>
+      <td rowspan="4" style="vertical-align: middle; border-bottom: none;">Walsh J.E., Bhatt U.S., Littell J. S.,
+        Leonawicz M., Lindgren M., Kurkowski T. A., Bieniek P. A., Gray S., & Rupp T. S. (2018). Downscaling of climate
+        model output for Alaskan stakeholders, <i>Environmental Modelling & Software, 110</i>, 38&ndash;51. DOI <a
+          href="https://doi.org/10.1016/j.envsoft.2018.03.021">10.1016/j.envsoft.2018.03.021</a></td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
Closes #353.

This PR simply changes the names of the January and July temperature endpoints in the documentation to remove "min/mean/max".

After looking at this closer, this wasn't actually a mistake, but just poor wording. The January and July temperature endpoints do indeed return min, mean, and max data (even when not provided the `?summarize=mmm` parameter), but the "min/mean/max" in the endpoint names makes the rest of the documentation very confusing, so I've gone ahead and renamed them to:

- January temperature
- July temperature
- January temperature within year range
- July temperature within year range

... and also updated the corresponding output documentation to reflect this.