### PR TITLE
Remove erroneous scenario column from degree days mmm summary CSVs

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -290,7 +290,7 @@ def degree_days_csv(data, endpoint):
         "air_thawing_index_Fdays",
         "air_freezing_index_Fdays",
     ]:
-        coords = ["model", "scenario"]
+        coords = ["model"]
         values = ["ddmin", "ddmean", "ddmax"]
     elif endpoint in [
         "heating_degree_days_Fdays_all",


### PR DESCRIPTION
Closes #432.

This PR fixes the issue described in issue #432. To test, try each of the URLs in #432 and make sure the bad `scenarios` column has been removed from the CSVs. You may need to use a different browser or a private window to see the difference if you have visited the same URLs recently. Chrome caches CSV downloads very aggressively! Not sure about other browsers.

Also, spot check some non-mmm degree days CSV URLs to make sure this change didn't impact those. They look good to me, though.