### PR TITLE
Removes the Obu and Jorg fields from the returned permafrost CSVs

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -504,9 +504,6 @@ def permafrost_csv(data, source_metadata):
                 "talikthickness",
             ],
         },
-        "jorg": {"coords": ["source"], "values": ["ice", "pfx"]},
-        "obu_magt": {"coords": ["source"], "values": ["year", "depth", "temp"]},
-        "obupfx": {"coords": ["source"], "values": ["pfx"]},
     }
 
     metadata = "# magt*m is the mean annual ground temperature at a given depth (* meters) in degrees Celsius\n"

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -511,9 +511,6 @@ def permafrost_csv(data, source_metadata):
     metadata += "# permafrost base is the lower boundary of the permafrost below the surface in meters\n"
     metadata += "# permafrost top is the upper boundary of the permafrost below the surface in meters\n"
     metadata += "# talikthickness is the thickness of the perennially unfrozen ground occurring in permafrost terrain in meters\n"
-    metadata += "# ice is the estimated ground ice volume\n"
-    metadata += "# pfx is the permafrost extent\n"
-
     metadata += "# gipl is the Geophysical Institute's Permafrost Laboratory\n"
 
     all_fields = []


### PR DESCRIPTION
This PR removes the three lines of code that added the Obu and Jorg fields to the returned CSVs for the permafrost endpoint that are no longer referenced in the header information of the CSV.

An example endpoint: http://localhost:5000/permafrost/point/65.0628/-146.56?format=csv

Closes #438 
Closes #332 