### PR TITLE
Adds the WFS query for generating nearby fires to the /fire endpoint

### DIFF
--- a/generate_urls.py
+++ b/generate_urls.py
@@ -42,6 +42,10 @@ def generate_wfs_search_url(
     """
     distance = "0.7"
     if nearby_fires:
+        ''' 
+        GeoServer only supports degrees, so this is a query for ~70 mile radius.
+        https://gis.stackexchange.com/questions/132251/dwithin-wfs-filter-is-not-working
+       '''
         distance = "1.0"
     wfs_url = (
         GS_BASE_URL

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -25,10 +25,27 @@ def generate_base_wfs_url(backend, workspace, lat, lon):
     return wfs_base
 
 
-def generate_wfs_search_url(workspace, lat, lon, hucs_pa_only=False):
+def generate_wfs_search_url(
+    workspace, lat, lon, hucs_pa_only=False, nearby_fires=False
+):
+    """
+    Generate a WFS URL for searching for nearby features which is what is used by the NCR for
+    finding nearby communities + polygon features, and the AFE for finding nearby active fires
+    using the site's search interface.
+
+    Args:
+        workspace (str): the Geoserver workspace name to search in such as "all_boundaries:all_communities"
+        lat (float): latitude of the requested point
+        lon (float): longitude of the requested point
+        hucs_pa_only (bool): whether to search only for HUCs and protected areas
+        nearby_fires (bool): whether to search for nearby fires (uses 1.0 statute mile radius instead of 0.7)
+    """
+    distance = "0.7"
+    if nearby_fires:
+        distance = "1.0"
     wfs_url = (
         GS_BASE_URL
-        + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName={workspace}&outputFormat=application/json&cql_filter=DWithin(the_geom, POINT({lon} {lat}), 0.7, statute miles)"
+        + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName={workspace}&outputFormat=application/json&cql_filter=DWithin(the_geom, POINT({lon} {lat}), {distance}, statute miles)"
     )
     if hucs_pa_only:
         wfs_url += "AND (type='huc' OR type='protected_area')"

--- a/routes/fire.py
+++ b/routes/fire.py
@@ -108,15 +108,11 @@ def package_landcover(landcover_resp):
 
 @routes.route("/fire/")
 @routes.route("/fire/abstract/")
-@routes.route("/wildfire/")
-@routes.route("/wildfire/abstract/")
-@routes.route("/wildfire/point/")
 @routes.route("/fire/point/")
 def fire_about():
     return render_template("documentation/fire.html")
 
 
-@routes.route("/wildfire/point/<lat>/<lon>")
 @routes.route("/fire/point/<lat>/<lon>")
 @routes.route("/fire/point/<lat>/<lon>/<geometry>")
 def run_fetch_fire(lat, lon, geometry=False):

--- a/templates/documentation/fire.html
+++ b/templates/documentation/fire.html
@@ -184,10 +184,10 @@
     "title": &lt;title describing these data&gt;
   },
   "fire_points": {
-    Returned fire points from the fire_points layer from within approximately ~50 miles of the query point.
+    Returned fire points from the fire_points layer from within approximately ~70 miles of the query point.
   },
   "fire_polygons": {
-    Returned fire polygons from the fire_polygons layer from within approximately ~50 miles of the query point.
+    Returned fire polygons from the fire_polygons layer from within approximately ~70 miles of the query point.
   }
 }
 </pre>

--- a/templates/documentation/fire.html
+++ b/templates/documentation/fire.html
@@ -87,7 +87,55 @@
   "prf": {
     "flamm": 0.0057,
     "title": "Projected relative flammability"
-  }
+  },
+  "fire_points": {
+    [
+      {
+        "geometry": {
+          "coordinates": [
+            
+          ],
+          "type": "Point"
+        },
+        "geometry_name": "the_geom",
+        "id": "fire_points.10",
+        "properties": {
+          "CAUSE": "Human",
+          "NAME": "Quartz Lake",
+          "OUTDATE": "1717989480000",
+          "acres": 0.3,
+          "active": "0",
+          "discovered": "1716850920000",
+          "updated": "1717989692000"
+        },
+        "type": "Feature"
+      },
+      ...
+    ]
+  },
+  fire_polygons": [
+    {
+      "geometry": {
+        "coordinates": [
+          
+        ],
+        "type": "MultiPolygon"
+      },
+      "geometry_name": "the_geom",
+      "id": "fire_polygons.7",
+      "properties": {
+        "CAUSE": "Natural",
+        "NAME": "American",
+        "OUTDATE": "",
+        "acres": 4836.1,
+        "active": "1",
+        "discovered": "1719372156000",
+        "updated": "1725393784000"
+      },
+      "type": "Feature"
+    },
+    ...
+  ]
 }
 </pre>
 
@@ -134,6 +182,12 @@
   "prf": {
     "flamm": &lt;numeric flammability value&gt;,
     "title": &lt;title describing these data&gt;
+  },
+  "fire_points": {
+    Returned fire points from the fire_points layer from within approximately ~50 miles of the query point.
+  },
+  "fire_polygons": {
+    Returned fire polygons from the fire_polygons layer from within approximately ~50 miles of the query point.
   }
 }
 </pre>


### PR DESCRIPTION
This PR adds the WFS search query that finds all fires within ~70 miles of the selected point and returns the points and polygons inside of two additional JSON keys: fire_points and fire_polygons. To test, try points around the state of Alaska to see the returned data and ensure that the documentation for this returned data is clear. 

This also removes an unused endpoint /wildfire that has no purpose remaining available.

Closes #424 
Closes #446 