### PR TITLE
Fixes CSV download filenames for all modern browsers

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -138,7 +138,9 @@ def csv_metadata(place_name=None, place_id=None, place_type=None, lat=None, lon=
         if place_type == "huc12":
             metadata += "# Corresponding HUC12 code: " + place_id + "\n"
     elif place_name is None and lat is None and lon is None:
-        metadata += "All communities Alaska\n" # this covers the demographic request for "all"
+        metadata += (
+            "All communities Alaska\n"  # this covers the demographic request for "all"
+        )
     elif place_type == "community":
         metadata += place_name + "\n"
     else:
@@ -225,11 +227,10 @@ def write_csv(properties):
         mimetype="text/csv",
         headers={
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": 'attachment; filename="'
+            "Content-Disposition": "attachment; filename="
             + properties["filename"]
-            + "\"; filename*=utf-8''\""
-            + properties["filename"]
-            + '"',
+            + "; filename*=utf-8''"
+            + properties["filename"],
         },
     )
     return response
@@ -952,14 +953,40 @@ def hydrology_csv(data, endpoint):
             "filename_data_name": filename_data_name,
         }
 
+
 def demographics_csv(data):
     coords = ["id"]
     values = [
-        "name", "comment", "total_population", "pct_under_18", "pct_under_5", "pct_65_plus", 
-        "pct_minority", "pct_african_american", "pct_amer_indian_ak_native", "pct_asian", "pct_hawaiian_pacislander", "pct_hispanic_latino", "pct_white", "pct_multi", "pct_other",
-        "pct_asthma", "pct_copd", "pct_diabetes", "pct_hd", "pct_kd", "pct_stroke",
-        "pct_w_disability", "moe_pct_w_disability", "pct_insured", "moe_pct_insured", "pct_uninsured", "moe_pct_uninsured",
-        "pct_no_bband", "pct_no_hsdiploma", "pct_below_150pov",
+        "name",
+        "comment",
+        "total_population",
+        "pct_under_18",
+        "pct_under_5",
+        "pct_65_plus",
+        "pct_minority",
+        "pct_african_american",
+        "pct_amer_indian_ak_native",
+        "pct_asian",
+        "pct_hawaiian_pacislander",
+        "pct_hispanic_latino",
+        "pct_white",
+        "pct_multi",
+        "pct_other",
+        "pct_asthma",
+        "pct_copd",
+        "pct_diabetes",
+        "pct_hd",
+        "pct_kd",
+        "pct_stroke",
+        "pct_w_disability",
+        "moe_pct_w_disability",
+        "pct_insured",
+        "moe_pct_insured",
+        "pct_uninsured",
+        "moe_pct_uninsured",
+        "pct_no_bband",
+        "pct_no_hsdiploma",
+        "pct_below_150pov",
     ]
     fieldnames = coords + values
     csv_dicts = build_csv_dicts(data, fieldnames, values=values)
@@ -972,11 +999,15 @@ def demographics_csv(data):
     metadata += "# pct_under_5 is the percentage of population under age 5\n"
     metadata += "# pct_65_plus is the percentage of population age 65 and older\n"
     metadata += "# pct_minority is the percentage of population of racial or ethnic minority status\n"
-    metadata += "# pct_african_american is the percentage of population African American\n"
+    metadata += (
+        "# pct_african_american is the percentage of population African American\n"
+    )
     metadata += "# pct_amer_indian_ak_native is the percentage of population American Indian or Alaska Native\n"
     metadata += "# pct_asian is the percentage of population Asian\n"
     metadata += "# pct_hawaiian_pacislander is the percentage of population Native Hawaiian and Pacific Islander\n"
-    metadata += "# pct_hispanic_latino is the percentage of population Hispanic or Latino\n"
+    metadata += (
+        "# pct_hispanic_latino is the percentage of population Hispanic or Latino\n"
+    )
     metadata += "# pct_white is the percentage of population White\n"
     metadata += "# pct_multi is the percentage of population two or more races\n"
     metadata += "# pct_other is the percentage of population other race\n"
@@ -985,12 +1016,16 @@ def demographics_csv(data):
     metadata += "# pct_diabetes is the percentage of of adults aged >=18 years with diagnosed diabetes\n"
     metadata += "# pct_hd is the percentage of of adults aged >=18 years with coronary heart disease\n"
     metadata += "# pct_kd is the percentage of of adults aged >=18 years with chronic kidney disease\n"
-    metadata += "# pct_stroke is the percentage of of adults aged >=18 years with stroke\n"
+    metadata += (
+        "# pct_stroke is the percentage of of adults aged >=18 years with stroke\n"
+    )
     metadata += "# pct_w_disability is the percentage of population with a disability\n"
     metadata += "# moe_pct_w_disability is the margin of error for percentage of population with a disability\n"
     metadata += "# pct_insured is the percentage of population with health insurance\n"
     metadata += "# moe_pct_insured is the margin of error percentage of population with health insurance\n"
-    metadata += "# pct_uninsured is the percentage of population without health insurance\n"
+    metadata += (
+        "# pct_uninsured is the percentage of population without health insurance\n"
+    )
     metadata += "# moe_pct_uninsured is the margin of error percentage of population without health insurance\n"
     metadata += "# pct_no_bband is the percentage of households with no broadband internet subscription\n"
     metadata += "# pct_no_hsdiploma is the percentage of adults aged >=25 years with no high school diploma\n"
@@ -999,8 +1034,8 @@ def demographics_csv(data):
     filename_data_name = "Demographic Data - "
 
     return {
-            "csv_dicts": csv_dicts,
-            "fieldnames": fieldnames,
-            "metadata": metadata,
-            "filename_data_name": filename_data_name,
-        }
+        "csv_dicts": csv_dicts,
+        "fieldnames": fieldnames,
+        "metadata": metadata,
+        "filename_data_name": filename_data_name,
+    }


### PR DESCRIPTION
This PR fixes the issue of the filename structure of the download CSVs from the API on different browsers. For example, in Firefox, we were getting: _Precipitation for Utqiaġvik (Barrow).csv_ while in Sarari, we were seeing the HTML entities showing up in the filename like this: Precipitation for Utqia%C4%A1vik%20%28Barrow%29.csv

I modified the code to remove the unneeded double quotes in the response header's representation of the filename, and that fixed the issue per this Stack Overflow article: [CSV Underscore Issue](https://stackoverflow.com/questions/22477273/firefox-and-chrome-appending-underscore-before-and-after-file-name-while-interne)

Additionally, I found that if I remove the second properties["filename"] in this code: https://github.com/ua-snap/data-api/blob/01510c3cae46d2e588f625fce96fa2f14b3e0c03/csv_functions.py#L228-L234 that the file name adds the HTML entities back into the file name for Safari. Thus, it is a required portion of this code to work across all of the browsers.

This also has Python Black format changes as we have not run the linter on that code in a while.

Closes #454 