### PR TITLE
Replaces all unnecessary star imports for functions across the API and changes fetch_data_api function name

### DIFF
--- a/application.py
+++ b/application.py
@@ -3,7 +3,7 @@ from flask import Flask, render_template, send_from_directory
 from flask_cors import CORS
 from config import SITE_OFFLINE
 
-from routes import *
+from routes import routes, request
 
 # Elastic Beanstalk wants `application` to be present.
 application = app = Flask(__name__)

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1,8 +1,12 @@
-from flask import request, Response, request
+from flask import request, Response, render_template
+import copy
 import csv
-from postprocessing import *
-from fetch_data import *
-from validate_data import *
+import io
+from urllib.parse import quote
+from postprocessing import nullify_and_prune
+from fetch_data import extract_nested_dict_keys, get_from_dict
+from luts import place_type_labels
+from validate_data import place_name_and_type
 from datetime import datetime
 
 

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -74,7 +74,7 @@ async def fetch_layer_data(url, session, encoding="json"):
     return data
 
 
-async def fetch_data_api(backend, workspace, wms_targets, wfs_targets, lat, lon):
+async def fetch_geoserver_data(backend, workspace, wms_targets, wfs_targets, lat, lon):
     """Generic Data API for GeoServer queries - gather all async requests
     for specified data layers in a GeoServer workspace."""
     base_wms_url = generate_base_wms_url(backend, workspace, lat, lon)

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -19,10 +19,15 @@ from lxml import etree as ET
 from aiohttp import ClientSession
 from flask import current_app as app
 from rasterstats import zonal_stats
-from config import RAS_BASE_URL, WEB_APP_URL
-from generate_requests import *
-from generate_urls import *
-from luts import place_type_labels
+from config import RAS_BASE_URL
+from generate_requests import generate_wcs_getcov_str, generate_netcdf_wcs_getcov_str
+from generate_urls import (
+    generate_wcs_query_url,
+    generate_base_wms_url,
+    generate_base_wfs_url,
+    generate_wms_and_wfs_query_urls,
+    generate_wfs_places_url,
+)
 
 
 async def fetch_wcs_point_data(x, y, cov_id, var_coord=None):
@@ -567,6 +572,7 @@ def deepflatten(iterable, depth=None, types=None, ignore=None):
             else:
                 yield from deepflatten(x, depth - 1, types, ignore)
 
+
 def replace_nans(json_str):
     """Replace nan values in a JSON string with -9999 to allow for parsing.
 
@@ -578,5 +584,5 @@ def replace_nans(json_str):
     """
     # Match only nans that have these characters on either side of them: ,[]
     # This is to prevent matches against strings that contain 'nan' within them.
-    json_str = re.sub(r'(?<=[,\[\]])nan(?=[,\[\]])', '-9999', json_str)
+    json_str = re.sub(r"(?<=[,\[\]])nan(?=[,\[\]])", "-9999", json_str)
     return json_str

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -1,8 +1,5 @@
 """A module to generate query URLs"""
 
-import asyncio
-from aiohttp import ClientSession
-import urllib.parse
 from config import RAS_BASE_URL, GS_BASE_URL
 from luts import bbox_offset
 
