### PR TITLE
Splash page for when the data API is offline

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from flask import Flask, render_template, send_from_directory
 from flask_cors import CORS
+from config import OFFLINE_SITE
 
 from routes import *
 
@@ -30,7 +31,7 @@ def add_cache_control(response):
 @app.route("/")
 def index():
     """Render index page"""
-    return render_template("index.html")
+    return render_template("index.html", OFFLINE_SITE=OFFLINE_SITE)
 
 
 @app.route("/robots.txt")

--- a/application.py
+++ b/application.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from flask import Flask, render_template, send_from_directory
 from flask_cors import CORS
-from config import OFFLINE_SITE
+from config import SITE_OFFLINE
 
 from routes import *
 
@@ -31,7 +31,7 @@ def add_cache_control(response):
 @app.route("/")
 def index():
     """Render index page"""
-    return render_template("index.html", OFFLINE_SITE=OFFLINE_SITE)
+    return render_template("index.html", SITE_OFFLINE=SITE_OFFLINE)
 
 
 @app.route("/robots.txt")

--- a/config.py
+++ b/config.py
@@ -10,4 +10,4 @@ WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]
 WEB_APP_URL = os.getenv("WEB_APP_URL") or "https://northernclimatereports.org/"
-OFFLINE_SITE = os.getenv("OFFLINE_SITE") or False
+SITE_OFFLINE = os.getenv("SITE_OFFLINE") or False

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """
 Configuration common to multiple routes.
 """
+
 import os
 
 GS_BASE_URL = os.getenv("API_GS_BASE_URL") or "https://gs.mapventure.org/geoserver/"
@@ -9,3 +10,4 @@ WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]
 WEB_APP_URL = os.getenv("WEB_APP_URL") or "https://northernclimatereports.org/"
+OFFLINE_SITE = os.getenv("OFFLINE_SITE") or False

--- a/static/style.css
+++ b/static/style.css
@@ -37,3 +37,8 @@ table.data-source th {
 	height: 400px;
 	width: 400px;
 }
+
+.offline {
+	border: 0.1px solid #888;
+	background-color: #E7B69A;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %} {% block content %} {% if not OFFLINE_SITE %}
+{% extends 'base.html' %} {% block content %} {% if not SITE_OFFLINE %}
 <h3>Introduction</h3>
 <p>
   Welcome to SNAP&rsquo;s data API, your gateway to seamless connectivity
@@ -60,7 +60,7 @@
   <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International (CC by 4.0)</a>.
 </p>
 {% endif %}
-{% if OFFLINE_SITE %}
+{% if SITE_OFFLINE %}
 <h3>SNAP's Data API offline for maintenance</h3>
 <p>
   We're sorry!  SNAP's Data API is currently offline for system maintenance.  We're working to complete this maintenance and have SNAP's Data API back online as soon as possible, but we don't have an estimated time for completion.  Please check back soon, or reach out to us at uaf-snap-data-tools@alaska.edu with questions.

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,9 +61,13 @@
 </p>
 {% endif %}
 {% if SITE_OFFLINE %}
-<h3>SNAP's Data API offline for maintenance</h3>
-<p>
-  We're sorry!  SNAP's Data API is currently offline for system maintenance.  We're working to complete this maintenance and have SNAP's Data API back online as soon as possible, but we don't have an estimated time for completion.  Please check back soon, or reach out to us at uaf-snap-data-tools@alaska.edu with questions.
-</p>
+<div class="offline mx-6 my-6 px-6 py-6">
+  <h3 class="title is-3">SNAP Data API offline for maintenance</h3>
+  <div class="content is-size-4">
+    <p>
+      We&rsquo;re sorry!  The SNAP Data API is currently offline for system maintenance.  We&rsquo;re working to complete this maintenance and have the SNAP Data API back online as soon as possible, but we don&rsquo;t have an estimated time for completion.  Please check back soon, or reach out to us at <a href="mailto:uaf-snap-data-tools@alaska.edu">uaf-snap-data-tools@alaska.edu</a> with questions.
+    </p>
+  </div>
+</div>
 {% endif %}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %} {% block content %}
+{% extends 'base.html' %} {% block content %} {% if not OFFLINE_SITE %}
 <h3>Introduction</h3>
 <p>
   Welcome to SNAP&rsquo;s data API, your gateway to seamless connectivity
@@ -59,4 +59,11 @@
   through this tool is available through the
   <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International (CC by 4.0)</a>.
 </p>
+{% endif %}
+{% if OFFLINE_SITE %}
+<h3>SNAP's Data API offline for maintenance</h3>
+<p>
+  We're sorry!  SNAP's Data API is currently offline for system maintenance.  We're working to complete this maintenance and have SNAP's Data API back online as soon as possible, but we don't have an estimated time for completion.  Please check back soon, or reach out to us at uaf-snap-data-tools@alaska.edu with questions.
+</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This PR makes an environment variable available called OFFLINE_SITE is made available to show an "Under Maintenance" page when our data API's backend is offline.

To test:
export SITE_OFFLINE=True
pipenv run flask run

http://localhost:5000

Expected: You should see the "peech" colored message stating our data API is offline for maintenance.