### PR TITLE
Fixes tuple return error in ALFRESCO endpoint

### DIFF
--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -275,7 +275,12 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
-        return render_template("422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX), 422
+        return (
+            render_template(
+                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+            ),
+            422,
+        )
 
     # Requests for HUC12s that intersect
     huc12_features = asyncio.run(

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -275,12 +275,7 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
-        return (
-            render_template(
-                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
-            ),
-            422,
-        )
+        return render_template("422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX), 422
 
     # Requests for HUC12s that intersect
     huc12_features = asyncio.run(
@@ -295,6 +290,10 @@ def run_fetch_alf_local_data(var_ep, lat, lon):
     # Collect the HUC12 ID for the returned nearest HUC12
     huc_id = huc12_gdf.loc[0, "id"]
     huc12_pkg = run_fetch_alf_area_data(var_ep, huc_id, ignore_csv=True)
+
+    # this is only ever true when it is returning an error template
+    if isinstance(huc12_pkg, tuple):
+        return huc12_pkg
 
     if request.args.get("format") == "csv":
         huc12_pkg = nullify_and_prune(huc12_pkg, var_ep)


### PR DESCRIPTION
Closes #135 

This is a similar problem to the one fixed in PR #464 , and I just copied the solution from there.

To test:

Fire up the API and make sure these endpoints render a template instead of a tuple error:

http://localhost:5000/alfresco/flammability/local/52.938/-168.868
http://localhost:5000/alfresco/flammability/local/53.267/-168.217