@@ -42,10 +39,10 @@ def generate_wfs_search_url(
     """
     distance = "0.7"
     if nearby_fires:
-        ''' 
+        """
         GeoServer only supports degrees, so this is a query for ~70 mile radius.
         https://gis.stackexchange.com/questions/132251/dwithin-wfs-filter-is-not-working
-       '''
+        """
         distance = "1.0"
     wfs_url = (
         GS_BASE_URL

--- a/routes/alfresco.py
+++ b/routes/alfresco.py
@@ -9,9 +9,17 @@ from flask import (
 )
 
 # local imports
-from generate_requests import *
+from generate_requests import generate_netcdf_wcs_getcov_str
 from generate_urls import generate_wcs_query_url, generate_wfs_huc12_intersection_url
-from fetch_data import *
+from fetch_data import (
+    fetch_bbox_netcdf_list,
+    fetch_data,
+    get_dim_encodings,
+    zonal_stats,
+    generate_nested_dict,
+    get_from_dict,
+    get_poly_3338_bbox,
+)
 from csv_functions import create_csv
 from validate_request import (
     validate_latlon,

--- a/routes/beetles.py
+++ b/routes/beetles.py
@@ -4,8 +4,14 @@ from flask import Blueprint, render_template, request
 
 # local imports
 from generate_urls import generate_wcs_query_url
-from generate_requests import *
-from fetch_data import *
+from generate_requests import generate_netcdf_wcs_getcov_str
+from fetch_data import (
+    fetch_bbox_netcdf_list,
+    fetch_wcs_point_data,
+    zonal_stats,
+    itertools,
+    get_poly_3338_bbox,
+)
 from csv_functions import create_csv
 from validate_request import (
     validate_latlon,
@@ -82,9 +88,9 @@ def package_beetle_data(beetle_resp, beetle_percents=None):
     for sni in range(len(beetle_resp[0][0][0])):
         snowpack = dim_encodings["snowpack"][sni]
         di["1988-2017"]["Daymet"]["Historical"][snowpack] = dict()
-        di["1988-2017"]["Daymet"]["Historical"][snowpack][
-            "climate-protection"
-        ] = dim_encodings["climate_protection"][int(beetle_resp[0][0][0][sni])]
+        di["1988-2017"]["Daymet"]["Historical"][snowpack]["climate-protection"] = (
+            dim_encodings["climate_protection"][int(beetle_resp[0][0][0][sni])]
+        )
         if beetle_percents is not None:
             # This conditional will check to see if all percentages are 0% meaning that there is no data.
             # We must set the returned data dictionary values explicitly to 0 to ensure the pruning function
@@ -127,9 +133,9 @@ def package_beetle_data(beetle_resp, beetle_percents=None):
                 for sni, risk_level in enumerate(sn_li):
                     snowpack = dim_encodings["snowpack"][sni]
                     di[era][model][scenario][snowpack] = dict()
-                    di[era][model][scenario][snowpack][
-                        "climate-protection"
-                    ] = dim_encodings["climate_protection"][int(risk_level)]
+                    di[era][model][scenario][snowpack]["climate-protection"] = (
+                        dim_encodings["climate_protection"][int(risk_level)]
+                    )
                     if beetle_percents is not None:
                         # This conditional will check to see if all percentages are 0% meaning that there is no data.
                         # We must set the returned data dictionary values explicitly to 0 to ensure the pruning function
@@ -255,9 +261,9 @@ def summarize_within_poly_marr(ds, poly_mask_arr, bandname="Gray"):
                     # If the mode is 1 above, it will take the count for all 1's
                     # and divide that by the total size of the array to get the
                     # percentage of the area that is low risk
-                    return_percentages[era][model][scenario][snowpack][
-                        int(mode)
-                    ] = round(mode_count / len(rm_nan_slice) * 100)
+                    return_percentages[era][model][scenario][snowpack][int(mode)] = (
+                        round(mode_count / len(rm_nan_slice) * 100)
+                    )
 
                     # If the uniques variable has more than one value, we need to
                     # check to see if this value should actually be the mode of the

--- a/routes/eds.py
+++ b/routes/eds.py
@@ -1,10 +1,7 @@
 from flask import (
     Blueprint,
-    Response,
-    render_template,
     request,
     current_app as app,
-    jsonify,
 )
 import asyncio
 from aiohttp import ClientSession, ClientResponseError, client_exceptions

--- a/routes/elevation.py
+++ b/routes/elevation.py
@@ -6,7 +6,7 @@ import rasterio as rio
 from generate_requests import generate_wcs_getcov_str, get_wcs_xy_str_from_bbox_bounds
 from generate_urls import generate_wcs_query_url
 from fetch_data import (
-    fetch_data_api,
+    fetch_geoserver_data,
     fetch_bbox_geotiff_from_gs,
     geotiff_zonal_stats,
     get_poly_3338_bbox,
@@ -89,7 +89,7 @@ def run_fetch_elevation(lat, lon):
         )
     try:
         results = asyncio.run(
-            fetch_data_api(GS_BASE_URL, "dem", wms_targets, wfs_targets, lat, lon)
+            fetch_geoserver_data(GS_BASE_URL, "dem", wms_targets, wfs_targets, lat, lon)
         )
     except Exception as exc:
         if hasattr(exc, "status") and exc.status == 404:

--- a/routes/fire.py
+++ b/routes/fire.py
@@ -5,7 +5,7 @@ from flask import (
 )
 
 # local imports
-from fetch_data import fetch_data, fetch_data_api
+from fetch_data import fetch_data, fetch_geoserver_data
 from generate_urls import generate_wfs_search_url
 from validate_request import validate_latlon
 from postprocessing import nullify_nodata, postprocess
@@ -130,7 +130,7 @@ def run_fetch_fire(lat, lon):
         )
     try:
         results = asyncio.run(
-            fetch_data_api(
+            fetch_geoserver_data(
                 GS_BASE_URL, "alaska_wildfires", wms_targets, wfs_targets, lat, lon
             )
         )

--- a/routes/hydrology.py
+++ b/routes/hydrology.py
@@ -8,7 +8,6 @@ from validate_request import (
     validate_latlon,
     project_latlon,
 )
-from validate_data import *
 from postprocessing import postprocess
 from csv_functions import create_csv
 from config import WEST_BBOX, EAST_BBOX

--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -11,7 +11,16 @@ from flask import Blueprint, render_template, request
 # local imports
 from generate_urls import generate_wcs_query_url
 from generate_requests import generate_wcs_getcov_str
-from fetch_data import *
+from fetch_data import (
+    fetch_data,
+    get_dim_encodings,
+    fetch_bbox_data,
+    get_poly_3338_bbox,
+    get_poly_mask_arr,
+    get_from_dict,
+    generate_nested_dict,
+    itertools,
+)
 from validate_request import (
     validate_latlon,
     project_latlon,

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -8,7 +8,7 @@ from generate_urls import generate_wcs_query_url
 from validate_data import place_name_and_type
 from fetch_data import (
     fetch_data,
-    fetch_data_api,
+    fetch_geoserver_data,
     fetch_wcs_point_data,
     get_dim_encodings,
     generate_wcs_getcov_str,
@@ -334,7 +334,7 @@ def run_point_fetch_all_permafrost(lat, lon):
         )
 
     gs_results = asyncio.run(
-        fetch_data_api(
+        fetch_geoserver_data(
             GS_BASE_URL, "permafrost_beta", wms_targets, wfs_targets, lat, lon
         )
     )

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -1,13 +1,20 @@
 import asyncio
 import pandas as pd
-import numpy as np
 from urllib.parse import quote
 from flask import Blueprint, render_template, request, jsonify, Response
 
 # local imports
 from generate_urls import generate_wcs_query_url
-from fetch_data import *
-from csv_functions import create_csv
+from validate_data import place_name_and_type
+from fetch_data import (
+    fetch_data,
+    fetch_data_api,
+    fetch_wcs_point_data,
+    get_dim_encodings,
+    generate_wcs_getcov_str,
+    deepflatten,
+)
+from csv_functions import csv_metadata, create_csv
 
 from validate_request import (
     validate_latlon,
@@ -49,9 +56,9 @@ def package_obu_magt(obu_magt_resp):
         return None
     depth = "Top of Permafrost"
     year = "2000-2016"
-    titles[
-        "obu_magt"
-    ] = f"Obu et al. (2018) {year} Mean Annual {depth} Ground Temperature (deg C)"
+    titles["obu_magt"] = (
+        f"Obu et al. (2018) {year} Mean Annual {depth} Ground Temperature (deg C)"
+    )
     temp = obu_magt_resp["features"][0]["properties"]["GRAY_INDEX"]
     if temp is None:
         return None

--- a/routes/physiography.py
+++ b/routes/physiography.py
@@ -5,7 +5,7 @@ from flask import (
 )
 
 # local imports
-from fetch_data import fetch_data_api
+from fetch_data import fetch_geoserver_data
 from validate_request import validate_latlon
 from postprocessing import postprocess
 from config import GS_BASE_URL, WEST_BBOX, EAST_BBOX
@@ -53,7 +53,7 @@ def run_fetch_physiography(lat, lon):
     # verify that lat/lon are present
     try:
         results = asyncio.run(
-            fetch_data_api(
+            fetch_geoserver_data(
                 GS_BASE_URL, "physiography", wms_targets, wfs_targets, lat, lon
             )
         )

--- a/routes/taspr.py
+++ b/routes/taspr.py
@@ -30,7 +30,6 @@ from validate_request import (
     validate_var_id,
     validate_year,
 )
-from validate_data import *
 from postprocessing import (
     nullify_and_prune,
     postprocess,

--- a/routes/wet_days_per_year.py
+++ b/routes/wet_days_per_year.py
@@ -5,10 +5,11 @@ from flask import (
     request,
     jsonify,
 )
+from urllib.parse import quote
 
 # local imports
 from generate_urls import generate_wcs_query_url
-from fetch_data import *
+from fetch_data import fetch_data, get_dim_encodings, generate_wcs_getcov_str
 from csv_functions import create_csv
 from validate_request import (
     validate_latlon,

--- a/validate_data.py
+++ b/validate_data.py
@@ -1,9 +1,7 @@
 """A module to validate fetched data values."""
+
 import asyncio
-from config import RAS_BASE_URL, WEB_APP_URL
-from generate_requests import *
-from generate_urls import *
-from luts import place_type_labels
+from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
 
 

--- a/validate_request.py
+++ b/validate_request.py
@@ -7,7 +7,7 @@ import asyncio
 from flask import render_template
 from pyproj import Transformer
 import numpy as np
-from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX, INDICATORS_BBOX
+from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX
 from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
 


### PR DESCRIPTION
This PR replaces all of the unnecessary star imports in the API and explicitly calls the functions that it needs to operate in each route and functionality. 

To test, ensure that all of the endpoints are still operational after this change as this touches a number of different routes and files that contain functions used across the API. 

Closes #349 
Closes #401 