### PR TITLE
Adds AQI and PM2.5 concentration forecasts to the /fire endpoint

### DIFF
--- a/luts.py
+++ b/luts.py
@@ -28,7 +28,7 @@ landcover_names = {
 }
 smokey_bear_names = {
     1: "Low",
-    2: "Medium",
+    2: "Moderate",
     3: "High",
     4: "Very High",
     5: "Extreme",

--- a/routes/fire.py
+++ b/routes/fire.py
@@ -143,7 +143,6 @@ def run_fetch_fire(lat, lon):
             return render_template("404/no_data.html"), 404
         return render_template("500/server_error.html"), 500
 
-    print(results)
     landcover = package_landcover(results[0])
     firedanger = package_fire_danger(results[1])
     snow = package_snow(results[2])

--- a/routes/fire.py
+++ b/routes/fire.py
@@ -19,8 +19,24 @@ wms_targets = [
     "spruceadj_3338",
     "snow_cover_3338",
     "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
+    "aqi_forecast_6_hrs",
+    "aqi_forecast_12_hrs",
+    "aqi_forecast_24_hrs",
+    "aqi_forecast_48_hrs",
 ]
 wfs_targets = {"historical_fire_perimiters": "NAME,FIREYEAR"}
+
+
+def package_aqi_forecast(aqi_forecast_resp):
+    """Package AQI forecast data in dict"""
+    if aqi_forecast_resp["features"] == []:
+        return None
+    pm25_conc = aqi_forecast_resp["features"][0]["properties"]["PM2.5_Concentration"]
+    aqi = aqi_forecast_resp["features"][0]["properties"]["AQI"]
+    if pm25_conc is None or aqi is None:
+        return None
+    di = {"pm25_conc": round(pm25_conc), "aqi": round(aqi)}
+    return di
 
 
 def package_fire_history(fihist_resp):
@@ -127,17 +143,26 @@ def run_fetch_fire(lat, lon):
             return render_template("404/no_data.html"), 404
         return render_template("500/server_error.html"), 500
 
+    print(results)
     landcover = package_landcover(results[0])
     firedanger = package_fire_danger(results[1])
     snow = package_snow(results[2])
     relflammability = package_flammability(results[3])
-    firehist = package_fire_history(results[4])
+    aqi_forecast_6_hrs = package_aqi_forecast(results[4])
+    aqi_forecast_12_hrs = package_aqi_forecast(results[5])
+    aqi_forecast_24_hrs = package_aqi_forecast(results[6])
+    aqi_forecast_48_hrs = package_aqi_forecast(results[7])
+    firehist = package_fire_history(results[8])
 
     data = {
         "lc": landcover,
         "is_snow": snow,
         "cfd": firedanger,
         "hist_fire": firehist,
+        "aqi_6": aqi_forecast_6_hrs,
+        "aqi_12": aqi_forecast_12_hrs,
+        "aqi_24": aqi_forecast_24_hrs,
+        "aqi_48": aqi_forecast_48_hrs,
         "prf": relflammability,
     }
 

--- a/templates/documentation/fire.html
+++ b/templates/documentation/fire.html
@@ -97,19 +97,19 @@
 {
   "aqi_12": {
     "aqi": &lt;numeric air quality index value&gt;,
-    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+    "pm25_conc": &lt;numeric PM2.5 concentration in &micro;g/m&sup3;&gt;
   },
   "aqi_24": {
     "aqi": &lt;numeric air quality index value&gt;,
-    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+    "pm25_conc": &lt;numeric PM2.5 concentration in &micro;g/m&sup3;&gt;
   },
   "aqi_48": {
     "aqi": &lt;numeric air quality index value&gt;,
-    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+    "pm25_conc": &lt;numeric PM2.5 concentration in &micro;g/m&sup3;&gt;
   },
   "aqi_6": {
     "aqi": &lt;numeric air quality index value&gt;,
-    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+    "pm25_conc": &lt;numeric PM2.5 concentration in &micro;g/m&sup3;&gt;
   },
   "cfd": {
     "code": &lt;numeric fire danger rating, range 1 through 5&gt;,

--- a/templates/documentation/fire.html
+++ b/templates/documentation/fire.html
@@ -11,7 +11,7 @@
     <li>Land cover types from 2015 were provided by the North American Land Change Monitoring System at a resolution of 30m.</li>
     <li>Historical fires from 1940&ndash;2021 were provided by the Alaska Interagency Coordination Center (AICC).</li>
     <li>Flammability projections are summarized across years 2000&ndash;2099 and were provided by ALFRESCO model outputs, simulated with the CRU TS 4.0 dataset (2000&ndash;2015) and NCAR-CCSM4 model outputs using the RCP 8.5 emissions scenario (2016&ndash;2099).</li>
-    <li>PM2.5 Concentration and AQI are model forecasts run by NASA once every 6 hours and available from the <a href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">GMAO GEOS NRT Data Products webpage</a>.</li>
+    <li>PM2.5 Concentration are model forecasts run by NASA once every 6 hours and available from the <a href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">GMAO GEOS NRT Data Products webpage</a>.  AQI is derived from these data once per day, using the 0th hour PM2.5 concentration.</li>
   </ul>
 </p>
 

--- a/templates/documentation/fire.html
+++ b/templates/documentation/fire.html
@@ -11,6 +11,7 @@
     <li>Land cover types from 2015 were provided by the North American Land Change Monitoring System at a resolution of 30m.</li>
     <li>Historical fires from 1940&ndash;2021 were provided by the Alaska Interagency Coordination Center (AICC).</li>
     <li>Flammability projections are summarized across years 2000&ndash;2099 and were provided by ALFRESCO model outputs, simulated with the CRU TS 4.0 dataset (2000&ndash;2015) and NCAR-CCSM4 model outputs using the RCP 8.5 emissions scenario (2016&ndash;2099).</li>
+    <li>PM2.5 Concentration and AQI are model forecasts run by NASA once every 6 hours and available from the <a href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">GMAO GEOS NRT Data Products webpage</a>.</li>
   </ul>
 </p>
 
@@ -47,6 +48,22 @@
 
 <pre>
 {
+  "aqi_12": {
+    "aqi": 14,
+    "pm25_conc": 3
+  },
+  "aqi_24": {
+    "aqi": 10,
+    "pm25_conc": 2
+  },
+  "aqi_48": {
+    "aqi": 15,
+    "pm25_conc": 4
+  },
+  "aqi_6": {
+    "aqi": 6,
+    "pm25_conc": 1
+  },
   "cfd": {
     "code": 1,
     "color": "#2b83ba",
@@ -78,6 +95,22 @@
 
 <pre>
 {
+  "aqi_12": {
+    "aqi": &lt;numeric air quality index value&gt;,
+    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+  },
+  "aqi_24": {
+    "aqi": &lt;numeric air quality index value&gt;,
+    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+  },
+  "aqi_48": {
+    "aqi": &lt;numeric air quality index value&gt;,
+    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+  },
+  "aqi_6": {
+    "aqi": &lt;numeric air quality index value&gt;,
+    "pm25_conc": &lt;numeric PM2.5 concentration&gt;
+  },
   "cfd": {
     "code": &lt;numeric fire danger rating, range 1 through 5&gt;,
     "color": &lt;hex color code to visualize fire danger&gt;,
@@ -145,7 +178,12 @@
           href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">Flammability</a>
       </td>
       <td>Johnstone, J. F., Rupp, T. S., Olson, M. A., & Verbyla, D. L. (2011). Modeling impacts of fire severity on successional trajectories and future fire behavior in Alaskan boreal forests. <i>Landscape Ecology, 26</i>(4), 487&ndash;500. <a href="https://doi.org/10.1007/s10980-011-9574-6">https://doi.org/10.1007/s10980-011-9574-6</a></td>
-      
+    </tr>
+    <tr>
+      <td><a href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">
+          PM2.5 Concentration and AQI
+      </a></td>
+      <td>The GEOS data used in this project have been provided by the Global Modeling and Assimilation Office (GMAO) at NASA Goddard Space Flight Center through the online data portal in the NASA Center for Climate Simulation.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR adds the AQI and PM2.5 concentration forecasts to the /wildfire/point endpoint. This is used by the Alaska Wildfire Explorer to show the values for a given point that is selected either via community name or lat / lng.

Example: http://localhost:5000/fire/point/65.0628/-146.1627