### PR TITLE
Add hydrology endpoint

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -83,6 +83,8 @@ def create_csv(
         properties = veg_type_csv(data)
     elif endpoint in ["wet_days_per_year", "wet_days_per_year_all"]:
         properties = wet_days_per_year_csv(data, endpoint)
+    elif endpoint == "hydrology":
+        properties = hydrology_csv(data)
     else:
         return render_template("500/server_error.html"), 500
 
@@ -745,6 +747,35 @@ def wet_days_per_year_csv(data, endpoint):
     csv_dicts = build_csv_dicts(data, fieldnames, values=values)
     metadata = "# wdpy is the count of wet days (days where the total precipitation amount is greater than or equal to 1.0 mm) per calendar year\n"
     filename_data_name = "Wet Days Per Year"
+
+    return {
+        "csv_dicts": csv_dicts,
+        "fieldnames": fieldnames,
+        "metadata": metadata,
+        "filename_data_name": filename_data_name,
+    }
+
+
+def hydrology_csv(data):
+    coords = ["model", "scenario", "month", "era"]
+    values = [
+        "evap",
+        "glacier_melt",
+        "iwe",
+        "pcp",
+        "runoff",
+        "sm1",
+        "sm2",
+        "sm3",
+        "snow_melt",
+        "swe",
+        "tmax",
+        "tmin",
+    ]
+    fieldnames = coords + values
+    csv_dicts = build_csv_dicts(data, fieldnames, values=values)
+    metadata = "# Hydrology model outputs for ten variables.\n"
+    filename_data_name = "Hydrology Model Outputs"
 
     return {
         "csv_dicts": csv_dicts,

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -83,8 +83,9 @@ def create_csv(
         properties = veg_type_csv(data)
     elif endpoint in ["wet_days_per_year", "wet_days_per_year_all"]:
         properties = wet_days_per_year_csv(data, endpoint)
-    elif endpoint == "hydrology":
-        properties = hydrology_csv(data)
+    elif endpoint in ["hydrology", "hydrology_mmm"]:
+        properties = hydrology_csv(data, endpoint)
+
     else:
         return render_template("500/server_error.html"), 500
 
@@ -756,30 +757,93 @@ def wet_days_per_year_csv(data, endpoint):
     }
 
 
-def hydrology_csv(data):
-    coords = ["model", "scenario", "month", "era"]
-    values = [
-        "evap",
-        "glacier_melt",
-        "iwe",
-        "pcp",
-        "runoff",
-        "sm1",
-        "sm2",
-        "sm3",
-        "snow_melt",
-        "swe",
-        "tmax",
-        "tmin",
-    ]
-    fieldnames = coords + values
-    csv_dicts = build_csv_dicts(data, fieldnames, values=values)
-    metadata = "# Hydrology model outputs for ten variables.\n"
-    filename_data_name = "Hydrology Model Outputs"
+def hydrology_csv(data, endpoint):
+    if endpoint == "hydrology":
+        coords = ["model", "scenario", "month", "era"]
+        values = [
+            "evap",
+            "glacier_melt",
+            "iwe",
+            "pcp",
+            "runoff",
+            "sm1",
+            "sm2",
+            "sm3",
+            "snow_melt",
+            "swe",
+            "tmax",
+            "tmin",
+        ]
+        fieldnames = coords + values
+        csv_dicts = build_csv_dicts(data, fieldnames, values=values)
+        metadata = "# Hydrology model outputs for ten variables; decadal means of monthly values.\n"
+        metadata += "# model is the model the data is derived from\n"
+        metadata += "# scenario is the emissions scenario\n"
+        metadata += "# month is the month of year over which data are summarized\n"
+        metadata += "# era is the decade over which data are summarized\n"
+        metadata += "# variable is the hydrology variable name\n"
+        metadata += "# evap is the decadal mean of the monthly sum of daily evapotranspiration in mm\n"
+        metadata += "# glacier_melt is the decadal mean of the monthly sum of daily glacier ice melt in mm\n"
+        metadata += "# iwe is the decadal mean of the monthly maximum of daily ice water equivalent in mm\n"
+        metadata += "# pcp is the decadal mean of the monthly sum of daily precipitation in mm\n"
+        metadata += "# runoff is the decadal mean of the monthly sum of daily surface runoff in mm\n"
+        metadata += "# sm1 is the decadal mean of the monthly mean of daily soil moisture in layer 1 in mm\n"
+        metadata += "# sm2 is the decadal mean of the monthly mean of daily soil moisture in layer 2 in mm\n"
+        metadata += "# sm3 is the decadal mean of the monthly mean of daily soil moisture in layer 3 in mm\n"
+        metadata += "# snowmelt is the decadal mean of the monthly sum of daily snowmelt in mm\n"
+        metadata += "# swe is the decadal mean of the monthly maximum of daily snow water equivalent in mm\n"
+        metadata += "# tmax is the decadal mean of the monthly mean of daily maximum air temperature at 2m in degrees C\n"
+        metadata += "# tmin is the decadal mean of the monthly mean of daily minimum air temperature at 2m in degrees C\n"
+        filename_data_name = "Hydrology Model Outputs - Decadal Mean Values - "
 
-    return {
-        "csv_dicts": csv_dicts,
-        "fieldnames": fieldnames,
-        "metadata": metadata,
-        "filename_data_name": filename_data_name,
-    }
+        return {
+            "csv_dicts": csv_dicts,
+            "fieldnames": fieldnames,
+            "metadata": metadata,
+            "filename_data_name": filename_data_name,
+        }
+
+    if endpoint == "hydrology_mmm":
+        coords = ["model", "scenario", "month", "variable"]
+        values = ["min", "mean", "max"]
+        fieldnames = coords + values
+        csv_dicts = build_csv_dicts(data, fieldnames, values=values)
+        metadata = "# Hydrology model outputs for ten variables; minimum mean and maximum across all decades (1950-2099).\n"
+        metadata += "# model is the model the data is derived from\n"
+        metadata += "# scenario is the emissions scenario\n"
+        metadata += "# month is the month of year over which data are summarized\n"
+        metadata += "# variable is the hydrology variable name\n"
+        metadata += "# mean is the mean of all decadal mean values\n"
+        metadata += "# max is the maximum of all decadal mean values\n"
+        metadata += "# min is the minimum of all decadal mean values\n"
+        metadata += "# evap is the monthly sum of daily evapotranspiration in mm\n"
+        metadata += (
+            "# glacier_melt is the monthly sum of daily glacier ice melt in mm\n"
+        )
+        metadata += "# iwe is the monthly maximum of daily ice water equivalent in mm\n"
+        metadata += "# pcp is the monthly sum of daily precipitation in mm\n"
+        metadata += "# runoff is the monthly sum of daily surface runoff in mm\n"
+        metadata += (
+            "# sm1 is the monthly mean of daily soil moisture in layer 1 in mm\n"
+        )
+        metadata += (
+            "# sm2 is the monthly mean of daily soil moisture in layer 2 in mm\n"
+        )
+        metadata += (
+            "# sm3 is the monthly mean of daily soil moisture in layer 3 in mm\n"
+        )
+        metadata += "# snowmelt is the monthly sum of daily snowmelt in mm\n"
+        metadata += (
+            "# swe is the monthly maximum of daily snow water equivalent in mm\n"
+        )
+        metadata += "# tmax is the monthly mean of daily maximum air temperature at 2m in degrees C\n"
+        metadata += "# tmin is the monthly mean of daily minimum air temperature at 2m in degrees C\n"
+
+        filename_data_name = "Hydrology Model Outputs - Minimum, Mean, and Maximum Across All Decades 1950-2099 - "
+
+        return {
+            "csv_dicts": csv_dicts,
+            "fieldnames": fieldnames,
+            "metadata": metadata,
+            "filename_data_name": filename_data_name,
+        }

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -25,6 +25,7 @@ nodata_mappings = {
     "heating_degree_days": nodata_values["default"],
     "heating_degree_days_all": nodata_values["default"],
     "hydrology": nodata_values["default"],
+    "hydrology_mmm": nodata_values["default"],
     "landfastice": [],
     "ncar12km_indicators": nodata_values["ncar12km_indicators"],
     "permafrost": nodata_values["permafrost"],

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -24,6 +24,7 @@ nodata_mappings = {
     "gipl_summary": [],
     "heating_degree_days": nodata_values["default"],
     "heating_degree_days_all": nodata_values["default"],
+    "hydrology": nodata_values["default"],
     "landfastice": [],
     "ncar12km_indicators": nodata_values["ncar12km_indicators"],
     "permafrost": nodata_values["permafrost"],

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -20,3 +20,4 @@ from .beetles import *
 from .eds import *
 from .wet_days_per_year import *
 from .indicators import *
+from .hydrology import *

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -178,11 +178,9 @@ def run_get_hydrology_point_data(lat, lon):
         return render_template("500/server_error.html"), 500
 
     if request.args.get("format") == "csv":
-        point_pkg = nullify_and_prune(point_pkg, "hydrology")
-        if point_pkg in [{}, None, 0]:
-            return render_template("404/no_data.html"), 404
-
-        place_id = request.args.get("community")
-        return create_csv(point_pkg, "hydrology", place_id, lat, lon)
-
+        # point_pkg = nullify_and_prune(point_pkg, "hydrology")
+        # if point_pkg in [{}, None, 0]:
+        # return render_template("404/no_data.html"), 404
+        # place_id = request.args.get("community")
+        return create_csv(point_pkg, "hydrology", place_id=None, lat=lat, lon=lon)
     return postprocess(point_pkg, "hydrology")

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -1,10 +1,5 @@
 import asyncio
-import io
-import time
-import itertools
 from urllib.parse import quote
-import numpy as np
-import xarray as xr
 from flask import (
     Blueprint,
     render_template,
@@ -14,26 +9,13 @@ from flask import (
 )
 
 # local imports
-from generate_requests import generate_wcs_getcov_str, generate_mmm_wcs_getcov_str
-from generate_urls import generate_wcs_query_url
-from fetch_data import (
-    fetch_data,
-    fetch_wcs_point_data,
-    get_from_dict,
-    summarize_within_poly,
-    get_poly_3338_bbox,
-)
+from fetch_data import fetch_wcs_point_data
 from validate_request import (
     validate_latlon,
     project_latlon,
-    validate_var_id,
-    validate_year,
 )
 from validate_data import *
-from postprocessing import (
-    nullify_and_prune,
-    postprocess,
-)
+from postprocessing import postprocess
 from csv_functions import create_csv
 from config import WEST_BBOX, EAST_BBOX
 from . import routes
@@ -178,9 +160,7 @@ def run_get_hydrology_point_data(lat, lon):
         return render_template("500/server_error.html"), 500
 
     if request.args.get("format") == "csv":
-        # point_pkg = nullify_and_prune(point_pkg, "hydrology")
-        # if point_pkg in [{}, None, 0]:
-        # return render_template("404/no_data.html"), 404
+        # need to implement "community" arg later
         # place_id = request.args.get("community")
         return create_csv(point_pkg, "hydrology", place_id=None, lat=lat, lon=lon)
     return postprocess(point_pkg, "hydrology")

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -128,7 +128,12 @@ def run_fetch_hydrology_point_data(lat, lon):
     for variable in range(len(dim_encodings["varnames"])):
         rasdaman_response.append(
             asyncio.run(
-                fetch_wcs_point_data(x, y, hydrology_coverage_id, var_coord=variable)
+                fetch_wcs_point_data(
+                    x,
+                    y,
+                    hydrology_coverage_id,
+                    var_coord=variable,
+                )
             )
         )
 

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -292,6 +292,8 @@ def run_get_hydrology_point_data(lat, lon):
                 if hasattr(exc, "status") and exc.status == 404:
                     return render_template("404/no_data.html"), 404
                 return render_template("500/server_error.html"), 500
+        else:
+            return render_template("400/bad_request.html"), 400
 
     else:
         return render_template("400/bad_request.html"), 400

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -1,0 +1,186 @@
+import asyncio
+import io
+import time
+import itertools
+from urllib.parse import quote
+import numpy as np
+import xarray as xr
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    current_app as app,
+    jsonify,
+)
+
+# local imports
+from generate_requests import generate_wcs_getcov_str, generate_mmm_wcs_getcov_str
+from generate_urls import generate_wcs_query_url
+from fetch_data import (
+    fetch_data,
+    fetch_wcs_point_data,
+    get_from_dict,
+    summarize_within_poly,
+    get_poly_3338_bbox,
+)
+from validate_request import (
+    validate_latlon,
+    project_latlon,
+    validate_var_id,
+    validate_year,
+)
+from validate_data import *
+from postprocessing import (
+    nullify_and_prune,
+    postprocess,
+)
+from csv_functions import create_csv
+from config import WEST_BBOX, EAST_BBOX
+from . import routes
+
+hydrology_api = Blueprint("hydrology_api", __name__)
+hydrology_coverage_id = "hydrology"
+
+dim_encodings = {
+    "varnames": {
+        0: "evap",
+        1: "glacier_melt",
+        2: "iwe",
+        3: "pcp",
+        4: "runoff",
+        5: "sm1",
+        6: "sm2",
+        7: "sm3",
+        8: "snow_melt",
+        9: "swe",
+        10: "tmax",
+        11: "tmin",
+    },
+    "models": {
+        0: "ACCESS1-3",
+        1: "CCSM4",
+        2: "CSIRO-Mk3-6-0",
+        3: "CanESM2",
+        4: "GFDL-ESM2M",
+        5: "HadGEM2-ES",
+        6: "MIROC5",
+        7: "MPI-ESM-MR",
+        8: "MRI-CGCM3",
+        9: "inmcm4",
+    },
+    "scenarios": {
+        0: "rcp45",
+        1: "rcp85",
+    },
+    "months": {
+        0: "apr",
+        1: "aug",
+        2: "dec",
+        3: "feb",
+        4: "jan",
+        5: "jul",
+        6: "jun",
+        7: "mar",
+        8: "may",
+        9: "nov",
+        10: "oct",
+        11: "sep",
+    },
+    "eras": {
+        0: "1950-1959",
+        1: "1960-1969",
+        2: "1970-1979",
+        3: "1980-1989",
+        4: "1990-1999",
+        5: "2000-2009",
+        6: "2010-2019",
+        7: "2020-2029",
+        8: "2030-2039",
+        9: "2040-2049",
+        10: "2050-2059",
+        11: "2060-2069",
+        12: "2070-2079",
+        13: "2080-2089",
+        14: "2090-2099",
+    },
+}
+
+
+def run_fetch_hydrology_point_data(lat, lon):
+    """Fetch projected precipitation data for a
+       given latitude and longitude.
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+
+    Returns:
+        JSON-like dict of data at provided latitude and
+        longitude
+    """
+    x, y = project_latlon(lat, lon, 3338)
+    rasdaman_response = list()
+
+    # Due to the large amount of dimensions, it was found that splitting up
+    # our Rasdaman requests across each of the variable dimension (12 different values)
+    # and recombining on the API was much faster than simply requesting all of the
+    # data at once.
+    for variable in range(len(dim_encodings["varnames"])):
+        rasdaman_response.append(
+            asyncio.run(
+                fetch_wcs_point_data(x, y, hydrology_coverage_id, var_coord=variable)
+            )
+        )
+
+    # package point data with decoded coord values (names)
+    # these functions are hard-coded  with coord values for now
+    point_pkg = dict()
+    for variable in range(len(dim_encodings["varnames"])):
+        variable_key = dim_encodings["varnames"][variable]
+        point_pkg[variable_key] = dict()
+        for model in range(len(dim_encodings["models"])):
+            model_key = dim_encodings["models"][model]
+            point_pkg[variable_key][model_key] = dict()
+            for scenario in range(len(dim_encodings["scenarios"])):
+                scenario_key = dim_encodings["scenarios"][scenario]
+                point_pkg[variable_key][model_key][scenario_key] = dict()
+                for month in range(len(dim_encodings["months"])):
+                    month_key = dim_encodings["months"][month]
+                    point_pkg[variable_key][model_key][scenario_key][month_key] = dict()
+                    for era in range(len(dim_encodings["eras"])):
+                        era_key = dim_encodings["eras"][era]
+                        point_pkg[variable_key][model_key][scenario_key][month_key][
+                            era_key
+                        ] = rasdaman_response[variable][model][scenario][month][era]
+
+    return point_pkg
+
+
+@routes.route("/hydrology/point/<lat>/<lon>")
+def run_get_hydrology_point_data(lat, lon):
+    validation = validate_latlon(lat, lon)
+    if validation == 400:
+        return render_template("400/bad_request.html"), 400
+    if validation == 422:
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
+    try:
+        point_pkg = run_fetch_hydrology_point_data(lat, lon)
+    except Exception as exc:
+        if hasattr(exc, "status") and exc.status == 404:
+            return render_template("404/no_data.html"), 404
+        return render_template("500/server_error.html"), 500
+
+    if request.args.get("format") == "csv":
+        point_pkg = nullify_and_prune(point_pkg, "hydrology")
+        if point_pkg in [{}, None, 0]:
+            return render_template("404/no_data.html"), 404
+
+        place_id = request.args.get("community")
+        return create_csv(point_pkg, "hydrology", place_id, lat, lon)
+
+    return postprocess(point_pkg, "hydrology")

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -1,22 +1,18 @@
 import asyncio
 import numpy as np
-from urllib.parse import quote
 from flask import (
     Blueprint,
     render_template,
     request,
     current_app as app,
-    jsonify,
 )
 
 # local imports
-from fetch_data import fetch_wcs_point_data, fetch_data
+from fetch_data import fetch_wcs_point_data
 from validate_request import (
     validate_latlon,
     project_latlon,
 )
-from generate_requests import generate_average_wcps_str
-from generate_urls import generate_wcs_query_url
 from validate_data import *
 from postprocessing import postprocess
 from csv_functions import create_csv

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -168,6 +168,10 @@ def run_get_hydrology_point_data(lat, lon):
 
     if request.args.get("format") == "csv":
         # need to implement "community" arg later
-        # place_id = request.args.get("community")
+        place_id = request.args.get("community")
+        if place_id:
+            return create_csv(
+                point_pkg, "hydrology", place_id=place_id, lat=lat, lon=lon
+            )
         return create_csv(point_pkg, "hydrology", place_id=None, lat=lat, lon=lon)
     return postprocess(point_pkg, "hydrology")

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -140,6 +140,13 @@ def run_fetch_hydrology_point_data(lat, lon):
     return point_pkg
 
 
+@routes.route("/hydrology/")
+@routes.route("/hydrology/abstract/")
+@routes.route("/hydrology/point/")
+def hydro_about():
+    return render_template("documentation/hydrology.html")
+
+
 @routes.route("/hydrology/point/<lat>/<lon>")
 def run_get_hydrology_point_data(lat, lon):
     validation = validate_latlon(lat, lon)

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -56,7 +56,7 @@
 
 <h4>Decadal hydrology variables</h4>
 
-<p>Results from decadal queries will look like this:</p>
+<p>Results from point queries will look like this:</p>
 
 <pre>
   {
@@ -105,8 +105,8 @@
           "sm3": &lt;monthly mean of daily soil moisture in layer 3, mm&gt;,
           "snow_melt": &lt;monthly sum of daily snowmelt, mm&gt;,
           "swe": &lt;monthly maximum of daily snow water equivalent, mm&gt;,
-          "tmax": &lt;monthly mean of daily maximum air temperature at 2m, degrees C&gt;,
-          "tmin": &lt;monthly mean of daily minimum air temperature at 2m, degrees C&gt;,
+          "tmax": &lt;monthly mean of daily maximum air temperature at 2m, &deg;C&gt;,
+          "tmin": &lt;monthly mean of daily minimum air temperature at 2m, &deg;C&gt;,
         },
         ...
       },

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -224,6 +224,7 @@
   <thead>
     <tr>
       <th>Metadata & source data access</th>
+      <th>Academic reference</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -1,0 +1,151 @@
+{% extends 'base.html' %} {% block content %}
+<h2>Hydrology</h2>
+
+<p>
+  These endpoints provide access to historical and projected modeled decadal
+  summaries of hydrologic data for Alaska at a resolution of XXXm. Historical
+  data were derived from the XXX dataset. Projections were derived from XXX,
+  YYY, and ZZZ model outputs under the RCP 4.5 and RCP 8.5 emissions scenarios.
+</p>
+
+<p>
+  Links to academic references and source datasets are included at the bottom of
+  this page.
+</p>
+
+<h3>Service endpoints</h3>
+
+<h4>All hydrologic variables (point query)</h4>
+
+<p>
+  Query all hydrologic variables for all models and scenarios for each decade.
+</p>
+
+<table class="endpoints">
+  <thead>
+    <tr>
+      <th class="endpoint-label">Endpoint</th>
+      <th class="endpoint-url">Example URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Decadal variables</td>
+      <td>
+        <a href="/hydrology/point/61.5/-147">/hydrology/point/61.5/-147</a>
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">
+        CSV output is available by appending <code>?format=csv</code> to the
+        URL.
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<h3>Output</h3>
+
+<h4>Decadal hydrology variables</h4>
+
+<p>Results from decadal queries will look like this:</p>
+
+<pre>
+  {
+    "ACCESS1-3": {
+      "rcp45": {
+        "apr": {
+          "1950-1959": {
+            "evap": "3",
+            "glacier_melt": "0",
+            "iwe": "131342",
+            "pcp": "120",
+            "runoff": "0",
+            "sm1": "10",
+            "sm2": "440",
+            "sm3": "0",
+            "snow_melt": "0",
+            "swe": "1348",
+            "tmax": "-6.5",
+            "tmin": "-20.7"
+          },
+          ...
+        },
+      ...
+    },
+    ...
+  },
+  ...
+},
+</pre>
+
+<p>The above output is structured like this:</p>
+
+<pre>
+{
+  &lt;model&gt;: {
+    &lt;scenario&gt;: {
+      &lt;month&gt;: {
+        &lt;decade&gt;: {
+          "evap": &lt;monthly sum of daily evapotranspiration, mm&gt;,
+          "glacier_melt": &lt;monthly sum of daily glacier ice melt, mm&gt;,
+          "iwe": &lt;monthly maximum of daily ice water equivalent, mm&gt;,
+          "pcp": &lt;monthly sum of daily precipitation, mm&gt;,
+          "runoff": &lt;monthly sum of daily surface runoff, mm&gt;,
+          "sm1": &lt;monthly mean of daily soil moisture in layer 1, mm&gt;,
+          "sm2": &lt;monthly mean of daily soil moisture in layer 2, mm&gt;,
+          "sm3": &lt;monthly mean of daily soil moisture in layer 3, mm&gt;,
+          "snow_melt": &lt;monthly sum of daily snowmelt, mm&gt;,
+          "swe": &lt;monthly maximum of daily snow water equivalent, mm&gt;,
+          "tmax": &lt;monthly mean of daily maximum air temperature at 2m, degrees C&gt;,
+          "tmin": &lt;monthly mean of daily minimum air temperature at 2m, degrees C&gt;,
+        },
+        ...
+      },
+      ...
+    },
+    ...
+  },
+  ...
+}
+</pre>
+
+<h3>Source data</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>Metadata & source data access</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a
+          href="https://github.com/ua-snap/ardac-curation/tree/ncar12km_decadal_summaries/ncar12km_decadal_summaries"
+          >Near-Surface Met + VIC Hydrologic Model Outputs: NCAR 12 km
+          Edition</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a
+          href="https://www.earthsystemgrid.org/dataset/ucar.ral.hydro.predictions.html"
+          >21st Century Hydrologic Projections for Alaska and Hawaii</a
+        >
+      </td>
+      <td>
+        Mizukami, N., Newman, A. J., Wood, A. W., Gutmann, E. D., and Hamman, J.
+        J. (2022). Boulder, CO: UCAR/NCAR/RAL.
+        <a href="https://doi.org/10.5065/c3kn-2y77"
+          >https://doi.org/10.5065/c3kn-2y77</a
+        >
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{% endblock %}

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -3,14 +3,15 @@
 
 <p>
   These endpoints provide access to historical and projected modeled decadal
-  summaries of hydrologic data for Alaska at a resolution of XXXm. Historical
-  data were derived from the XXX dataset. Projections were derived from XXX,
-  YYY, and ZZZ model outputs under the RCP 4.5 and RCP 8.5 emissions scenarios.
+  summaries of hydrologic data for Alaska at a resolution of 12km. These data
+  were derived by applying the Variable Infiltration Capacity (VIC) model to
+  downscaled CMIP5 historical and projected climate data, using RCP 4.5 and RCP
+  8.5 emissions scenarios.
 </p>
 
 <p>
-  Links to academic references and source datasets are included at the bottom of
-  this page.
+  For more detailed model information, see the links to academic references and
+  source datasets included at the bottom of this page.
 </p>
 
 <h3>Service endpoints</h3>
@@ -18,7 +19,8 @@
 <h4>All hydrologic variables (point query)</h4>
 
 <p>
-  Query all hydrologic variables for all models and scenarios for each decade.
+  Query hydrologic variables for all models and scenarios. Monthly variable data
+  is averaged over each decade.
 </p>
 
 <table class="endpoints">
@@ -30,7 +32,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>Decadal variables</td>
+      <td>Decadal means for all variables</td>
       <td>
         <a href="/hydrology/point/61.5/-147">/hydrology/point/61.5/-147</a>
       </td>
@@ -39,8 +41,12 @@
   <tfoot>
     <tr>
       <td colspan="2">
-        CSV output is available by appending <code>?format=csv</code> to the
-        URL.
+        Min/mean/max summaries of across all decades are available by appending
+        <code>?summarize=mmm</code> to the URL. <br />
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL. <br />
+        Chaining of multiple arguments is supported (e.g.,
+        <code>?summarize=mmm&format=csv</code>).
       </td>
     </tr>
   </tfoot>
@@ -101,6 +107,106 @@
           "swe": &lt;monthly maximum of daily snow water equivalent, mm&gt;,
           "tmax": &lt;monthly mean of daily maximum air temperature at 2m, degrees C&gt;,
           "tmin": &lt;monthly mean of daily minimum air temperature at 2m, degrees C&gt;,
+        },
+        ...
+      },
+      ...
+    },
+    ...
+  },
+  ...
+}
+</pre>
+
+<h4>Min/mean/max summaries across all decades</h4>
+
+<p>Results from min/mean/max summary queries will look like this:</p>
+
+<pre>
+  {
+    "ACCESS1-3": {
+      "rcp45": {
+        "apr": {
+          "evap": {
+            "max": 13.0,
+            "mean": 0.5,
+            "min": -16.0
+          },
+          "glacier_melt": {
+            "max": 42090.0,
+            "mean": 4289.65,
+            "min": 0.0
+          },
+          "iwe": {
+            "max": 207495.0,
+            "mean": 151004.6,
+            "min": 64746.0
+          },
+          "pcp": {
+            "max": 749.0,
+            "mean": 219.32,
+            "min": 23.0
+          },
+          "runoff": {
+            "max": 1941.0,
+            "mean": 217.61,
+            "min": 0.0
+          },
+          "sm1": {
+            "max": 10.0,
+            "mean": 9.98,
+            "min": 9.0
+          },
+          "sm2": {
+            "max": 440.0,
+            "mean": 439.82,
+            "min": 408.0
+          },
+          "sm3": {
+            "max": 27.0,
+            "mean": 0.07,
+            "min": 0.0
+          },
+          "snow_melt": {
+            "max": 1943.0,
+            "mean": 217.74,
+            "min": 0.0
+          },
+          "swe": {
+            "max": 2090.0,
+            "mean": 957.38,
+            "min": 5.0
+          },
+          "tmax": {
+            "max": 20.4,
+            "mean": -3.74,
+            "min": -23.3
+          },
+          "tmin": {
+            "max": 5.7,
+            "mean": -15.39,
+            "min": -35.0
+          }
+        },
+        ...
+      },
+      ...
+    },
+    ...
+  }
+</pre>
+
+<p>The above output is structured like this:</p>
+
+<pre>
+{
+  &lt;model&gt;: {
+    &lt;scenario&gt;: {
+      &lt;month&gt;: {
+        &lt;variable&gt;: {
+          "max": &lt;maxmimum values for variable across all decades&gt;,
+          "mean": &lt;mean values for variable across all decades&gt;,
+          "min": &lt;minimum values for variable across all decades&gt;
         },
         ...
       },

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -236,6 +236,7 @@
           Edition</a
         >
       </td>
+      <td></td>
     </tr>
     <tr>
       <td>

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -41,7 +41,7 @@
   <tfoot>
     <tr>
       <td colspan="2">
-        Min/mean/max summaries of across all decades are available by appending
+        Min/mean/max summaries of each model/scenario across all decades are available by appending
         <code>?summarize=mmm</code> to the URL. <br />
         CSV output is also available by appending <code>?format=csv</code> to
         the URL. <br />

--- a/templates/documentation/hydrology.html
+++ b/templates/documentation/hydrology.html
@@ -239,17 +239,26 @@
       <td></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="https://www.earthsystemgrid.org/dataset/ucar.ral.hydro.predictions.html"
-          >21st Century Hydrologic Projections for Alaska and Hawaii</a
-        >
+      <td rowspan="2" style="vertical-align: middle; border-bottom: none">
+        21st Century Hydrologic Projections for Alaska and Hawaiʻi
       </td>
       <td>
         Mizukami, N., Newman, A. J., Wood, A. W., Gutmann, E. D., and Hamman, J.
         J. (2022). Boulder, CO: UCAR/NCAR/RAL.
         <a href="https://doi.org/10.5065/c3kn-2y77"
           >https://doi.org/10.5065/c3kn-2y77</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
+        A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijsenn, B., Clark,
+        M. P., and Arnold, J. R. (2022). New projections of 21st century climate
+        and hydrology for Alaska and Hawaiʻi. <i>Climate Services, 27</i>,
+        100312.
+        <a href="https://doi.org/10.1016/j.cliser.2022.100312"
+          >https://doi.org/10.1016/j.cliser.2022.100312</a
         >
       </td>
     </tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,7 @@
   <li><a href="/elevation">Digital Elevation Models (DEMs)</a></li>
   <li><a href="/alfresco">Flammability and Vegetation Type (ALFRESCO)</a></li>
   <li><a href="/geology">Geology</a></li>
+  <li><a href="/hydrology">Hydrology</a></li>
   <li><a href="/landfastice">Landfast Sea Ice</a></li>
   <li><a href="/permafrost">Permafrost</a></li>
   <li><a href="/boundary">Physical and Administrative Boundary Polygons</a></li>


### PR DESCRIPTION
This PR adds the basic `/hydrology/point/<lat>/<lon>` endpoint, which includes a point data query with optional `?format=csv` and `?summarize=mmm` arguments. 

(You will notice that I did not use a WCPS request to get the min, mean, max values - instead I just summarized these from the regular WCS results. I could not seem to write a WCPS query that would return the correct data in this structure without resorting to a bunch of iteration wrapping the WCPS query, sending lots of round trip requests to rasdaman. This method seemed much simpler / more transparent to me, but of course I am open to suggestions!)

To test, run the flask application as described in `README.md`, then review the documentation at `/hydrology.html`. Then try:

Standard endpoint:

```
/hydrology/point/62/-145
```

Endpoints with ?summarize=mmm argument, ?format=csv argument, and combined ?summarize=mmm&format=csv arguments:

```
/hydrology/point/62/-145?summarize=mmm
/hydrology/point/62/-145?format=csv
/hydrology/point/62/-145?summarize=mmm&format=csv

```
Bad arguments to make sure no data is returned:

```
/hydrology/point/62/-145?summarize=mean
/hydrology/point/62/-145?format=xlsx
/hydrology/point/62/-145?summarize=mean&format=csv
/hydrology/point/62/-145?summarize=mmm&format=xlsx
```