### PR TITLE
hydroviz data via API

### DIFF
--- a/application.py
+++ b/application.py
@@ -35,6 +35,7 @@ def get_service_categories():
         ("Wet Days Per Year", "/wet_days_per_year"),
         ("Wildfire", "/fire"),
         ("Demographics", "/demographics"),
+        ("CONUS Hydrology", "/conus_hydrology"),
     ]
 
 

--- a/generate_requests.py
+++ b/generate_requests.py
@@ -196,3 +196,33 @@ def generate_netcdf_average_wcps_str(bbox_bounds, generate_average_wcps_str_kwar
         **generate_average_wcps_str_kwargs,
     )
     return netcdf_avg_wcps_str
+
+
+def generate_conus_hydrology_wcs_str(
+    cov_id, geom_id, lc=None, model=None, scenario=None, era=None, vars=None
+):
+    # lc, model, scenario, and era arguments must already be encoded to integers before building the request string
+    # TODO: Add support for multiple models, scenarios, and eras etc.
+
+    request_string = f"/ows?&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&"
+    request_string += f"COVERAGEID={cov_id}&"
+    request_string += f"SUBSET=geom_id({geom_id})&"
+
+    if lc is not None:
+        request_string += f"SUBSET=lc({lc})&"
+    if model is not None:
+        request_string += f"SUBSET=model({model})&"
+    if scenario is not None:
+        request_string += f"SUBSET=scenario({scenario})&"
+    if era is not None:
+        request_string += f"SUBSET=era({era})&"
+    if vars is not None:
+        if len(vars) == 1:
+            var_string = vars[0]
+        else:
+            var_string = ",".join(vars)
+        request_string += f"RANGESUBSET={var_string}&"
+
+    request_string += f"FORMAT=application/netcdf"
+
+    return request_string

