### PR TITLE
Adds a decorator to all routes that redirects to the root of the site ('/') if SITE_OFFLINE is True.

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,6 +1,20 @@
-from flask import Blueprint
+import os
+from flask import Blueprint, redirect, request
 
 routes = Blueprint("routes", __name__)
+
+
+def check_site_offline():
+    site_offline = os.environ.get("SITE_OFFLINE", "").lower() == "true"
+    if site_offline:
+        return redirect("/")
+
+
+# Applies a decorator to all routes to check for the SITE_OFFLINE environment variable.
+@routes.before_request
+def enforce_site_offline():
+    return check_site_offline()
+
 
 from .fire import *
 from .permafrost import *

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,5 +1,5 @@
 import os
-from flask import Blueprint, redirect, request
+from flask import Blueprint, redirect
 
 routes = Blueprint("routes", __name__)
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,12 +1,12 @@
 import os
 from flask import Blueprint, redirect
+from config import SITE_OFFLINE
 
 routes = Blueprint("routes", __name__)
 
 
 def check_site_offline():
-    site_offline = os.environ.get("SITE_OFFLINE", "").lower() == "true"
-    if site_offline:
+    if SITE_OFFLINE:
         return redirect("/")
 
 


### PR DESCRIPTION
This is a simple PR for forcing all of the routes to redirect to '/' when the SITE_OFFLINE environment variable is set to True. 

To test this:
- Verify that the site works as expected when the SITE_OFFLINE variable is unset
- export SITE_OFFLINE=True & verify that the site shows the maintenance notice when going to http://localhost:5000
- Try to go to any of the routes to verify a redirect to the site offline message:
http://localhost:5000/temperature/
http://localhost:5000/indicators/