### PR TITLE
Adds map to API 422 returns for invalid latitude / longitude requests and shows the described bounding box on the map.

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -32,3 +32,8 @@ th.endpoint-url {
 table.data-source th {
 	white-space: nowrap;
 }
+
+#map {
+	height: 400px;
+	width: 400px;
+}

--- a/templates/422/invalid_latlon.html
+++ b/templates/422/invalid_latlon.html
@@ -30,9 +30,7 @@
     var map = L.map('map', {zoomControl: false, scrollWheelZoom: false}).setView([61.0, -151.505], 5);
     map.attributionControl.setPrefix('');
     
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        maxZoom: 19,
-    }).addTo(map);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 
     var southWest = L.latLng(51.3492, -187.5799),
         northEast = L.latLng(71.3694, -122.8098),

--- a/templates/422/invalid_latlon.html
+++ b/templates/422/invalid_latlon.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
 <h3>Invalid coordinates</h3>
+
+<div id="map"></div>
+
 <p>
   Provided coordinates are outside of the valid range. Coordinates must be
   within one of the following two bounding boxes depending on which side of the
@@ -20,4 +23,23 @@
 <p>
   <strong>Longitude:</strong> <code>{{ east_bbox[0] }}</code> to <code>{{ east_bbox[2] }}</code>
 </p>
+
+
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+<script>
+    var map = L.map('map', {zoomControl: false, scrollWheelZoom: false}).setView([61.0, -151.505], 5);
+    map.attributionControl.setPrefix('');
+    
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+    }).addTo(map);
+
+    var southWest = L.latLng(51.3492, -187.5799),
+        northEast = L.latLng(71.3694, -122.8098),
+        bounds = L.latLngBounds(southWest, northEast);
+
+    L.rectangle(bounds, {color: "#DDDDDD", weight: 3}).addTo(map);
+
+    map.fitBounds(bounds);
+</script>
 {% endblock %}

--- a/templates/422/invalid_latlon.html
+++ b/templates/422/invalid_latlon.html
@@ -36,7 +36,7 @@
         northEast = L.latLng(71.3694, -122.8098),
         bounds = L.latLngBounds(southWest, northEast);
 
-    L.rectangle(bounds, {color: "#DDDDDD", weight: 3}).addTo(map);
+    L.rectangle(bounds, {color: "#F1891E", weight: 3}).addTo(map);
 
     map.fitBounds(bounds);
 </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
 <head>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <title>Alaska + Arctic Geospatial Data API</title>
 </head>
 


### PR DESCRIPTION
This PR adds a simple Leaflet map to the API's 422 HTTP code returns when an invalid latitude / longitude has been requested. The map has the bounding box that is described in the returned page to more quickly highlight where our data boundaries are for our point based queries.

An example of this error can be found at: http://localhost:5000/temperature/point/80.0628/-146.162

Note: The color of the bounding box may need to be adjusted to be more visible, but let me know if you think that is the case.

Closes #420 