--- a/generate_requests.py
+++ b/generate_requests.py
@@ -198,31 +198,22 @@ def generate_netcdf_average_wcps_str(bbox_bounds, generate_average_wcps_str_kwar
     return netcdf_avg_wcps_str
 
 
-def generate_conus_hydrology_wcs_str(
-    cov_id, geom_id, lc=None, model=None, scenario=None, era=None, vars=None
-):
-    # lc, model, scenario, and era arguments must already be encoded to integers before building the request string
-    # TODO: Add support for multiple models, scenarios, and eras etc.
+def generate_conus_hydrology_wcs_str(cov_id, geom_id):
+    """Generate a WCS GetCoverage request for fetching CONUS hydrology data.
+    Args:
+        cov_id (str): Coverage ID
+        geom_id (str): Geometry ID
+    Returns:
+        request_string (str): WCS GetCoverage Request to append to a query URL
+    """
 
-    request_string = f"/ows?&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&"
+    request_string = f"ows?&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&"
     request_string += f"COVERAGEID={cov_id}&"
+
+    # adding the model subset because there is a bug with the default rasql query
+    request_string += f"SUBSET=model(0,12)&"
+
     request_string += f"SUBSET=geom_id({geom_id})&"
-
-    if lc is not None:
-        request_string += f"SUBSET=lc({lc})&"
-    if model is not None:
-        request_string += f"SUBSET=model({model})&"
-    if scenario is not None:
-        request_string += f"SUBSET=scenario({scenario})&"
-    if era is not None:
-        request_string += f"SUBSET=era({era})&"
-    if vars is not None:
-        if len(vars) == 1:
-            var_string = vars[0]
-        else:
-            var_string = ",".join(vars)
-        request_string += f"RANGESUBSET={var_string}&"
-
     request_string += f"FORMAT=application/netcdf"
 
     return request_string

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -42,10 +42,10 @@ def generate_wfs_search_url(
     """
     distance = "0.7"
     if nearby_fires:
-        ''' 
+        """
         GeoServer only supports degrees, so this is a query for ~70 mile radius.
         https://gis.stackexchange.com/questions/132251/dwithin-wfs-filter-is-not-working
-       '''
+        """
         distance = "1.0"
     wfs_url = (
         GS_BASE_URL
@@ -101,3 +101,11 @@ def generate_wms_and_wfs_query_urls(wms, wms_base, wfs, wfs_base):
     for veclyr in wfs:
         urls.append(wfs_base.format(veclyr, wfs[veclyr]))
     return urls
+
+
+def generate_wfs_conus_hydrology_url(geom_id):
+    wfs_url = (
+        GS_BASE_URL
+        + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:seg&propertyName=(GNIS_NAME,the_geom)&outputFormat=application/json&cql_filter=(seg_id_nat={geom_id})"
+    )
+    return wfs_url

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -16,23 +16,25 @@ def enforce_site_offline():
     return check_site_offline()
 
 
-from .fire import *
-from .permafrost import *
-from .seaice import *
-from .taspr import *
-from .physiography import *
-from .boundary import *
-from .vectordata import *
-from .recache import *
-from .elevation import *
-from .alfresco import *
-from .degree_days import *
-from .snow import *
-from .landfastice import *
-from .beetles import *
-from .eds import *
-from .wet_days_per_year import *
-from .indicators import *
-from .hydrology import *
-from .demographics import *
-from .cmip6 import *
+# many of these fail if I try to use Zeus! So ignore them for hydroviz development
+# from .fire import *
+# from .permafrost import *
+# from .seaice import *
+# from .taspr import *
+# from .physiography import *
+# from .boundary import *
+# from .vectordata import *
+# from .recache import *
+# from .elevation import *
+# from .alfresco import *
+# from .degree_days import *
+# from .snow import *
+# from .landfastice import *
+# from .beetles import *
+# from .eds import *
+# from .wet_days_per_year import *
+# from .indicators import *
+# from .hydrology import *
+# from .demographics import *
+# from .cmip6 import *
+from .conus_hydrology import *

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -1,0 +1,173 @@
+import requests
+import io
+import xarray as xr
+import xml.etree.ElementTree as ET
+import json
+import xml.etree.ElementTree as ET
+from flask import (
+    Blueprint,
+    Response,
+    render_template,
+    request,
+    current_app as app,
+    jsonify,
+)
+
+from generate_requests import generate_conus_hydrology_wcs_str
+from config import RAS_BASE_URL
+from . import routes
+
+cov_id = "conus_hydro_segments_crstephenson"
+# TODO: change this to 'Rasdaman Encoding' once coverage is updated
+encoding_attr = "Encoding"
+
+
+def fetch_hydrology_data(
+    cov_id,
+    encoding_attr,
+    geom_id,
+    lc,
+    model,
+    scenario,
+    era,
+    vars,
+):
+    """
+    Function to fetch hydrology data from Rasdaman. Data is fetched for one geometry ID at a time!
+    The lc, model, scenario, era and vars parameters are all optional; omitting any of these will not slice the datacube
+    in that dimension and will return all data. String parameters (except vars) are encoded to integers before the WCS request.
+    Args:
+        coverage_id (str): Coverage ID for the hydrology data
+        encoding_attr (str): Attribute name that holds dictionary of Rasdaman encodings
+        geom_id (int): Geometry ID for the hydrology data
+        lc (str): Land cover type (dynamic or static)
+        model (str): Model name (e.g. CCSM4)
+        scenario (str): Scenario name (e.g. historical)
+        era (str): Era name (e.g. 1976_2005)
+        vars (list): a list of variable names (e.g. ['dh3', 'dh15'])
+
+    Returns:
+        Xarray dataset with hydrological stats for the requested var/lc/model/scenario/era combination
+    """
+    lc_, model_, scenario_, era_ = encode_parameters(
+        cov_id, encoding_attr, lc, model, scenario, era
+    )
+    # TODO: use RAS_BASE_URL config env variable instead of hardcoded URL
+    url = RAS_BASE_URL + generate_conus_hydrology_wcs_str(
+        cov_id, geom_id, lc_, model_, scenario_, era_, vars
+    )
+
+    print(url)
+
+    with requests.get(url, verify=False) as r:
+        if r.status_code != 200:
+            return render_template("500/server_error.html"), 500
+        ds = xr.open_dataset(io.BytesIO(r.content))
+
+    return ds
+
+
+def encode_parameters(cov_id, encoding_attr, lc, model, scenario, era):
+    """
+    Function to encode the parameters for the Rasdaman request.
+    Searches the XML response from the DescribeCoverage request for the encodings metadata and
+    returns the dictionary of encodings. Encodes the input parameters to integers for the WCS request.
+    Args:
+        cov_id (str): Coverage ID for the hydrology data
+        encoding_attr (str): Attribute name that holds dictionary of Rasdaman encodings
+        lc (str): Land cover type (dynamic or static)
+        model (str): Model name (e.g. CCSM4)
+        scenario (str): Scenario name (e.g. historical)
+        era (str): Era name (e.g. 1976_2005)
+    Returns:
+        Tuple of encoded parameters (integers) for Rasdaman request"""
+
+    url = f"https://zeus.snap.uaf.edu/rasdaman/ows?&SERVICE=WCS&VERSION=2.1.0&REQUEST=DescribeCoverage&COVERAGEID={cov_id}&outputType=GeneralGridCoverage"
+    with requests.get(url, verify=False) as r:
+        if r.status_code != 200:
+            return render_template("500/server_error.html"), 500
+        tree = ET.ElementTree(ET.fromstring(r.content))
+
+    xml_search_string = str(".//{http://www.rasdaman.org}" + encoding_attr)
+    encoding_dict_str = tree.findall(xml_search_string)[0].text
+    encoding_dict = eval(encoding_dict_str)
+
+    if lc is not None:
+        lc_ = encoding_dict["lc"][lc]
+    else:
+        lc_ = None
+
+    if model is not None:
+        model_ = encoding_dict["model"][model]
+    else:
+        model_ = None
+
+    if scenario is not None:
+        scenario_ = encoding_dict["scenario"][scenario]
+    else:
+        scenario_ = None
+
+    if era is not None:
+        era_ = encoding_dict["era"][era]
+    else:
+        era_ = None
+
+    return lc_, model_, scenario_, era_
+
+
+@routes.route("/conus_hydrology/")
+def conus_hydrology_about():
+    return render_template("/documentation/conus_hydrology.html")
+
+
+@routes.route("/conus_hydrology/<geom_id>")
+def run_get_conus_hydrology_point_data(
+    geom_id, lc=None, model=None, scenario=None, era=None, vars=None
+):
+    """
+    Function to fetch hydrology data from Rasdaman for a single geometry ID.
+    Additional reguest arguments can be made for land cover type, model, scenario, era, and variables.
+    For example: /conus_hydrology/12345?lc=dynamic&model=CCSM4&scenario=historical&era=1976_2005&vars=dh3,dh15
+    Args:
+        geom_id (str): Geometry ID for the hydrology data
+    Returns:
+        JSON response with hydrological stats for the requested geom ID.
+    """
+
+    # sort through request arguments and assign to variables, if they exist
+    if request.args.get("lc"):
+        lc = request.args.get("lc")
+
+    if request.args.get("model"):
+        model = request.args.get("model")
+
+    if request.args.get("scenario"):
+        scenario = request.args.get("scenario")
+
+    if request.args.get("era"):
+        era = request.args.get("era")
+
+    if request.args.get("vars"):
+        if len(request.args.get("vars").split(",")) > 1:
+            vars = request.args.get("vars").split(",")
+        else:
+            vars = [request.args.get("vars")]
+
+    ds = fetch_hydrology_data(
+        cov_id, encoding_attr, geom_id, lc, model, scenario, era, vars
+    )
+
+    # save nc to test size of return
+    ds.to_netcdf("/home/jdpaul3/stats_from_geom_id.nc", engine="h5netcdf")
+
+    # # populate the stats in the data dictionary with the hydrology statistics
+    # huc6_data_dict = populate_stats(huc6_data_dict, stats_ds, lc, model, scenario, era)
+
+    # # return Flask JSON Response
+    # json_results = json.dumps(huc6_data_dict, indent=4)
+
+    # # save json to test size of return
+    # with open("/home/jdpaul3/result.json", "w", encoding="utf-8") as f:
+    #     json.dump(json_results, f, ensure_ascii=False, indent=4)
+
+    return "done!"

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -1,9 +1,7 @@
 import requests
 import io
 import xarray as xr
-import xml.etree.ElementTree as ET
 import json
-import xml.etree.ElementTree as ET
 from flask import (
     Blueprint,
     Response,
@@ -18,45 +16,20 @@ from config import RAS_BASE_URL
 from . import routes
 
 cov_id = "conus_hydro_segments_crstephenson"
-# TODO: change this to 'Rasdaman Encoding' once coverage is updated
-encoding_attr = "Encoding"
 
 
-def fetch_hydrology_data(
-    cov_id,
-    encoding_attr,
-    geom_id,
-    lc,
-    model,
-    scenario,
-    era,
-    vars,
-):
+def fetch_hydrology_data(cov_id, geom_id):
     """
     Function to fetch hydrology data from Rasdaman. Data is fetched for one geometry ID at a time!
-    The lc, model, scenario, era and vars parameters are all optional; omitting any of these will not slice the datacube
-    in that dimension and will return all data. String parameters (except vars) are encoded to integers before the WCS request.
     Args:
         coverage_id (str): Coverage ID for the hydrology data
-        encoding_attr (str): Attribute name that holds dictionary of Rasdaman encodings
-        geom_id (int): Geometry ID for the hydrology data
-        lc (str): Land cover type (dynamic or static)
-        model (str): Model name (e.g. CCSM4)
-        scenario (str): Scenario name (e.g. historical)
-        era (str): Era name (e.g. 1976_2005)
-        vars (list): a list of variable names (e.g. ['dh3', 'dh15'])
+        geom_id (str): Geometry ID for the hydrology data
 
     Returns:
-        Xarray dataset with hydrological stats for the requested var/lc/model/scenario/era combination
+        Xarray dataset with hydrological stats for the all var/lc/model/scenario/era combinations for the requested geom ID.
     """
-    lc_, model_, scenario_, era_ = encode_parameters(
-        cov_id, encoding_attr, lc, model, scenario, era
-    )
-    # TODO: use RAS_BASE_URL config env variable instead of hardcoded URL
-    url = RAS_BASE_URL + generate_conus_hydrology_wcs_str(
-        cov_id, geom_id, lc_, model_, scenario_, era_, vars
-    )
 
+    url = RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, geom_id)
     print(url)
 
     with requests.get(url, verify=False) as r:
@@ -67,52 +40,116 @@ def fetch_hydrology_data(
     return ds
 
 
-def encode_parameters(cov_id, encoding_attr, lc, model, scenario, era):
+# might use the code below if we want to request only subsets of the datacube; right now we are requesting the entire contents for the geom ID
+# def encode_parameters(cov_id, encoding_attr, lc, model, scenario, era):
+#     """
+#     Function to encode the parameters for the Rasdaman request.
+#     Searches the XML response from the DescribeCoverage request for the encodings metadata and
+#     returns the dictionary of encodings. Encodes the input parameters to integers for the WCS request.
+#     Args:
+#         cov_id (str): Coverage ID for the hydrology data
+#         encoding_attr (str): Attribute name that holds dictionary of Rasdaman encodings
+#         lc (str): Land cover type (dynamic or static)
+#         model (str): Model name (e.g. CCSM4)
+#         scenario (str): Scenario name (e.g. historical)
+#         era (str): Era name (e.g. 1976_2005)
+#     Returns:
+#         Tuple of encoded parameters (integers) for Rasdaman request"""
+
+#     url = RAS_BASE_URL + f"ows?&SERVICE=WCS&VERSION=2.1.0&REQUEST=DescribeCoverage&COVERAGEID={cov_id}&outputType=GeneralGridCoverage"
+#     with requests.get(url, verify=False) as r:
+#         if r.status_code != 200:
+#             return render_template("500/server_error.html"), 500
+#         tree = ET.ElementTree(ET.fromstring(r.content))
+
+#     xml_search_string = str(".//{http://www.rasdaman.org}" + encoding_attr)
+#     encoding_dict_str = tree.findall(xml_search_string)[0].text
+#     encoding_dict = eval(encoding_dict_str)
+
+#     if lc is not None:
+#         lc_ = encoding_dict["lc"][lc]
+#     else:
+#         lc_ = None
+
+#     if model is not None:
+#         model_ = encoding_dict["model"][model]
+#     else:
+#         model_ = None
+
+#     if scenario is not None:
+#         scenario_ = encoding_dict["scenario"][scenario]
+#     else:
+#         scenario_ = None
+
+#     if era is not None:
+#         era_ = encoding_dict["era"][era]
+#     else:
+#         era_ = None
+
+#     return lc_, model_, scenario_, era_
+
+
+def build_dict_and_populate_stats(geom_id, ds):
     """
-    Function to encode the parameters for the Rasdaman request.
-    Searches the XML response from the DescribeCoverage request for the encodings metadata and
-    returns the dictionary of encodings. Encodes the input parameters to integers for the WCS request.
+    Function to populate the stats in the data dictionary with the hydrology statistics.
+    The levels of the stats data dictionary are as follows: landcover, model, scenario, era, variable.
     Args:
-        cov_id (str): Coverage ID for the hydrology data
-        encoding_attr (str): Attribute name that holds dictionary of Rasdaman encodings
-        lc (str): Land cover type (dynamic or static)
-        model (str): Model name (e.g. CCSM4)
-        scenario (str): Scenario name (e.g. historical)
-        era (str): Era name (e.g. 1976_2005)
+        geom_id (str): Geometry ID for the hydrology data
+        ds (xarray dataset): Dataset with hydrological stats for the geom ID
+        data_dict (dict): Data dictionary to populate with the hydrology stats
     Returns:
-        Tuple of encoded parameters (integers) for Rasdaman request"""
+        Data dictionary with the hydrology stats populated.
+    """
 
-    url = f"https://zeus.snap.uaf.edu/rasdaman/ows?&SERVICE=WCS&VERSION=2.1.0&REQUEST=DescribeCoverage&COVERAGEID={cov_id}&outputType=GeneralGridCoverage"
-    with requests.get(url, verify=False) as r:
-        if r.status_code != 200:
-            return render_template("500/server_error.html"), 500
-        tree = ET.ElementTree(ET.fromstring(r.content))
+    data_dict = {
+        geom_id: {"name": None, "centroid_lat": None, "centroid_lon": None, "stats": {}}
+    }
 
-    xml_search_string = str(".//{http://www.rasdaman.org}" + encoding_attr)
-    encoding_dict_str = tree.findall(xml_search_string)[0].text
-    encoding_dict = eval(encoding_dict_str)
+    # get the stats from the dataset for each landcover, model, scenario, era, and variable.
+    vars = list(ds.data_vars)
+    for lc in ds.lc.values:
+        data_dict[geom_id]["stats"][lc] = {}
+        for model in ds.model.values:
+            data_dict[geom_id]["stats"][lc][model] = {}
+            for scenario in ds.scenario.values:
+                data_dict[geom_id]["stats"][lc][model][scenario] = {}
+                for era in ds.era.values:
+                    data_dict[geom_id]["stats"][lc][model][scenario][era] = {}
+                    stats_dict = {}
+                    for var in vars:
+                        stat_value = float(
+                            ds[var].sel(lc=lc, model=model, scenario=scenario, era=era)
+                        )
+                        stats_dict[var] = stat_value
+                        data_dict[geom_id]["stats"][lc][model][scenario][
+                            era
+                        ] = stats_dict
 
-    if lc is not None:
-        lc_ = encoding_dict["lc"][lc]
-    else:
-        lc_ = None
+    data_dict = encode_data_dict(data_dict, ds)
 
-    if model is not None:
-        model_ = encoding_dict["model"][model]
-    else:
-        model_ = None
+    return data_dict
 
-    if scenario is not None:
-        scenario_ = encoding_dict["scenario"][scenario]
-    else:
-        scenario_ = None
 
-    if era is not None:
-        era_ = encoding_dict["era"][era]
-    else:
-        era_ = None
+# def populate_attributes(geom_id, data_dict):
+#    for idx, row in huc_segments.iterrows():
 
-    return lc_, model_, scenario_, era_
+#         geojson = (
+#             huc_segments[["seg_id_nat", "GNIS_NAME", "geometry"]]
+#             .loc[idx]
+#             .to_json(default_handler=str)
+#         )
+
+#         segment_dict = dict(
+#             {
+#                 "name": row.GNIS_NAME,
+#                 "data_by_model": dict({}),
+#                 "geojson": geojson,
+#             }
+#         )
+
+#         data_dict["segments"][row.seg_id_nat] = segment_dict
+
+#     return data_dict
 
 
 @routes.route("/conus_hydrology/")
@@ -121,9 +158,7 @@ def conus_hydrology_about():
 
 
 @routes.route("/conus_hydrology/<geom_id>")
-def run_get_conus_hydrology_point_data(
-    geom_id, lc=None, model=None, scenario=None, era=None, vars=None
-):
+def run_get_conus_hydrology_point_data(geom_id):
     """
     Function to fetch hydrology data from Rasdaman for a single geometry ID.
     Additional reguest arguments can be made for land cover type, model, scenario, era, and variables.
@@ -133,41 +168,37 @@ def run_get_conus_hydrology_point_data(
     Returns:
         JSON response with hydrological stats for the requested geom ID.
     """
-
+    # might incorporate the code below if we want to field GET requests for further subsetting of the datacube
     # sort through request arguments and assign to variables, if they exist
-    if request.args.get("lc"):
-        lc = request.args.get("lc")
+    # if request.args.get("lc"):
+    #     lc = request.args.get("lc")
+    # if request.args.get("model"):
+    #     model = request.args.get("model")
+    # if request.args.get("scenario"):
+    #     scenario = request.args.get("scenario")
+    # if request.args.get("era"):
+    #     era = request.args.get("era")
+    # if request.args.get("vars"):
+    #     if len(request.args.get("vars").split(",")) > 1:
+    #         vars = request.args.get("vars").split(",")
+    #     else:
+    #         vars = [request.args.get("vars")]
 
-    if request.args.get("model"):
-        model = request.args.get("model")
-
-    if request.args.get("scenario"):
-        scenario = request.args.get("scenario")
-
-    if request.args.get("era"):
-        era = request.args.get("era")
-
-    if request.args.get("vars"):
-        if len(request.args.get("vars").split(",")) > 1:
-            vars = request.args.get("vars").split(",")
-        else:
-            vars = [request.args.get("vars")]
-
-    ds = fetch_hydrology_data(
-        cov_id, encoding_attr, geom_id, lc, model, scenario, era, vars
-    )
-
+    ds = fetch_hydrology_data(cov_id, geom_id)
     # save nc to test size of return
     ds.to_netcdf("/home/jdpaul3/stats_from_geom_id.nc", engine="h5netcdf")
 
-    # # populate the stats in the data dictionary with the hydrology statistics
-    # huc6_data_dict = populate_stats(huc6_data_dict, stats_ds, lc, model, scenario, era)
+    # build the data dictionary and populate with the hydrology statistics
+    data_dict = build_dict_and_populate_stats(geom_id, ds)
 
-    # # return Flask JSON Response
-    # json_results = json.dumps(huc6_data_dict, indent=4)
+    # populate attributes from vector data
+    # data_dict = populate_attributes(geom_id, data_dict)
 
-    # # save json to test size of return
-    # with open("/home/jdpaul3/result.json", "w", encoding="utf-8") as f:
-    #     json.dump(json_results, f, ensure_ascii=False, indent=4)
+    # return Flask JSON Response
+    json_results = json.dumps(data_dict, indent=4)
 
-    return "done!"
+    # save json to test size of return
+    with open("/home/jdpaul3/result.json", "w", encoding="utf-8") as f:
+        json.dump(json_results, f, ensure_ascii=False, indent=4)
+
+    return Response(json_results, mimetype="application/json")

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -97,7 +97,7 @@ def build_dict_and_populate_stats(geom_id, ds):
     lc_dict, model_dict, scenario_dict, era_dict = build_decode_dicts(ds, encoding_attr)
 
     data_dict = {
-        geom_id: {"name": None, "centroid_lat": None, "centroid_lon": None, "stats": {}}
+        geom_id: {"name": None, "latitude": None, "longitude": None, "stats": {}}
     }
 
     # get the stats from the dataset for each landcover, model, scenario, era, and variable.
@@ -229,6 +229,6 @@ def run_get_conus_hydrology_point_data(geom_id):
 
     # save json to test size of return
     with open("/home/jdpaul3/result.json", "w", encoding="utf-8") as f:
-        json.dump(json_results, f, ensure_ascii=False, indent=4)
+        json.dump(json_results, f)
 
     return Response(json_results, mimetype="application/json")


### PR DESCRIPTION
This PR adds an endpoint to access data for the SECASC Hydroviz project. Append a unique identifier for stream geometry features (i.e. `geom_id`) to the route URL to fetch data for that stream segment. For example:

`http://localhost:5000/conus_hydrology/1000` to fetch data for stream segment 1000.

Data is pulled from both Geoserver and Rasdaman. 

**NOTE: the shapefiles on Geoserver and the coverage on Rasdaman will likely be updated or otherwise revised in the future, which will probably break things in this branch.**

To test, set environment variables as below and start the app as instructed in the `README.md`:

```
export FLASK_APP=application.py
export FLASK_DEBUG=True
export API_GS_BASE_URL=https://gs.earthmaps.io/geoserver[/](https://gs.earthmaps.io/geoserver/)
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
```

Confirm that this works in general, and check out the JSON output for a stream segment. Any ideas for improvement here? Should we incorporate more request flexibility into the route?

I was considering adding support for GET parameters to make specific requests, but I don't know if this level of granularity in the request will be necessary, or if we will always want the whole datacube for the stream segment (for example, something like: `http://localhost:5000/conus_hydrology/1000?model=CCSM4&scenario=rcp85&vars=dh3,dh15,fl1`)



**ALSO NOTE: using Zeus prevents the app from starting (see [this convo](https://uasnap.slack.com/archives/C027TE7VAM8/p1729266492726979) in Slack for details) so `routes.__init__.py` has been modified in the branch as a workaround. Therefore, expect that none of the other endpoints will work when running this branch!**