### PR TITLE
Adds the CMIP6 indicators as a point query in data API

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """
 Configuration common to multiple routes.
 """
+
 import os
 
 GS_BASE_URL = os.getenv("API_GS_BASE_URL") or "https://gs.mapventure.org/geoserver/"
@@ -8,4 +9,5 @@ RAS_BASE_URL = os.getenv("API_RAS_BASE_URL") or "https://apollo.snap.uaf.edu/ras
 WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]
+INDICATORS_BBOX = [0, 49.94, 359.37, 90]
 WEB_APP_URL = os.getenv("WEB_APP_URL") or "https://northernclimatereports.org/"

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -44,6 +44,8 @@ def create_csv(
 
     if endpoint == "beetles":
         properties = beetles_csv(data)
+    if endpoint == "cmip6_indicators":
+        properties = cmip6_indicators_csv(data)
     elif endpoint in [
         "heating_degree_days",
         "degree_days_below_zero",
@@ -274,6 +276,26 @@ def beetles_csv(data):
 
     filename_data_name = "Climate Protection from Spruce Beetles"
     metadata = "# Values shown are for climate-related protection level from spruce beetle spread in the area.\n"
+
+    return {
+        "csv_dicts": csv_dicts,
+        "fieldnames": fieldnames,
+        "metadata": metadata,
+        "filename_data_name": filename_data_name,
+    }
+
+
+def cmip6_indicators_csv(data):
+
+    coords = ["scenario", "model", "year"]
+    values = ["dw", "ftc", "rx1day", "su"]
+    fieldnames = coords + values
+    csv_dicts = build_csv_dicts(data, fieldnames, values=values)
+    metadata = "# dw are Deep Winter Days. This is the number of days with minimum temperature below -30 (deg C).\n"
+    metadata += "# ftc are Freeze-Thaw Days. This is defined as a day where maximum daily temperature is above 0°C a given threshold and minimum daily temperature is at or below 0°C.\n"
+    metadata += "# rx1day is the Maximum 1-day Precipitation. This is the maximum precipitation total for a single day in mm.\n"
+    metadata += "# su are Summer Days. This is the number of days with maximum temperature above 25 (deg C).\n"
+    filename_data_name = "CMIP6 Indicators"
 
     return {
         "csv_dicts": csv_dicts,

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -1,6 +1,7 @@
 """
 A module of data gathering functions for use across multiple endpoints.
 """
+
 import copy
 import io
 import itertools

--- a/generate_requests.py
+++ b/generate_requests.py
@@ -1,4 +1,5 @@
 """A module to generate specific request strings."""
+
 from collections import namedtuple
 from urllib.parse import quote
 
@@ -59,7 +60,13 @@ def generate_mmm_wcs_getcov_str(x, y, cov_id, model, scenario, encoding="json"):
 
 
 def generate_wcs_getcov_str(
-    x, y, cov_id, var_coord=None, time_slice=None, encoding="json"
+    x,
+    y,
+    cov_id,
+    var_coord=None,
+    time_slice=None,
+    encoding="json",
+    projection="EPSG:3338",
 ):
     """Generate a WCS GetCoverage request for fetching a
     subset of a coverage over X and Y axes.
@@ -90,11 +97,19 @@ def generate_wcs_getcov_str(
         time_slice_str = f"&SUBSET={time_axis}({slice_string})"
     else:
         time_slice_str = ""
-    wcs_getcov_str = (
-        f"GetCoverage&COVERAGEID={cov_id}"
-        f"&SUBSET=X({x})&SUBSET=Y({y}){var_subset_str}{time_slice_str}"
-        f"&FORMAT=application/{encoding}"
-    )
+
+    if projection == "EPSG:4326":
+        wcs_getcov_str = (
+            f"GetCoverage&COVERAGEID={cov_id}"
+            f"&SUBSET=lon({x})&SUBSET=lat({y}){var_subset_str}{time_slice_str}"
+            f"&FORMAT=application/{encoding}"
+        )
+    else:
+        wcs_getcov_str = (
+            f"GetCoverage&COVERAGEID={cov_id}"
+            f"&SUBSET=X({x})&SUBSET=Y({y}){var_subset_str}{time_slice_str}"
+            f"&FORMAT=application/{encoding}"
+        )
     return wcs_getcov_str
 
 

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -12,6 +12,7 @@ nodata_values = {
 
 nodata_mappings = {
     "beetles": nodata_values["beetles"],
+    "cmip6_indicators": nodata_values["ncar12km_indicators"],
     "crrel_gipl": nodata_values["default"],
     "degree_days_below_zero": nodata_values["default"],
     "degree_days_below_zero_all": nodata_values["default"],

--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -5,7 +5,7 @@ These endpoint(s) query a coverage containing summarized versions of the indicat
 
 import asyncio
 import numpy as np
-from math import floor
+from math import floor, isnan
 from flask import Blueprint, render_template, request
 
 # local imports
@@ -118,7 +118,15 @@ def package_cmip6_indicators_data(point_data_list):
                 di[scenario][model][year] = dict()
                 for vi, value in enumerate(year_li.split(" ")):
                     indicator = cmip6_dim_encodings["indicator"][vi]
-                    di[scenario][model][year][indicator] = value
+
+                    if indicator == "rx1day":
+                        value = round(float(value), 1)
+                        if isnan(value):
+                            value = -9999
+                    # else:
+                    #     value = int(value)
+
+                    di[scenario][model][year][indicator] = int(value)
 
     return di
 
@@ -205,22 +213,22 @@ def run_fetch_cmip6_indicators_point_data(lat, lon):
             ),
             422,
         )
-    try:
-        point_data_list = asyncio.run(fetch_cmip6_indicators_point_data(lat, lon))
-        results = package_cmip6_indicators_data(point_data_list)
-        results = nullify_and_prune(results, "cmip6_indicators")
+    # try:
+    point_data_list = asyncio.run(fetch_cmip6_indicators_point_data(lat, lon))
+    results = package_cmip6_indicators_data(point_data_list)
+    results = nullify_and_prune(results, "cmip6_indicators")
 
-        if request.args.get("format") == "csv":
-            place_id = request.args.get("community")
-            return create_csv(results, "cmip6_indicators", place_id, lat, lon)
+    if request.args.get("format") == "csv":
+        place_id = request.args.get("community")
+        return create_csv(results, "cmip6_indicators", place_id, lat, lon)
 
-        return results
+    return results
 
-    except ValueError:
-        return render_template("400/bad_request.html"), 400
-    except Exception as exc:
-        if hasattr(exc, "status") and exc.status == 404:
-            return render_template("404/no_data.html"), 404
+    # except ValueError:
+    #     return render_template("400/bad_request.html"), 400
+    # except Exception as exc:
+    #     if hasattr(exc, "status") and exc.status == 404:
+    #         return render_template("404/no_data.html"), 404
 
 
 @routes.route("/indicators/base/point/<lat>/<lon>")

--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -208,6 +208,12 @@ def run_fetch_cmip6_indicators_point_data(lat, lon):
     try:
         point_data_list = asyncio.run(fetch_cmip6_indicators_point_data(lat, lon))
         results = package_cmip6_indicators_data(point_data_list)
+        results = nullify_and_prune(results, "cmip6_indicators")
+
+        if request.args.get("format") == "csv":
+            place_id = request.args.get("community")
+            return create_csv(results, "cmip6_indicators", place_id, lat, lon)
+
         return results
 
     except ValueError:

--- a/templates/documentation/indicators.html
+++ b/templates/documentation/indicators.html
@@ -14,7 +14,67 @@
 
 <h3>Service endpoints</h3>
 
-<h4>All climate indicator variables</h4>
+<h4>CMIP6 climate indicator variables</h4>
+
+<p>
+  Query CMIP6 climate indicator variables for all models and scenarios.
+</p>
+
+<table class="endpoints">
+  <thead>
+    <tr>
+      <th class="endpoint-label">Endpoint</th>
+      <th class="endpoint-url">Example URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Annual mean values for all climate indicator variables at a given latitude and longitude.</td>
+      <td>
+        <a href="/indicators/cmip6/point/61.5/247">/indicators/cmip6/point/61.5/247</a>
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL. <br />
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<h4>Output</h4>
+
+<p>Results from point and area queries will look like this:</p>
+
+<pre>
+{
+  "historical": {
+    EC-Earth3-Veg": {
+      "1850": {
+        "dw": 71,
+        "ftc": 23,
+        "rx1day": 9,
+        "su": 0
+      },
+      1851": {
+        "dw": 239,
+        "ftc": 0,
+        "rx1day": 7,
+        "su": 0
+      },
+      ...
+    },
+    ...
+  },
+...
+}
+
+</pre>
+
+<h4>NCAR climate indicator variables</h4>
 
 <p>
   Query min-mean-max climate indicator variables for all models and scenarios.
@@ -34,6 +94,7 @@
         <a href="/indicators/base/point/61.5/-147">/indicators/base/point/61.5/-147</a>
       </td>
     </tr>
+    <tr>
     <td>Era-based min-mean-max for all climate indicator variables for a specific area</td>
     <td>
       <a href="/indicators/base/area/1903040601">/indicators/base/area/1903040601</a>
@@ -50,7 +111,7 @@
   </tfoot>
 </table>
 
-<h3>Output</h3>
+<h4>Output</h4>
 
 <p>Results from point and area queries will look like this:</p>
 

--- a/validate_request.py
+++ b/validate_request.py
@@ -7,7 +7,7 @@ import asyncio
 from flask import render_template
 from pyproj import Transformer
 import numpy as np
-from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX
+from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX, INDICATORS_BBOX
 from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
 
@@ -52,6 +52,30 @@ def validate_seaice_latlon(lat, lon):
 
     # Validate against two different BBOXes to deal with antimeridian issues
     for bbox in [SEAICE_BBOX]:
+        valid_lat = bbox[1] <= lat_float <= bbox[3]
+        valid_lon = bbox[0] <= lon_float <= bbox[2]
+        if valid_lat and valid_lon:
+            return True
+
+    return 422
+
+
+def validate_cmip6_indicators_latlon(lat, lon):
+    """Validate the lat and lon values for Arctic CMIP6 indicator data.
+    Return True if valid or HTTP status code if validation failed
+    """
+    try:
+        lat_float = float(lat)
+        lon_float = float(lon)
+    except:
+        return 400  # HTTP status code
+    lat_in_world = -90 <= lat_float <= 90
+    lon_in_world = 0 <= lon_float <= 360
+    if not lat_in_world or not lon_in_world:
+        return 400  # HTTP status code
+
+    # Validate against two different BBOXes to deal with antimeridian issues
+    for bbox in [INDICATORS_BBOX]:
         valid_lat = bbox[1] <= lat_float <= bbox[3]
         valid_lon = bbox[0] <= lon_float <= bbox[2]
         if valid_lat and valid_lon:


### PR DESCRIPTION
This PR adds the CMIP6 indicator data available in Rasdaman as a new endpoint in the indicators endpoint.

To access the new indicators endpoint, you can request a point location by specifying a latitude and longitude where longitude is specified as 0-360° like: [http://localhost:5000/indicators/cmip6/point/61.5/247](http://localhost:5000/indicators/cmip6/point/61.5/247)

This update contains the ability to generate a CSV document of the returned data as well such as: [http://localhost:5000/indicators/cmip6/point/61.5/247?format=csv](http://localhost:5000/indicators/cmip6/point/61.5/247?format=csv)

Finally, there is some additional documentation that highlights the new CMIP6 indicators that have been added to the top of the indicators documentation at: [http://localhost:5000/indicators/](http://localhost:5000/indicators/). 

Please let me know if you think there is anything missing or that I should change!