### PR TITLE
Add new monthly CMIP6 endpoint

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -362,7 +362,32 @@ def cmip6_monthly_csv(data, vars=None):
     for variable in values:
         metadata += metadata_variables[variable]
 
-    filename_data_name = "CMIP6 Monthly"
+    # This dictionary contains the variable pairs that would append to the file name if selected.
+    # This is most likely to happen when the user is downloading the CSV from ARDAC.
+    cmip6_variable_groups = {
+        "Temperature": {"tas", "tasmin", "tasmax"},
+        "Precipitation": {"pr"},
+        "Wind": {"sfcWind", "uas", "vas"},
+        "Oceanography": {"psl", "ts"},
+        "Evaporation": {"evspsbl"},
+        "Solar Radiation & Cloud Cover": {"rsds", "rlds", "hfss", "hfls", "clt"},
+    }
+
+    cmip6_variable_name = None
+
+    # This checks if the variables going into the CSV are a part of the CMIP6 variable groups.
+    # The set of variables must match the required variables exactly or else the default name is used.
+    for name, required_vars in cmip6_variable_groups.items():
+        if required_vars == set(vars):
+            cmip6_variable_name = name
+            break
+
+    # File name is "CMIP6 Monthly" by default.
+    filename_data_name = (
+        f"CMIP6 Monthly {cmip6_variable_name}"
+        if cmip6_variable_name
+        else "CMIP6 Monthly"
+    )
 
     return {
         "csv_dicts": csv_dicts,

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -338,9 +338,7 @@ def cmip6_monthly_csv(data, vars=None):
         "pr": "# pr is the total monthly precipitation in mm.\n",
         "psl": "# psl is the mean monthly sea level pressure in Pa.\n",
         "rlds": "# rlds is the mean monthly surface downwelling longwave flux in the air in W/m².\n",
-        "rls": "# rls is the mean monthly surface net downward longwave flux in W/m².\n",
         "rsds": "# rsds is the mean monthly surface downwelling shortwave flux in the air in W/m².\n",
-        "rss": "# rss is the mean monthly surface net downward shortwave flux in W/m².\n",
         "sfcWind": "# sfcWind is the mean near surface wind speed in m/s.\n",
         "tas": "# tas is the mean monthly temperature in deg C.\n",
         "tasmax": "# tasmax is the maximum monthly temperature in deg C.\n",
@@ -355,13 +353,13 @@ def cmip6_monthly_csv(data, vars=None):
     if vars is not None:
         values = vars
     else:
-        values = metadata_variables.keys()
+        values = list(metadata_variables.keys())
 
     fieldnames = coords + values
     csv_dicts = build_csv_dicts(data, fieldnames, values=values)
 
     metadata = ""
-    for variable in vars:
+    for variable in values:
         metadata += metadata_variables[variable]
 
     filename_data_name = "CMIP6 Monthly"

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -14,6 +14,7 @@ def create_csv(
     lon=None,
     source_metadata=None,
     filename_prefix=None,
+    vars=None,
 ):
     """Create a CSV for any supported data set
     Args:
@@ -46,6 +47,8 @@ def create_csv(
         properties = beetles_csv(data)
     elif endpoint == "cmip6_indicators":
         properties = cmip6_indicators_csv(data)
+    elif endpoint == "cmip6_monthly":
+        properties = cmip6_monthly_csv(data, vars)
     elif endpoint in [
         "heating_degree_days_Fdays",
         "degree_days_below_zero_Fdays",
@@ -317,6 +320,51 @@ def cmip6_indicators_csv(data):
         metadata += "# rx1day is the Maximum 1-day Precipitation. This is the maximum precipitation total for a single calendar day in mm.\n"
         metadata += "# su are Summer Days. This is the number of days with maximum temperature above 25 (deg C).\n"
         filename_data_name = "CMIP6 Indicators"
+
+    return {
+        "csv_dicts": csv_dicts,
+        "fieldnames": fieldnames,
+        "metadata": metadata,
+        "filename_data_name": filename_data_name,
+    }
+
+
+def cmip6_monthly_csv(data, vars=None):
+    metadata_variables = {
+        "clt": "# clt is the mean monthly cloud area fraction as a percentage.\n",
+        "evspsbl": "# evspsbl is the total monthly evaporation (including sublimation and transpiration) in kg/m²/s.\n",
+        "hfls": "# hfls is the mean monthly surface upward latent heat flux in W/m².\n",
+        "hfss": "# hfss is the mean monthly surface upward sensible heat flux in W/m².\n",
+        "pr": "# pr is the total monthly precipitation in mm.\n",
+        "psl": "# psl is the mean monthly sea level pressure in Pa.\n",
+        "rlds": "# rlds is the mean monthly surface downwelling longwave flux in the air in W/m².\n",
+        "rls": "# rls is the mean monthly surface net downward longwave flux in W/m².\n",
+        "rsds": "# rsds is the mean monthly surface downwelling shortwave flux in the air in W/m².\n",
+        "rss": "# rss is the mean monthly surface net downward shortwave flux in W/m².\n",
+        "sfcWind": "# sfcWind is the mean near surface wind speed in m/s.\n",
+        "tas": "# tas is the mean monthly temperature in deg C.\n",
+        "tasmax": "# tasmax is the maximum monthly temperature in deg C.\n",
+        "tasmin": "# tasmin is the mimimum monthly temperature in deg C.\n",
+        "ts": "# ts is the mean monthly surface temperature in deg C.\n",
+        "uas": "# uas is the mean monthly near surface eastward wind in m/s.\n",
+        "vas": "# vas is the mean monthly near surface northward wind in m/s.\n",
+    }
+
+    coords = ["model", "scenario", "month"]
+
+    if vars is not None:
+        values = vars
+    else:
+        values = metadata_variables.keys()
+
+    fieldnames = coords + values
+    csv_dicts = build_csv_dicts(data, fieldnames, values=values)
+
+    metadata = ""
+    for variable in vars:
+        metadata += metadata_variables[variable]
+
+    filename_data_name = "CMIP6 Monthly"
 
     return {
         "csv_dicts": csv_dicts,

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -3,6 +3,7 @@ from flask import render_template
 nodata_values = {
     "beetles": [0],
     "cmip6_indicators": [-9999, -9999.0],
+    "cmip6_monthly": [-9999, -9999.0, "nan"],
     "default": [-9999],
     "hydrology": [-9999, "nan"],
     "ncar12km_indicators": [-9999, -9999.0],
@@ -18,6 +19,7 @@ nodata_mappings = {
     "air_thawing_index_Fdays_all": nodata_values["default"],
     "beetles": nodata_values["beetles"],
     "cmip6_indicators": nodata_values["cmip6_indicators"],
+    "cmip6_monthly": nodata_values["cmip6_monthly"],
     "crrel_gipl": nodata_values["default"],
     "degree_days_below_zero_Fdays": nodata_values["default"],
     "degree_days_below_zero_Fdays_all": nodata_values["default"],

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -36,3 +36,4 @@ from .wet_days_per_year import *
 from .indicators import *
 from .hydrology import *
 from .demographics import *
+from .cmip6 import *

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -102,7 +102,7 @@ def package_cmip6_monthly_data(point_data_list, var_id=None):
 
                     # Evaporation has very tiny values.
                     if varname == "evspsbl":
-                        precision = 7
+                        precision = 8
                     else:
                         precision = 2
 

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -1,16 +1,12 @@
 import asyncio
-import numpy as np
-from math import floor, isnan
 from flask import Blueprint, render_template, request
 
 # local imports
 from generate_urls import generate_wcs_query_url
 from generate_requests import generate_wcs_getcov_str
-from fetch_data import *
+from fetch_data import fetch_data, get_dim_encodings
 from validate_request import (
     validate_latlon,
-    project_latlon,
-    validate_var_id,
 )
 from postprocessing import postprocess, prune_nulls_with_max_intensity
 from csv_functions import create_csv

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -149,6 +149,8 @@ def run_fetch_cmip6_monthly_point_data(lat, lon):
             for var_id in vars:
                 if var_id not in varnames.values():
                     return render_template("400/bad_request.html"), 400
+        else:
+            vars = None
 
         if var_parameter:
             results = {}

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -1,0 +1,183 @@
+import asyncio
+import numpy as np
+from math import floor, isnan
+from flask import Blueprint, render_template, request
+
+# local imports
+from generate_urls import generate_wcs_query_url
+from generate_requests import generate_wcs_getcov_str
+from fetch_data import *
+from validate_request import (
+    validate_latlon,
+    project_latlon,
+    validate_var_id,
+)
+from postprocessing import postprocess, prune_nulls_with_max_intensity
+from csv_functions import create_csv
+from . import routes
+from config import WEST_BBOX, EAST_BBOX
+
+cmip6_api = Blueprint("cmip6_api", __name__)
+
+cmip6_monthly_coverage_id = "cmip6_monthly"
+dim_encodings = asyncio.run(get_dim_encodings(cmip6_monthly_coverage_id))
+varnames = dim_encodings["varname"]
+
+
+async def fetch_cmip6_monthly_point_data(lat, lon, var_coord=None):
+    """
+    Make an async request for CMIP6 monthly data for a range of models, scenarios, and years at a specified point
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+        var_coord (int): variable coordinate from dim_encoding, if specified
+
+    Returns:
+        list of data results from each of historical and future data at a specified point
+    """
+
+    # We must use EPSG:4326 for the CMIP6 monthly coverage to match the coverage projection
+    wcs_str = generate_wcs_getcov_str(
+        lon,
+        lat,
+        cov_id=cmip6_monthly_coverage_id,
+        projection="EPSG:4326",
+        var_coord=var_coord,
+    )
+
+    # Generate the URL for the WCS query
+    url = generate_wcs_query_url(wcs_str)
+
+    # Fetch the data
+    point_data_list = await fetch_data([url])
+
+    return point_data_list
+
+
+def package_cmip6_monthly_data(point_data_list, var_id):
+    """
+    Package the CMIP6 monthly values into human-readable JSON format
+
+    Args:
+        point_data_list (list): nested list of data from Rasdaman WCPS query
+
+    Returns:
+        di (dict): dictionary mirroring structure of nested list with keys derived from dim_encodings global variable
+    """
+    di = dict()
+
+    for mi, model_li in enumerate(point_data_list):
+        model = dim_encodings["model"][mi]
+        di[model] = dict()
+        for si, scenario_li in enumerate(model_li):
+            scenario = dim_encodings["scenario"][si]
+            di[model][scenario] = dict()
+
+            # Create an array of every month since January 1950 in the format "YYYY-MM"
+            months = [
+                f"{year}-{str(month).zfill(2)}"
+                for year in range(1950, 2100 + 1)
+                for month in range(1, 13)
+            ]
+
+            for moi, month_li in enumerate(months):
+                month = months[moi]
+                di[model][scenario][month] = dict()
+
+                if var_id != None:
+                    values = [scenario_li[moi]]
+                else:
+                    values = scenario_li[moi].split(" ")
+
+                for vi, value in enumerate(values):
+                    if var_id != None:
+                        varname = var_id
+                    else:
+                        varname = varnames[vi]
+
+                    # The "ts" variable is still in Kelvin in the Rasdaman coverage.
+                    # Convert this to Celsius. All other temperature variables have
+                    # already been converted to Celsius before Rasdaman import.
+                    if varname == "ts" and float(value) != -9999:
+                        value = float(value) - 273.15
+
+                    # Evaporation has very tiny values.
+                    if varname == "evspsbl":
+                        precision = 7
+                    else:
+                        precision = 2
+
+                    di[model][scenario][month][varname] = round(float(value), precision)
+
+    return di
+
+
+@routes.route("/cmip6/point/<lat>/<lon>")
+def run_fetch_cmip6_monthly_point_data(lat, lon):
+    """
+    Query the CMIP6 monthly coverage
+
+    Args:
+        lat (float): latitude
+        lon (float): longitude
+
+    Returns:
+        JSON-like dict of requested CMIP6 monthly data
+
+    Notes:
+        example request: http://localhost:5000/cmip6/point/65.06/-146.16?vars=tas,pr
+    """
+    # Validate the lat/lon values
+    validation = validate_latlon(lat, lon)
+    if validation == 400:
+        return render_template("400/bad_request.html"), 400
+    if validation == 422:
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
+    try:
+        var_parameter = False
+        if request.args.get("vars"):
+            var_parameter = True
+            vars = request.args.get("vars").split(",")
+            for var_id in vars:
+                if var_id not in varnames.values():
+                    return render_template("400/bad_request.html"), 400
+
+        if var_parameter:
+            results = {}
+            for var_id in vars:
+                var_coord = next(
+                    key for key, value in varnames.items() if value == var_id
+                )
+                point_data_list = asyncio.run(
+                    fetch_cmip6_monthly_point_data(lat, lon, var_coord)
+                )
+                new_results = package_cmip6_monthly_data(point_data_list, var_id)
+                for model, scenarios in new_results.items():
+                    results.setdefault(model, {})
+                    for scenario, months in scenarios.items():
+                        results[model].setdefault(scenario, {})
+                        for month, variables in months.items():
+                            results[model][scenario].setdefault(month, {})
+                            results[model][scenario][month].update(variables)
+        else:
+            point_data_list = asyncio.run(fetch_cmip6_monthly_point_data(lat, lon))
+            results = package_cmip6_monthly_data(point_data_list)
+
+        results = prune_nulls_with_max_intensity(postprocess(results, "cmip6_monthly"))
+
+        if request.args.get("format") == "csv":
+            place_id = request.args.get("community")
+            return create_csv(results, "cmip6_monthly", place_id, lat, lon, vars=vars)
+
+        return results
+    except ValueError:
+        return render_template("400/bad_request.html"), 400
+    except Exception as exc:
+        if hasattr(exc, "status") and exc.status == 404:
+            return render_template("404/no_data.html"), 404


### PR DESCRIPTION
This PR implements a new CMIP6 endpoint that serves the following variables at monthly temporal resolution:


- clt
- evspsbl
- hfls
- hfss
- pr
- pls
- rlds
- rsds
- sfcWind
- tas
- tasmax
- tasmin
- ts
- uas
- vas

The variables are pulled from the `cmip6_monthly` coverage on Apollo. The variables are stored in their own coverage axis and the new API endpoint uses axis subsetting to pull only the variables that are requested to improve performance. CSV export support is also implemented.

To test, run the API like this:

```
git checkout cmip6_monthly
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then, you can fetch the full set of variables all at once like this (this may take a couple minutes):

http://localhost:5000/cmip6/point/65/-147

To fetch just one variable, or a smaller set of variables, you can do this:

http://localhost:5000/cmip6/point/65/-147?vars=sfcWind
http://localhost:5000/cmip6/point/65/-147?vars=tas,pr

CSV exports also react accordingly, including CSV columns and metadata header lines only for the requested variables. For example:

http://localhost:5000/cmip6/point/65/-147?vars=rsds,rlds,hfss,hfls,clt&format=csv

Try testing a few arbitrary lat/lon points with arbitrary sets of variables to verify that everything works as expected. Also please double check that the values for the requested variables are sane.

Also, this PR does not include documentation for the endpoint. I plan to tackle this separately via ticket #471.