### PR TITLE
Additional CSV fix for latitude and longitude filenames

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -110,7 +110,7 @@ def create_csv(
         elif endpoint == "demographics":
             filename += quote("All communities in Alaska")
         else:
-            filename += lat + ", " + lon
+            filename += lat + " " + lon
     filename += ".csv"
     properties["filename"] = filename
 


### PR DESCRIPTION
This PR fixes the file names with latitude and longitude and doesn't have a community ID name. The previous fix for the special characters working the same way in all of the browsers removed quotes that were preventing the comma in the latitude and longitude file name from breaking the write_csv function. 

This removes the comma between the latitude and longitude and all of the special characters work across all of the major browsers still.