### PR TITLE
Fix beetle CSV HTTP 500 bug

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -44,7 +44,7 @@ def create_csv(
 
     if endpoint == "beetles":
         properties = beetles_csv(data)
-    if endpoint == "cmip6_indicators":
+    elif endpoint == "cmip6_indicators":
         properties = cmip6_indicators_csv(data)
     elif endpoint in [
         "heating_degree_days_Fdays",


### PR DESCRIPTION
This PR fixes a bug that was causing HTTP 500 errors for all beetle CSV downloads, like this for example:

http://127.0.0.1:5000/beetles/point/64.74/-156.22?format=csv

This is because `csv_functions.py` explicitly returns an HTTP 500 error page when the `endpoint` variable doesn't match any of the known CSV endpoints. When `cmip6_indicators` was added as a CSV endpoint option, it was added using `if` instead of `elif`, which created a new `if`/`elif`/`else` chain that effectively made the script forget about the "beetles" endpoint option.

To test, run the API off this branch and verify that the CSV download link above works & returns a valid beetle CSV.