### PR TITLE
Restore "import re" to fix GET parameter validation

### DIFF
--- a/application.py
+++ b/application.py
@@ -3,6 +3,7 @@ from flask import Flask, render_template, send_from_directory
 from flask_cors import CORS
 from config import SITE_OFFLINE
 from marshmallow import Schema, fields, validate
+import re
 
 from routes import routes, request
 


### PR DESCRIPTION
Closes #484.

This PR simply adds `import re` back into `application.py` to fix our regex GET parameter validation.

To replicate the problem:

```
git checkout main
export FLASK_APP=application.py
pipenv run flask run
```

And observe the error when using the `vars` GET parameter here:

http://localhost:5000/cmip6/point/65/-147?vars=tas,sfcWind

To see the fix:

```
git checkout import_re_module
pipenv run flask run
```

And visit this same URL (you may need to do a hard reload with Shift + Reload to see the difference):

http://localhost:5000/cmip6/point/65/-147?vars=tas,sfcWind