### PR TITLE
Remove extended-charset mm glyph

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -394,12 +394,12 @@ def ncar12km_indicators_csv(data):
     fieldnames = coords + values
     csv_dicts = build_csv_dicts(reordered, fieldnames, values=values)
     metadata = "# cd is the Very Cold Day Threshold. Only 5 days in a year are colder than this.\n"
-    metadata += "# cdd are Consecutive Dry Days. This is the number of consecutive days with less than 1㎜ precipitation.\n"
+    metadata += "# cdd are Consecutive Dry Days. This is the number of consecutive days with less than 1mm precipitation.\n"
     metadata += "# csdi is the Cold Spell Duration Index. This is a cold spell metric: the number of cold days (<10th percentile) occurring in a row following an initial cold spell period of six days.\n"
-    metadata += "# cwd are Consecutive Wet Days. This is the number of consecutive days with more than 1㎜ precipitation.\n"
+    metadata += "# cwd are Consecutive Wet Days. This is the number of consecutive days with more than 1mm precipitation.\n"
     metadata += "# dw are Deep Winter Days. This is the number of days with mean temperature below -30 (deg C).\n"
     metadata += "# hd is the Very Hot Day Threshold. Only 5 days in a year are warmer than this.\n"
-    metadata += "# r10mm are Heavy Precipitation Days. This is the number of individual days with 10㎜ or more precipitation.\n"
+    metadata += "# r10mm are Heavy Precipitation Days. This is the number of individual days with 10mm or more precipitation.\n"
     metadata += "# rx1day is the Maximum 1-day Precipitation. This is the maximum precipitation total for a single day in mm.\n"
     metadata += "# rx5day is the Maximum 5-day Precipitation. This is the maximum precipitation total for a 5-day period in mm.\n"
     metadata += "# su are Summer Days. This is the number of days with mean temperature above 25 (deg C).\n"


### PR DESCRIPTION
Testing:

 - Trigger a CSV download for an Indicators endpoint, such as: `localhost:5000//indicators/base/point/64.8378/-147.716?format=csv&community=AK124`

Check that there's no goofy special characters in the metadata header at the top.