### PR TITLE
Modifies EDS endpoint for Wet Days Per Year with checks for error conditions being returned

### DIFF
--- a/routes/wet_days_per_year.py
+++ b/routes/wet_days_per_year.py
@@ -350,16 +350,22 @@ def get_wet_days_per_year_plate(lat, lon):
     results = run_fetch_wet_days_per_year_point_data(
         lat, lon, "projected", start_year="2010", end_year="2039"
     )
+    if isinstance(results, tuple):
+        return results
     wdpy_plate["2010-2039"] = results["projected"]
 
     results = run_fetch_wet_days_per_year_point_data(
         lat, lon, "projected", start_year="2040", end_year="2069"
     )
+    if isinstance(results, tuple):
+        return results
     wdpy_plate["2040-2069"] = results["projected"]
 
     results = run_fetch_wet_days_per_year_point_data(
         lat, lon, "projected", start_year="2070", end_year="2099"
     )
+    if isinstance(results, tuple):
+        return results
     wdpy_plate["2070-2099"] = results["projected"]
 
     return jsonify(wdpy_plate)


### PR DESCRIPTION
This PR adds the missing checks for returned error tuples in the projected data results and rendering them if there is an issue getting data back from Rasdaman.

This will fix the case where the network cuts out or the Rasdaman server returns any of the error codes we expect to need to render for the /eds/wet_days_per_year/point/

Working endpoint: http://localhost:5000/eds/wet_days_per_year/point/62.15/-155.65
Failing endpoint showing error condition: http://localhost:5000/eds/wet_days_per_year/point/62.15/-115.65

Non-working endpoint on production site: https://earthmaps.io/eds/wet_days_per_year/point/62.15/-115.65

NOTE: The error case in #459 could only occur previous when the data is returned correctly for the historical data and incorrectly for any of the projected data which would be a 404 or 500 error.

Closes #459 