### PR TITLE
Adds the range of years to the CSVs that are generated for any endpoints with start and end years

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -15,6 +15,8 @@ def create_csv(
     source_metadata=None,
     filename_prefix=None,
     vars=None,
+    start_year=None,
+    end_year=None,
 ):
     """Create a CSV for any supported data set
     Args:
@@ -25,6 +27,9 @@ def create_csv(
         lon: longitude for points or None for polygons
         source_metadata: optional metadata to credit data sources
         filename_prefix: optional filename prefix (a month, for example)
+        vars: optional list of variables to include in CSV
+        start_year: optional start year for CSV
+        end_year: optional end year for CSV
     Returns:
         CSV Response
     """
@@ -33,13 +38,17 @@ def create_csv(
     place_name, place_type = place_name_and_type(place_id)
 
     if not endpoint.startswith("places_"):
-        metadata = csv_metadata(place_name, place_id, place_type, lat, lon)
+        metadata = csv_metadata(
+            place_name, place_id, place_type, lat, lon, start_year, end_year
+        )
     else:
         metadata = ""
 
     properties = {}
 
     data = nullify_and_prune(data, endpoint)
+    # if request.args.get("summarize") == "mmm":
+    #     return render_template("400/bad_request.html"), 400
     if data in [{}, None, 0]:
         return render_template("404/no_data.html"), 404
 
@@ -106,6 +115,8 @@ def create_csv(
     if filename_prefix is not None:
         filename += filename_prefix + " "
     filename += properties["filename_data_name"]
+    if start_year is not None and end_year is not None:
+        filename += " (" + start_year + " - " + end_year + ")"
     if not endpoint.startswith("places_"):
         filename += " for "
         if place_name is not None:
@@ -120,7 +131,15 @@ def create_csv(
     return write_csv(properties)
 
 
-def csv_metadata(place_name=None, place_id=None, place_type=None, lat=None, lon=None):
+def csv_metadata(
+    place_name=None,
+    place_id=None,
+    place_type=None,
+    lat=None,
+    lon=None,
+    start_year=None,
+    end_year=None,
+):
     """
     Creates metadata string to add to beginning of CSV file.
 
@@ -130,6 +149,8 @@ def csv_metadata(place_name=None, place_id=None, place_type=None, lat=None, lon=
         place_type (str): point or area
         lat: latitude for points or None for polygons
         lon: longitude for points or None for polygons
+        start_year: optional start year for CSV
+        end_year: optional end year for CSV
 
     Returns:
         Multiline metadata string
@@ -148,6 +169,9 @@ def csv_metadata(place_name=None, place_id=None, place_type=None, lat=None, lon=
         metadata += place_name + "\n"
     else:
         metadata += place_name + " (" + place_type_labels[place_type] + ")\n"
+
+    if start_year is not None and end_year is not None:
+        metadata += "# Time range: (" + start_year + " - " + end_year + ")\n"
 
     metadata += (
         "# View a report for this location at https://earthmaps.io"

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -47,8 +47,6 @@ def create_csv(
     properties = {}
 
     data = nullify_and_prune(data, endpoint)
-    # if request.args.get("summarize") == "mmm":
-    #     return render_template("400/bad_request.html"), 400
     if data in [{}, None, 0]:
         return render_template("404/no_data.html"), 404
 

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -411,7 +411,14 @@ def run_fetch_dd_point_data(
         if tidy_package in [{}, None, 0]:
             return render_template("404/no_data.html"), 404
         if request.args.get("summarize") == "mmm":
-            return create_csv(tidy_package, cov_id_str, lat=lat, lon=lon)
+            return create_csv(
+                tidy_package,
+                cov_id_str,
+                lat=lat,
+                lon=lon,
+                start_year=start_year,
+                end_year=end_year,
+            )
         else:
             return create_csv(
                 tidy_package,

--- a/routes/degree_days.py
+++ b/routes/degree_days.py
@@ -413,7 +413,14 @@ def run_fetch_dd_point_data(
         if request.args.get("summarize") == "mmm":
             return create_csv(tidy_package, cov_id_str, lat=lat, lon=lon)
         else:
-            return create_csv(tidy_package, cov_id_str + "_all", lat=lat, lon=lon)
+            return create_csv(
+                tidy_package,
+                cov_id_str + "_all",
+                lat=lat,
+                lon=lon,
+                start_year=start_year,
+                end_year=end_year,
+            )
 
     return tidy_package
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -49,9 +49,9 @@ def package_obu_magt(obu_magt_resp):
         return None
     depth = "Top of Permafrost"
     year = "2000-2016"
-    titles[
-        "obu_magt"
-    ] = f"Obu et al. (2018) {year} Mean Annual {depth} Ground Temperature (deg C)"
+    titles["obu_magt"] = (
+        f"Obu et al. (2018) {year} Mean Annual {depth} Ground Temperature (deg C)"
+    )
     temp = obu_magt_resp["features"][0]["properties"]["GRAY_INDEX"]
     if temp is None:
         return None
@@ -478,8 +478,22 @@ async def run_fetch_gipl_1km_point_data(
         if point_pkg in [{}, None, 0]:
             return render_template("404/no_data.html"), 404
         if summarize is not None:
-            return create_csv(point_pkg, "gipl_summary", lat=lat, lon=lon)
-        return create_csv(point_pkg, "gipl", lat=lat, lon=lon)
+            return create_csv(
+                point_pkg,
+                "gipl_summary",
+                lat=lat,
+                lon=lon,
+                start_year=start_year,
+                end_year=end_year,
+            )
+        return create_csv(
+            point_pkg,
+            "gipl",
+            lat=lat,
+            lon=lon,
+            start_year=start_year,
+            end_year=end_year,
+        )
     return postprocess(gipl_1km_point_package, "crrel_gipl")
 
 

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -1514,9 +1514,19 @@ def mmm_point_data_endpoint(
                 lat,
                 lon,
                 filename_prefix=filename_prefix,
+                start_year=start_year,
+                end_year=end_year,
             )
         else:
-            return create_csv(point_pkg, var_ep + "_all", place_id, lat, lon)
+            return create_csv(
+                point_pkg,
+                var_ep + "_all",
+                place_id,
+                lat,
+                lon,
+                start_year=start_year,
+                end_year=end_year,
+            )
 
     return postprocess(point_pkg, "taspr")
 

--- a/routes/wet_days_per_year.py
+++ b/routes/wet_days_per_year.py
@@ -322,9 +322,23 @@ def run_fetch_wet_days_per_year_point_data(
         if point_pkg in [{}, None, 0]:
             return render_template("404/no_data.html"), 404
         if horp != "all":
-            return create_csv(point_pkg, "wet_days_per_year", lat=lat, lon=lon)
+            return create_csv(
+                point_pkg,
+                "wet_days_per_year",
+                lat=lat,
+                lon=lon,
+                start_year=start_year,
+                end_year=end_year,
+            )
         else:
-            return create_csv(point_pkg, "wet_days_per_year_all", lat=lat, lon=lon)
+            return create_csv(
+                point_pkg,
+                "wet_days_per_year_all",
+                lat=lat,
+                lon=lon,
+                start_year=start_year,
+                end_year=end_year,
+            )
 
     return postprocess(point_pkg, "wet_days_per_year")
 


### PR DESCRIPTION
This PR adds the date range selected from any endpoint that has a start year & end year and puts it into both the metadata and the file name of the CSV files. This works for all of the Degree Day 

Examples:

**Temperature**
- http://localhost:5000/temperature/65.0628/-146.1627/1940/2060?format=csv

**Temperature in January**
- http://localhost:5000/temperature/jan/65.0628/-146.1627/1940/1970?format=csv

**Precipitation**
- http://localhost:5000/precipitation/65.0628/-146.1627/1980/2080?format=csv

**Degree Days** 
- http://localhost:5000/degree_days/freezing_index/65.0628/-146.1627/1990/2080?format=csv
- http://localhost:5000/degree_days/heating/65.0628/-146.1627/1970/2050?format=csv

**Wet Days per Year**
- http://localhost:5000/wet_days_per_year/projected/point/65.0628/-146.1627/2020/2080?format=csv

Closes #338 