### PR TITLE
Remove UTF-8 characters from CSV metadata

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -305,14 +305,10 @@ def degree_days_csv(data, endpoint):
 
     if endpoint in ["heating_degree_days", "heating_degree_days_all"]:
         filename_data_name = "Heating Degree Days"
-        metadata = (
-            "# dd is the total annual degree days below 65°F for the specified model\n"
-        )
+        metadata = "# dd is the total annual degree days below 65 (deg F) for the specified model\n"
     elif endpoint in ["degree_days_below_zero", "degree_days_below_zero_all"]:
         filename_data_name = "Degree Days Below Zero"
-        metadata = (
-            "# dd is the total annual degree days below 0°F for the specified model\n"
-        )
+        metadata = "# dd is the total annual degree days below 0 (deg F) for the specified model\n"
     elif endpoint in ["thawing_index", "thawing_index_all"]:
         filename_data_name = "Thawing Index"
         metadata = "# dd is the total annual degree days above freezing for the specified model\n"


### PR DESCRIPTION
Closes #342.

This PR replaces the last remaining `°` characters in CSV exports with our de facto standard of writing, for example, `(deg F)`. I also scanned through our `csv_functions.py` file for other special characters and found no others to fix.

So, this should make our CSV exports fairly bulletproof against Excel UTF-8 weirdness except for a handful of alternative (Indigenous) place names with special characters. I've explained in #342 why there's not necessarily a good path forward to solve this, however.