### PR TITLE
Demographics

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -90,6 +90,8 @@ def create_csv(
         properties = wet_days_per_year_csv(data, endpoint)
     elif endpoint in ["hydrology", "hydrology_mmm"]:
         properties = hydrology_csv(data, endpoint)
+    elif endpoint == "demographics":
+        properties = demographics_csv(data)
 
     else:
         return render_template("500/server_error.html"), 500
@@ -945,3 +947,6 @@ def hydrology_csv(data, endpoint):
             "metadata": metadata,
             "filename_data_name": filename_data_name,
         }
+
+def demographics_csv(data):
+    return data

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -107,7 +107,7 @@ def create_csv(
         filename += " for "
         if place_name is not None:
             filename += quote(place_name)
-        if endpoint == "demographics":
+        elif endpoint == "demographics":
             filename += quote("All communities in Alaska")
         else:
             filename += lat + ", " + lon
@@ -955,7 +955,7 @@ def hydrology_csv(data, endpoint):
 def demographics_csv(data):
     coords = ["id"]
     values = [
-        "name", "comment", "total_population", "pct_under_18", "pct_65_plus", 
+        "name", "comment", "total_population", "pct_under_18", "pct_under_5", "pct_65_plus", 
         "pct_minority", "pct_african_american", "pct_amer_indian_ak_native", "pct_asian", "pct_hawaiian_pacislander", "pct_hispanic_latino", "pct_white", "pct_multi", "pct_other",
         "pct_asthma", "pct_copd", "pct_diabetes", "pct_hd", "pct_kd", "pct_stroke",
         "pct_w_disability", "moe_pct_w_disability", "pct_insured", "moe_pct_insured", "pct_uninsured", "moe_pct_uninsured",
@@ -969,6 +969,7 @@ def demographics_csv(data):
     metadata += "# comment is the comment regarding data source\n"
     metadata += "# total_population is the total population of community\n"
     metadata += "# pct_under_18 is the percentage of population under age 18\n"
+    metadata += "# pct_under_5 is the percentage of population under age 5\n"
     metadata += "# pct_65_plus is the percentage of population age 65 and older\n"
     metadata += "# pct_minority is the percentage of population of racial or ethnic minority status\n"
     metadata += "# pct_african_american is the percentage of population African American\n"

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -949,4 +949,53 @@ def hydrology_csv(data, endpoint):
         }
 
 def demographics_csv(data):
-    return data
+    coords = ["id"]
+    values = [
+        "name", "comment", "total_population", "pct_under_18", "pct_65_plus", 
+        "pct_minority", "pct_african_american", "pct_amer_indian_ak_native", "pct_asian", "pct_hawaiian_pacislander", "pct_hispanic_latino", "pct_white", "pct_multi", "pct_other",
+        "pct_asthma", "pct_copd", "pct_diabetes", "pct_hd", "pct_kd", "pct_stroke",
+        "pct_w_disability", "moe_pct_w_disability", "pct_insured", "moe_pct_insured", "pct_uninsured", "moe_pct_uninsured",
+        "pct_no_bband", "pct_no_hsdiploma", "pct_below_150pov",
+    ]
+    fieldnames = coords + values
+    csv_dicts = build_csv_dicts(data, fieldnames, values=values)
+
+    metadata = "# Demographic data for individual communities plus the state of Alaska and United States\n"
+    metadata += "# name is the community name\n"
+    metadata += "# comment is the comment regarding data source\n"
+    metadata += "# total_population is the total population of community\n"
+    metadata += "# pct_under_18 is the percentage of population under age 18\n"
+    metadata += "# pct_65_plus is the percentage of population age 65 and older\n"
+    metadata += "# pct_minority is the percentage of population of racial or ethnic minority status\n"
+    metadata += "# pct_african_american is the percentage of population African American\n"
+    metadata += "# pct_amer_indian_ak_native is the percentage of population American Indian or Alaska Native\n"
+    metadata += "# pct_asian is the percentage of population Asian\n"
+    metadata += "# pct_hawaiian_pacislander is the percentage of population Native Hawaiian and Pacific Islander\n"
+    metadata += "# pct_hispanic_latino is the percentage of population Hispanic or Latino\n"
+    metadata += "# pct_white is the percentage of population White\n"
+    metadata += "# pct_multi is the percentage of population two or more races\n"
+    metadata += "# pct_other is the percentage of population other race\n"
+    metadata += "# pct_asthma is the percentage of of adults aged >=18 years with current asthma\n"
+    metadata += "# pct_copd is the percentage of of adults aged >=18 years with chronic obstructive pulmonary disease\n"
+    metadata += "# pct_diabetes is the percentage of of adults aged >=18 years with diagnosed diabetes\n"
+    metadata += "# pct_hd is the percentage of of adults aged >=18 years with coronary heart disease\n"
+    metadata += "# pct_kd is the percentage of of adults aged >=18 years with chronic kidney disease\n"
+    metadata += "# pct_stroke is the percentage of of adults aged >=18 years with stroke\n"
+    metadata += "# pct_w_disability is the percentage of population with a disability\n"
+    metadata += "# moe_pct_w_disability is the margin of error for percentage of population with a disability\n"
+    metadata += "# pct_insured is the percentage of population with health insurance\n"
+    metadata += "# moe_pct_insured is the margin of error percentage of population with health insurance\n"
+    metadata += "# pct_uninsured is the percentage of population without health insurance\n"
+    metadata += "# moe_pct_uninsured is the margin of error percentage of population without health insurance\n"
+    metadata += "# pct_no_bband is the percentage of households with no broadband internet subscription\n"
+    metadata += "# pct_no_hsdiploma is the percentage of adults aged >=25 years with no high school diploma\n"
+    metadata += "# pct_below_150pov is the percentage of population living below 150% of the poverty level\n"
+
+    filename_data_name = "Demographic Data - "
+
+    return {
+            "csv_dicts": csv_dicts,
+            "fieldnames": fieldnames,
+            "metadata": metadata,
+            "filename_data_name": filename_data_name,
+        }

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -107,6 +107,8 @@ def create_csv(
         filename += " for "
         if place_name is not None:
             filename += quote(place_name)
+        if endpoint == "demographics":
+            filename += quote("All communities in Alaska")
         else:
             filename += lat + ", " + lon
     filename += ".csv"
@@ -130,11 +132,13 @@ def csv_metadata(place_name=None, place_id=None, place_type=None, lat=None, lon=
         Multiline metadata string
     """
     metadata = "# Location: "
-    if place_name is None:
+    if place_name is None and lat is not None and lon is not None:
         metadata += lat + " " + lon + "\n"
         # if lat and lon and type huc12, then it's a local / point-to-huc query
         if place_type == "huc12":
             metadata += "# Corresponding HUC12 code: " + place_id + "\n"
+    elif place_name is None and lat is None and lon is None:
+        metadata += "All communities Alaska\n" # this covers the demographic request for "all"
     elif place_type == "community":
         metadata += place_name + "\n"
     else:

--- a/luts.py
+++ b/luts.py
@@ -111,7 +111,7 @@ areas_near = {
     "protected_area": "protected_areas_near",
 }
 
-# table to decode field names for demographic data
+# table to decode field names for demographic data from GeoServer
 # fields that were not truncated do not appear here
 # see data dictionary in the repo for more info: https://github.com/ua-snap/epa-justice/blob/main/README.md
 demographics_fields = {
@@ -130,7 +130,7 @@ demographics_fields = {
     "pct_no_bba": "pct_no_bband",
     "pct_no_hsd": "pct_no_hsdiploma",
     "pct_under_": "pct_under_18",
-    "":"pct_under_5", # TODO: add truncated dict key when GeoServer demographics file is updated!
+    "pct_unde_1": "pct_under_5",
     "pct_uninsu": "pct_uninsured",
     "pct_w_disa": "pct_w_disability",
     "total_popu": "total_population",

--- a/luts.py
+++ b/luts.py
@@ -110,3 +110,27 @@ areas_near = {
     "huc": "hucs_near",
     "protected_area": "protected_areas_near",
 }
+
+# table to decode field names for demographic data
+# fields that were not truncated do not appear here
+# see data dictionary in the repo for more info: https://github.com/ua-snap/epa-justice/blob/main/README.md
+demographics_fields = {
+    "moe_pct_in": "moe_pct_insured",
+    "moe_pct_un": "moe_pct_uninsured",
+    "moe_pct_w_": "more_pct_w_disability",
+    "pct_65_plu": "pct_65_plus",
+    "pct_africa": "pct_african_american",
+    "pct_amer_i": "pct_amer_indian_ak_native",
+    "pct_below_": "pct_below_150pov",
+    "pct_diabet": "pct_diabetes",
+    "pct_hawaii": "pct_hawaiian_pacislander",
+    "pct_hispan": "pct_hispanic_latino",
+    "pct_insure": "pct_insured",
+    "pct_minori": "pct_minority",
+    "pct_no_bba": "pct_no_bband",
+    "pct_no_hsd": "pct_no_hsdiploma",
+    "pct_under_": "pct_under_18",
+    "pct_uninsu": "pct_uninsured",
+    "pct_w_disa": "pct_w_disability",
+    "total_popu": "total_population",
+}

--- a/luts.py
+++ b/luts.py
@@ -117,7 +117,7 @@ areas_near = {
 demographics_fields = {
     "moe_pct_in": "moe_pct_insured",
     "moe_pct_un": "moe_pct_uninsured",
-    "moe_pct_w_": "more_pct_w_disability",
+    "moe_pct_w_": "moe_pct_w_disability",
     "pct_65_plu": "pct_65_plus",
     "pct_africa": "pct_african_american",
     "pct_amer_i": "pct_amer_indian_ak_native",
@@ -130,6 +130,7 @@ demographics_fields = {
     "pct_no_bba": "pct_no_bband",
     "pct_no_hsd": "pct_no_hsdiploma",
     "pct_under_": "pct_under_18",
+    "":"pct_under_5", # TODO: add truncated dict key when GeoServer demographics file is updated!
     "pct_uninsu": "pct_uninsured",
     "pct_w_disa": "pct_w_disability",
     "total_popu": "total_population",

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -61,6 +61,7 @@ nodata_mappings = {
     "veg_type": nodata_values["default"],
     "wet_days_per_year": nodata_values["default"],
     "wet_days_per_year_all": nodata_values["default"],
+    "demographics": nodata_values["default"],
 }
 
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -35,3 +35,4 @@ from .eds import *
 from .wet_days_per_year import *
 from .indicators import *
 from .hydrology import *
+from .demographics import *

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -1,0 +1,52 @@
+from flask import Blueprint, render_template, Response, request
+import asyncio
+# import pandas as pd
+
+# local imports
+from . import routes
+from luts import demographics_fields
+
+from generate_urls import generate_wfs_places_url
+from fetch_data import fetch_data
+from csv_functions import create_csv
+
+
+@routes.route("/demographics/<community>")
+def get_data_for_community(community):
+    """
+    Function to pull demographics data as JSON or CSV.
+       Args:
+           community (string): A community ID from https://earthmaps.io/places/communities.
+
+       Returns:
+           JSON-formatted output of demographic data for the requested community,
+           with additional contextual data for Alaska and the United States.
+
+       Notes:
+           example: http://localhost:5000/demographics/AK15
+    """
+    # List URLs
+    urls = []
+    for c in [community, "US0", "AK0"]:
+        urls.append(generate_wfs_places_url("demographics:demographics", filter=c, filter_type="id"))
+
+    # Requests the Geoserver WFS URLs and extracts property values to a dict
+    results = {}
+    for r in asyncio.run(fetch_data(urls)):
+        results[r["features"][0]["properties"]["id"]] = r["features"][0]["properties"]
+
+    # Rename keys
+    for c in [community, "US0", "AK0"]:
+        fields_to_rename = [x for x in list(results[c].keys()) if x in list(demographics_fields.keys())]
+
+        for field in fields_to_rename:
+            results[c][demographics_fields[field]] = results[c].pop(field)
+
+    # Return CSV if requested
+    if request.args.get("format") == "csv":
+         return create_csv(results, endpoint="demographics", place_id=community)
+
+    # Otherwise return results dict
+    return results
+
+

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -16,14 +16,18 @@ def validate_community_id(community):
     Args:
            community (string): A community ID from route input
     Returns:
-            Boolean : True means the community ID is valid, False means it is not valid
+            Tuple of boolean and list: for boolean, True means the community ID is valid and False means it is not valid; list is all valid community IDs
     """
-    url = generate_wfs_places_url("demographics:demographics", filter=community, filter_type="id")
+    #url = generate_wfs_places_url("demographics:demographics", filter=community, filter_type="id")
+    community_ids = []
+    url = generate_wfs_places_url("demographics:demographics", properties="id")
     with requests.get(url) as r:
-        if r.json()['features'] == []:
-            return False
-        else: return True
-
+        for feature in r.json()['features']:
+            community_ids.append(feature['properties']['id'])
+    if community in community_ids:
+        return True, community_ids
+    else: 
+        return False, community_ids
 
 @routes.route("/demographics/")
 def demographics_about():
@@ -34,7 +38,7 @@ def get_data_for_community(community):
     """
     Function to pull demographics data as JSON or CSV.
        Args:
-           community (string): A community ID from https://earthmaps.io/places/communities.
+           community (string): A community ID from https://earthmaps.io/places/communities, or "all" to get all available communities
 
        Returns:
            JSON-formatted output of demographic data for the requested community,
@@ -44,12 +48,16 @@ def get_data_for_community(community):
            example: http://localhost:5000/demographics/AK15
     """
     # Validate community ID; if not valid, return an error
-    if not validate_community_id(community):
+    validation, community_ids = validate_community_id(community)
+    if community == 'all': pass
+    elif not validation:
         return render_template("400/bad_request.html"), 400
+    else:
+        community_ids = [community, "US0", "AK0"]
 
     # List URLs
     urls = []
-    for c in [community, "US0", "AK0"]:
+    for c in community_ids:
         urls.append(generate_wfs_places_url("demographics:demographics", filter=c, filter_type="id"))
 
     # Requests the Geoserver WFS URLs and extracts property values to a dict
@@ -58,7 +66,7 @@ def get_data_for_community(community):
         results[r["features"][0]["properties"]["id"]] = r["features"][0]["properties"]
 
     # Rename keys
-    for c in [community, "US0", "AK0"]:
+    for c in community_ids:
         fields_to_rename = [x for x in list(results[c].keys()) if x in list(demographics_fields.keys())]
         for field in fields_to_rename:
             results[c][demographics_fields[field]] = results[c].pop(field)
@@ -73,7 +81,7 @@ def get_data_for_community(community):
     ]
 
     reformatted_results = {}
-    for c in [community, "US0", "AK0"]:
+    for c in community_ids:
         reformatted_results[c] = {}
         for field in fields:
             reformatted_results[c][field] = results[c][field]

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -11,6 +11,9 @@ from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
 from csv_functions import create_csv
 
+@routes.route("/demographics/")
+def demographics_about():
+    return render_template("/documentation/demographics.html")
 
 @routes.route("/demographics/<community>")
 def get_data_for_community(community):

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -73,7 +73,7 @@ def get_data_for_community(community):
 
     # Recreate the dicts in a better order for viewing (drops "id", "GEOID", and "areatype")
     # convert to JSON object to preserve ordered output
-    fields = ["name", "comment", "total_population", "pct_under_18", "pct_65_plus", 
+    fields = ["name", "comment", "total_population", "pct_under_18", "pct_under_5", "pct_65_plus", 
     "pct_minority", "pct_african_american", "pct_amer_indian_ak_native", "pct_asian", "pct_hawaiian_pacislander", "pct_hispanic_latino", "pct_white", "pct_multi", "pct_other",
     "pct_asthma", "pct_copd", "pct_diabetes", "pct_hd", "pct_kd", "pct_stroke",
     "pct_w_disability", "moe_pct_w_disability", "pct_insured", "moe_pct_insured", "pct_uninsured", "moe_pct_uninsured",

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -60,13 +60,12 @@ def get_data_for_community(community):
         for field in fields:
             reformatted_results[c][field] = results[c][field]
 
-    json_results = json.dumps(reformatted_results, indent = 4) 
-
     # Return CSV if requested
     if request.args.get("format") == "csv":
-         return create_csv(json_results, endpoint="demographics", place_id=community)
+         return create_csv(reformatted_results, endpoint="demographics", place_id=community)
     
     # Otherwise return Flask JSON Response
+    json_results = json.dumps(reformatted_results, indent = 4)
     return Response(response=json_results, status=200, mimetype="application/json")
 
 

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -88,7 +88,10 @@ def get_data_for_community(community):
 
     # Return CSV if requested
     if request.args.get("format") == "csv":
-         return create_csv(reformatted_results, endpoint="demographics", place_id=community)
+        if community != "all":
+            return create_csv(reformatted_results, endpoint="demographics", place_id=community)
+        else:
+            return create_csv(reformatted_results, endpoint="demographics", place_id=None)
     
     # Otherwise return Flask JSON Response
     json_results = json.dumps(reformatted_results, indent = 4)

--- a/routes/demographics.py
+++ b/routes/demographics.py
@@ -18,7 +18,6 @@ def validate_community_id(community):
     Returns:
             Tuple of boolean and list: for boolean, True means the community ID is valid and False means it is not valid; list is all valid community IDs
     """
-    #url = generate_wfs_places_url("demographics:demographics", filter=community, filter_type="id")
     community_ids = []
     url = generate_wfs_places_url("demographics:demographics", properties="id")
     with requests.get(url) as r:

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -4,7 +4,7 @@
 
 <p>
   The endpoints here provide access to demographic data derived from the 2020 US Census Demographics and 
-  Housing Characteristics File (DHC), the 2017-2021 US Census American Community Survey (ACS) 5-year dataset,
+  Housing Characteristics File (DHC), the 2017&ndash;2021 US Census American Community Survey (ACS) 5-year dataset,
    the 2023 CDC PLACES dataset, and the 2017-2021 CDC Social Determinants of Health (SDOH) dataset. 
    Data is returned for individual Alaskan communities, and also includes contextual data for the state of
     Alaska and the United States.

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -1,0 +1,118 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Demographics</h2>
+
+<p>
+  The endpoints here provide access to demographic data derived from the 2020 US Census Demographics and Housing Characteristics File (DHC), the 2017-2021 US Census American Community Survey (ACS) 5-year dataset, the 2023 CDC PLACES dataset, and the 2017-2021 CDC Social Determinants of Health (SDOH) dataset. Data is returned for individual Alaskan communities, and also includes contextual data for the state of Alaska and the United States.
+</p>
+
+<h3>Service endpoints</h3>
+
+<h4>Available Places</h4>
+
+<p>Query a community by ID.</p>
+
+<table class="endpoints">
+  <thead>
+    <tr>
+      <th class="endpoint-label">Endpoint</th>
+      <th class="endpoint-url">Example URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Demographic data by community</td>
+      <td><a href="/demographics/AK15">/demographics/AK15</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
+    </tr>
+  </tfoot>
+</table>
+
+<h3>Output</h3>
+
+<h4>Community query</h4>
+
+<p>Results from community queries will look like this:</p>
+
+<pre>
+{
+  ...
+  "AK15": {
+    "name": "Anchorage",
+    "comment": "Data represent information from nearest borough (Anchorage Municipality), which includes Municipality of Anchorage and Anchorage.",
+    "total_population": 291247,
+    "pct_under_18": 23.46,
+    "pct_65_plus": 12.41,
+    "pct_minority": 43.9,
+    "pct_african_american": 4.73,
+    "pct_amer_indian_ak_native": 7.72,
+    "pct_asian": 9.37,
+    "pct_hawaiian_pacislander": 3.38,
+    "pct_hispanic_latino": 9.08,
+    "pct_white": 54.33,
+    "pct_multi": 10.74,
+    "pct_other": 0.66,
+    "pct_asthma": 9.4,
+    "pct_copd": 5.3,
+    "pct_diabetes": 7.9,
+    "pct_hd": 4.7,
+    "pct_kd": 2.6,
+    "pct_stroke": 2.6,
+    "pct_w_disability": 11.2,
+    "moe_pct_w_disability": 0.6,
+    "pct_insured": 89.4,
+    "moe_pct_insured": 0.7,
+    "pct_uninsured": 10.6,
+    "moe_pct_uninsured": 0.7,
+    "pct_no_bband": 7.3,
+    "pct_no_hsdiploma": 5.8,
+    "pct_below_150pov": 15.1
+  },
+  ...
+}
+</pre>
+
+<p>The above output is structured like this:</p>
+
+<pre>
+{
+    "ID": &lt;community ID&gt;: {
+        "name": &lt;community name&gt;,
+        "comment": &lt;comments regarding data source&gt;,
+        "total_population": &lt;total population of community&gt;,
+        "pct_under_18": &lt;percentage of population under age 18&gt;,
+        "pct_65_plus": &lt;percentage of population age 65 and older&gt;,
+        "pct_minority": &lt;percentage of population of racial or ethnic minority status&gt;,
+        "pct_african_american": &lt;percentage of population African American&gt;,
+        "pct_amer_indian_ak_native": &lt;percentage of population American Indian or Alaska Native&gt;,
+        "pct_asian": &lt;percentage of population Asian&gt;,
+        "pct_hawaiian_pacislander": &lt;percentage of population Native Hawaiian and Pacific Islander&gt;,
+        "pct_hispanic_latino": &lt;percentage of population Hispanic or Latino&gt;,
+        "pct_white": &lt;percentage of population White&gt;,
+        "pct_multi": &lt;percentage of population two or more races&gt;,
+        "pct_other": &lt;percentage of population other race&gt;,
+        "pct_asthma": &lt;percentage of of adults aged >=18 years with current asthma&gt;,
+        "pct_copd": &lt;percentage of of adults aged >=18 years with chronic obstructive pulmonary disease&gt;,
+        "pct_diabetes": &lt;percentage of of adults aged >=18 years with diagnosed diabetes&gt;,
+        "pct_hd": &lt;percentage of of adults aged >=18 years with coronary heart disease&gt;,
+        "pct_kd": &lt;percentage of of adults aged >=18 years with chronic kidney disease&gt;,
+        "pct_stroke": &lt;percentage of of adults aged >=18 years with stroke&gt;,
+        "pct_w_disability": &lt;percentage of population with a disability&gt;,
+        "moe_pct_w_disability": &lt;margin of error for percentage of population with a disability&gt;,
+        "pct_insured": &lt;percentage of population with health insurance&gt;,
+        "moe_pct_insured": &lt;margin of error percentage of population with health insurance&gt;,
+        "pct_uninsured": &lt;percentage of population without health insurance&gt;,
+        "moe_pct_uninsured": &lt;margin of error percentage of population without health insurance&gt;,
+        "pct_no_bband": &lt;percentage of households with no broadband internet subscription&gt;,
+        "pct_no_hsdiploma": &lt;percentage of adults aged >=25 years with no high school diploma&gt;,
+        "pct_below_150pov": &lt;percentage of population living below 150% of the poverty level&gt;
+    },
+    ...
+    }
+</pre>
+
+{% endblock %}

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -5,7 +5,7 @@
 <p>
   The endpoints here provide access to demographic data derived from the 2020 US Census Demographics and 
   Housing Characteristics File (DHC), the 2017&ndash;2021 US Census American Community Survey (ACS) 5-year dataset,
-   the 2023 CDC PLACES dataset, and the 2017-2021 CDC Social Determinants of Health (SDOH) dataset. 
+   the 2023 CDC PLACES dataset, and the 2017&ndash;2021 CDC Social Determinants of Health (SDOH) dataset. 
    Data is returned for individual Alaskan communities, and also includes contextual data for the state of
     Alaska and the United States.
 </p>

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -51,6 +51,7 @@
     "comment": "Data represent information from nearest borough (Anchorage Municipality), which includes Municipality of Anchorage and Anchorage.",
     "total_population": 291247,
     "pct_under_18": 23.46,
+    "pct_under_5": 6.43,
     "pct_65_plus": 12.41,
     "pct_minority": 43.9,
     "pct_african_american": 4.73,
@@ -90,6 +91,7 @@
         "comment": &lt;comments regarding data source&gt;,
         "total_population": &lt;total population of community&gt;,
         "pct_under_18": &lt;percentage of population under age 18&gt;,
+        "pct_under_5": &lt;percentage of population under age 5&gt;,
         "pct_65_plus": &lt;percentage of population age 65 and older&gt;,
         "pct_minority": &lt;percentage of population of racial or ethnic minority status&gt;,
         "pct_african_american": &lt;percentage of population African American&gt;,
@@ -136,7 +138,8 @@
                 Accessed May 2024, from <a href="https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html">https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html</a></td>
             <td>
                 <code>total_population</code>, 
-                <code>pct_under_18</code>, 
+                <code>pct_under_18</code>,
+                <code>pct_under_5</code>,
                 <code>pct_65_plus</code>, 
                 <code>pct_african_american</code>, 
                 <code>pct_amer_indian_ak_native</code>, 

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -3,7 +3,11 @@
 <h2>Demographics</h2>
 
 <p>
-  The endpoints here provide access to demographic data derived from the 2020 US Census Demographics and Housing Characteristics File (DHC), the 2017-2021 US Census American Community Survey (ACS) 5-year dataset, the 2023 CDC PLACES dataset, and the 2017-2021 CDC Social Determinants of Health (SDOH) dataset. Data is returned for individual Alaskan communities, and also includes contextual data for the state of Alaska and the United States.
+  The endpoints here provide access to demographic data derived from the 2020 US Census Demographics and 
+  Housing Characteristics File (DHC), the 2017-2021 US Census American Community Survey (ACS) 5-year dataset,
+   the 2023 CDC PLACES dataset, and the 2017-2021 CDC Social Determinants of Health (SDOH) dataset. 
+   Data is returned for individual Alaskan communities, and also includes contextual data for the state of
+    Alaska and the United States.
 </p>
 
 <h3>Service endpoints</h3>

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -119,4 +119,72 @@
     }
 </pre>
 
+<h3>Source data</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Dataset source</th>
+            <th>Citation</th>
+            <th>Variables derived from dataset</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>2020 US Census Demographics and Housing Characteristics File (DHC)</td>
+            <td>U.S. Census Bureau (2020). Demographics and Housing Characteristics File. 
+                Accessed May 2024, from <a href="https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html">https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html</a></td>
+            <td>
+                <code>total_population</code>, 
+                <code>pct_under_18</code>, 
+                <code>pct_65_plus</code>, 
+                <code>pct_african_american</code>, 
+                <code>pct_amer_indian_ak_native</code>, 
+                <code>pct_asian</code>, 
+                <code>pct_hawaiian_pacislander</code>, 
+                <code>pct_hispanic_latino</code>, 
+                <code>pct_white</code>, 
+                <code>pct_multi</code>,
+                <code>pct_other</code>
+            </td>
+        </tr>
+        <tr>
+            <td>2017-2021 US Census American Community Survey (ACS) 5-year dataset</td>
+            <td>U.S. Census Bureau (2021). 2017-2021 American Community Survey 5-year estimates. 
+                Accessed May 2024, from <a href="https://www.census.gov/programs-surveys/acs/data.html">https://www.census.gov/programs-surveys/acs/data.html</a></td>
+            <td>
+                <code>pct_w_disability</code>, 
+                <code>moe_pct_w_disability</code>, 
+                <code>pct_insured</code>, 
+                <code>moe_pct_insured</code>, 
+                <code>pct_uninsured</code>, 
+                <code>moe_pct_uninsured</code>
+            </td>
+        </tr>
+        <tr>
+            <td>2023 CDC PLACES dataset</td>
+            <td>PLACES. Centers for Disease Control and Prevention. 
+                Accessed May 2024, from <a href="https://www.cdc.gov/places">https://www.cdc.gov/places</a></td>
+            <td> 
+                <code>pct_asthma</code>, 
+                <code>pct_copd</code>, 
+                <code>pct_diabetes</code>, 
+                <code>pct_hd</code>, 
+                <code>pct_kd</code>, 
+                <code>pct_stroke</code>
+            </td>
+        </tr>
+        <tr>
+            <td>2017-2021 CDC Social Determinants of Health (SDOH) dataset</td>
+            <td>Healthy People 2030, U.S. Department of Health and Human Services, Office of Disease Prevention and Health Promotion. 
+                Accessed May 2024, from <a href="https://health.gov/healthypeople/objectives-and-data/social-determinants-health">https://health.gov/healthypeople/objectives-and-data/social-determinants-health</a></td>
+            <td> 
+                <code>pct_no_bband</code>, 
+                <code>pct_no_hsdiploma</code>, 
+                <code>pct_below_150pov</code>, 
+                <code>pct_minority</code>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
 {% endblock %}

--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -14,7 +14,8 @@
 
 <h4>Available Places</h4>
 
-<p>Query a community by ID.</p>
+<p>Query a community by ID from the options at <a href="https://earthmaps.io/places/communities">earthmaps.io/places/communities</a>.</p> 
+<p>Get data for all available Alaskan communities by using <code>all</code> as the community ID.</p>
 
 <table class="endpoints">
   <thead>

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,7 @@
   <li><a href="/taspr">Temperature and Precipitation</a></li>
   <li><a href="/wet_days_per_year">Wet Days Per Year</a></li>
   <li><a href="/fire">Wildfire</a></li>
+  <li><a href="/demographics">Demographics</a></li>
 </ul>
 <h4>Rasdaman raster database</h4>
 <p>


### PR DESCRIPTION
This PR adds an endpoint for the demographics data associated with the EPA-Justice project. The data is accessed via WFS request to the `demographics:demographics` layer on GeoServer, and the response is reformatted for output as JSON or CSV.

The dataset is organized by community, and so the endpoint uses the community IDs found at [earthmaps.io/places/communities](https://earthmaps.io/places/communities). For example, data for Anchorage (`AK15`) is found at the endpoint below:

[http://127.0.0.1:5000/demographics/AK15](http://127.0.0.1:5000/demographics/AK15)

Every request also automatically returns data for the state of Alaska and the United States. I've also added an option to specify `all` in place of a community ID, which will request data for all communities in the dataset.

**TO TEST:**

- Start the `flask` application and review the documentation for the demographics endpoint at [http://127.0.0.1:5000/demographics](http://127.0.0.1:5000/demographics). Is everything looking consistent with other endpoints?
- Test some community IDs. I suggest `AK124` (Fairbanks) which should have all data populated, and `AK71` (Chisana) which should return null for all fields but total population.
- Test the `demographics/all` option.
- Test CSV outputs, paying particular attention to the dynamically generated filenames and metadata strings. Does everything look OK? No typos or weird strings?
