### PR TITLE
Incorporate more types of Yukon areas

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -168,7 +168,7 @@ def get_poly_3338_bbox(poly_id, crs=3338):
             fetch_data(
                 [
                     generate_wfs_places_url(
-                        "all_boundaries:all_areas", "the_geom", poly_id, "id"
+                        "playground:all_areas_test5", "the_geom", poly_id, "id"
                     )
                 ]
             )

--- a/luts.py
+++ b/luts.py
@@ -52,15 +52,18 @@ snow_status = {
 
 place_type_labels = {
     "huc": "HUC",
+    "yt_watershed": "Yukon Watershed",
     "protected_area": "Protected Area",
     "borough": "Borough",
     "census_area": "Census Area",
     "fire_zone": "Fire Management Unit",
+    "yt_fire_district": "Yukon Fire District",
     "corporation": "Corporation",
     "climate_division": "Climate Division",
     "ethnolinguistic_region": "Ethnolinguistic Region",
     "first_nation": "Canadian First Nation",
     "game_management_unit": "Game Management Unit",
+    "yt_game_management_subzone": "Yukon Game Management Subzone",
 }
 
 cached_urls = [
@@ -85,12 +88,15 @@ cached_urls = [
 all_jsons = [
     "communities",
     "hucs",
+    "yt_watersheds",
     "protected_areas",
     "corporations",
     "climate_divisions",
     "ethnolinguistic_regions",
     "fire_zones",
+    "yt_fire_districts",
     "game_management_units",
+    "yt_game_management_subzones",
     "first_nations",
     "boroughs",
     "census_areas",
@@ -105,9 +111,12 @@ areas_near = {
     "corporation": "corporations_near",
     "ethnolinguistic_region": "ethnolinguistic_regions_near",
     "fire_zone": "fire_management_units_near",
+    "yt_fire_district": "yt_fire_districts_near",
     "game_management_unit": "game_management_units_near",
+    "yt_game_management_subzone": "yt_game_management_subzones_near",
     "first_nation": "ca_first_nations_near",
     "huc": "hucs_near",
+    "yt_watershed": "yt_watersheds_near",
     "protected_area": "protected_areas_near",
 }
 

--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -71,7 +71,7 @@ def find_via_gs(lat, lon):
 
     # WFS request to Geoserver for all polygon areas.
     nearby_areas = asyncio.run(
-        fetch_data([generate_wfs_search_url("all_boundaries:all_areas", lat, lon)])
+        fetch_data([generate_wfs_search_url("playground:all_areas_test5", lat, lon)])
     )["features"]
 
     # Create the JSON section for each of the area types.
@@ -126,7 +126,11 @@ def get_total_bounds(nearby_areas, communities=None):
     areas_gdf = gpd.GeoDataFrame.from_features(nearby_areas)
 
     # Make a new GeoPandas GeoDataFrome which contains only the HUCs and protected areas
-    huc_pa_gdf = areas_gdf[areas_gdf["type"].isin(["huc", "protected_area"])].copy()
+    huc_pa_gdf = areas_gdf[
+        areas_gdf["type"].isin(
+            ["huc", "protected_area", "yt_watershed", "yt_game_management_zone"]
+        )
+    ].copy()
 
     # If there were any nearby communities, we want to ensure our
     # bounding box includes them.
@@ -227,7 +231,7 @@ def get_json_for_type(type, recurse=False):
                 fetch_data(
                     [
                         generate_wfs_places_url(
-                            "all_boundaries:all_areas", "id,name,type,area_type", type
+                            "playground:all_areas_test5", "id,name,type,area_type", type
                         )
                     ]
                 )

--- a/validate_data.py
+++ b/validate_data.py
@@ -27,7 +27,7 @@ def place_name_and_type(place_id):
         fetch_data(
             [
                 generate_wfs_places_url(
-                    "all_boundaries:all_areas", "name,alt_name,type", place_id, "id"
+                    "playground:all_areas_test5", "name,alt_name,type", place_id, "id"
                 )
             ]
         )

--- a/validate_request.py
+++ b/validate_request.py
@@ -111,7 +111,11 @@ def validate_var_id(var_id):
 
     var_id_check = asyncio.run(
         fetch_data(
-            [generate_wfs_places_url("all_boundaries:all_areas", "type", var_id, "id")]
+            [
+                generate_wfs_places_url(
+                    "playground:all_areas_test5", "type", var_id, "id"
+                )
+            ]
         )
     )
 


### PR DESCRIPTION
This PR incorporates the following new Yukon areas into the API:

- Yukon Fire Districts (YTFD*)
- Yukon Game Management Subzones (YTGMA*)
- Yukon Watersheds (YTHYDRO*)

The code in this PR is currently using the `playground:all_areas_test5` layer/shapefile from GeoServer, which is the soon-to-be production layer/shapefile that includes all previous polygons + the new Yukon areas listed above. **This is to help us with testing, but we'll need to change this back to `all_boundaries:all_areas` before merging this branch into `main`, and also update that layer in GeoServer.** Once this PR is marked as approved, I'll do this cleanup work before merging.

To test:
- Boot up the API from this branch, pointed at Apollo (default)
- Go to http://localhost:5000/places/all and confirm that each of the three new Yukon area types listed above (YTFD*, YTGMA*, YTHYDRO*)  are represented in the JSON response
- Go to http://localhost:5000/places/search/62.69/-136.56 and confirm that you see each of the three new Yukon area types here too