### PR TITLE
Degree days: replace all instances of "historical" with "modeled baseline"

### DIFF
--- a/templates/documentation/degree_days.html
+++ b/templates/documentation/degree_days.html
@@ -4,7 +4,7 @@
 <p>
   These endpoints provide access to historical and modeled total annual
   cumulative degree days for several different degree day thresholds at a
-  spatial resolution of 12 km. Historical data were derived from a Daymet
+  spatial resolution of 12 km. Modeled baseline data were derived from a Daymet
   dataset and are available for years 1980&ndash;2017. Modeled data were derived
   from bias corrected and downscaled CMIP5 climate models using RCP 4.5 and RCP
   8.5 emissions scenarios. Model outputs are available for years
@@ -23,8 +23,8 @@
 
 <p>
   Query degree days for all models, scenarios, and years. Included years are
-  between 1980&ndash;2017 for historical baseline data and 1950&ndash;2009 for
-  modeled data.
+  between 1980&ndash;2017 for modeled baseline baseline data and 1950&ndash;2009
+  for modeled data.
 </p>
 
 <table class="endpoints">
@@ -71,8 +71,8 @@
   <tfoot>
     <tr>
       <td colspan="2">
-        Min/mean/max summaries of historical and modeled years are available by
-        appending
+        Min/mean/max summaries of modeled baseline and modeled years are
+        available by appending
         <code>?summarize=mmm</code> to the URL.<br />
         CSV output is also available by appending <code>?format=csv</code> to
         the URL.
@@ -85,8 +85,8 @@
 
 <p>
   Query degree days values for the specified year range. Valid year ranges are
-  between 1980&ndash;2017 for historical data and 1950&ndash;2099 for modeled
-  data.
+  between 1980&ndash;2017 for modeled baseline data and 1950&ndash;2099 for
+  modeled data.
 </p>
 
 <table class="endpoints">
@@ -133,8 +133,8 @@
   <tfoot>
     <tr>
       <td colspan="2">
-        Min/mean/max summaries of historical and projected years are available
-        by appending <code>?summarize=mmm</code> to the URL.<br />
+        Min/mean/max summaries of modeled baseline and projected years are
+        available by appending <code>?summarize=mmm</code> to the URL.<br />
         CSV output is also available by appending <code>?format=csv</code> to
         the URL.
       </td>
@@ -151,7 +151,7 @@
 <pre>
 {
   "daymet": {
-    "historical": {
+    "modeled baseline": {
       "1980": {
         "dd:" 15810,
       },
@@ -189,7 +189,7 @@
 
 <pre>
 {
-  "historical": {
+  "modeled baseline": {
     "ddmax": 16197,
     "ddmean": 14291,
     "ddmin": 12627
@@ -202,7 +202,7 @@
 
 <pre>
 {
-  &lt;"historical" or "projected"&gt;: {
+  &lt;"modeled baseline" or "projected"&gt;: {
     "ddmax": &lt;max dd value across all models, scenarios, and years&gt;,
     "ddmean": &lt;mean dd value across all models, scenarios, and years&gt;,
     "ddmin": &lt;min dd value across all models, scenarios, and years&gt;

--- a/templates/documentation/degree_days.html
+++ b/templates/documentation/degree_days.html
@@ -2,14 +2,14 @@
 <h2>Degree Days</h2>
 
 <p>
-  These endpoints provide access to historical and modeled total annual
-  cumulative degree days for several different degree day thresholds at a
-  spatial resolution of 12 km. Modeled baseline data were derived from a Daymet
-  dataset and are available for years 1980&ndash;2017. Modeled data were derived
-  from bias corrected and downscaled CMIP5 climate models using RCP 4.5 and RCP
-  8.5 emissions scenarios. Model outputs are available for years
-  1950&ndash;2099. Data can be accessed for individual years or for minimum,
-  mean, and maximum summaries across all historical or modeled years.
+  These endpoints provide access to total annual cumulative degree days for
+  several different degree day thresholds at a spatial resolution of 12 km.
+  Modeled baseline data were derived from a Daymet dataset and are available for
+  years 1980&ndash;2017. Modeled data were derived from bias corrected and
+  downscaled CMIP5 climate models using RCP 4.5 and RCP 8.5 emissions scenarios.
+  Model outputs are available for years 1950&ndash;2099. Data can be accessed
+  for individual years or for minimum, mean, and maximum summaries across all
+  historical or modeled years.
 </p>
 
 <p>

--- a/templates/documentation/degree_days.html
+++ b/templates/documentation/degree_days.html
@@ -151,7 +151,7 @@
 <pre>
 {
   "daymet": {
-    "modeled baseline": {
+    "modeled_baseline": {
       "1980": {
         "dd:" 15810,
       },
@@ -189,7 +189,7 @@
 
 <pre>
 {
-  "modeled baseline": {
+  "modeled_baseline": {
     "ddmax": 16197,
     "ddmean": 14291,
     "ddmin": 12627
@@ -202,7 +202,7 @@
 
 <pre>
 {
-  &lt;"modeled baseline" or "projected"&gt;: {
+  &lt;"modeled_baseline" or "projected"&gt;: {
     "ddmax": &lt;max dd value across all models, scenarios, and years&gt;,
     "ddmean": &lt;mean dd value across all models, scenarios, and years&gt;,
     "ddmin": &lt;min dd value across all models, scenarios, and years&gt;

--- a/templates/documentation/degree_days.html
+++ b/templates/documentation/degree_days.html
@@ -23,7 +23,7 @@
 
 <p>
   Query degree days for all models, scenarios, and years. Included years are
-  between 1980&ndash;2017 for modeled baseline baseline data and 1950&ndash;2009
+  between 1980&ndash;2017 for modeled baseline data and 1950&ndash;2009
   for modeled data.
 </p>
 


### PR DESCRIPTION
This PR is motivated by Arctic-EDS feedback that "historical" in the context of "historical modeled data" was causing the audience (engineers) to stub their toes. Generally this audience is less familiar with climate model data and they interpreted the "historical" label as "historical data must match observed station data."  

We're using the phrase "modeled baseline" instead.

To test this PR, make sure your API is pointing toward Zeus.

Then try some of the routes [listed here](https://github.com/ua-snap/data-api/pull/428) and verify that keys and labels all read "modeled baseline". This key is often nested under "daymet".

Also review the documentation template to verify that the references to "historical" data are also updated: http://localhost:5000/degree_days/

This PR also removes some commented-out code that was leftover from development that wasn't caught in the first iteration.
