### PR TITLE
Validate CMIP6 lat/lons against CMIP6-specific BBOX

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ RAS_BASE_URL = os.getenv("API_RAS_BASE_URL") or "https://apollo.snap.uaf.edu/ras
 WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]
-INDICATORS_BBOX = [0, 49.94, 359.37, 90]
+CMIP6_BBOX = [-180, 49.95, 180, 90]
 WEB_APP_URL = os.getenv("WEB_APP_URL") or "https://northernclimatereports.org/"
 
 if os.getenv("SITE_OFFLINE"):

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -11,7 +11,7 @@ from validate_request import (
 from postprocessing import postprocess, prune_nulls_with_max_intensity
 from csv_functions import create_csv
 from . import routes
-from config import WEST_BBOX, EAST_BBOX
+from config import CMIP6_BBOX
 
 cmip6_api = Blueprint("cmip6_api", __name__)
 
@@ -127,14 +127,12 @@ def run_fetch_cmip6_monthly_point_data(lat, lon):
         example request: http://localhost:5000/cmip6/point/65.06/-146.16?vars=tas,pr
     """
     # Validate the lat/lon values
-    validation = validate_latlon(lat, lon)
+    validation = validate_latlon(lat, lon, CMIP6_BBOX)
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
         return (
-            render_template(
-                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
-            ),
+            render_template("422/invalid_cmip6_latlon.html", bbox=CMIP6_BBOX),
             422,
         )
     try:

--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -29,7 +29,7 @@ from validate_request import (
 from postprocessing import nullify_and_prune, postprocess
 from csv_functions import create_csv
 from . import routes
-from config import WEST_BBOX, EAST_BBOX
+from config import WEST_BBOX, EAST_BBOX, CMIP6_BBOX
 
 indicators_api = Blueprint("indicators_api", __name__)
 # Rasdaman targets
@@ -329,14 +329,12 @@ def run_fetch_cmip6_indicators_point_data(lat, lon):
     """
 
     # Validate the lat/lon values
-    validation = validate_latlon(lat, lon)
+    validation = validate_latlon(lat, lon, CMIP6_BBOX)
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
         return (
-            render_template(
-                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
-            ),
+            render_template("422/invalid_cmip6_latlon.html", bbox=CMIP6_BBOX),
             422,
         )
     try:

--- a/templates/422/invalid_cmip6_latlon.html
+++ b/templates/422/invalid_cmip6_latlon.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Invalid coordinates</h3>
+
+<div id="map"></div>
+
+<p>
+  Provided coordinates are outside of the valid range. Coordinates must be
+  within the following bounding box:
+</p>
+<h4 class="mt-4">Bounding box:</h4>
+<p>
+  <strong>Latitude:</strong> <code>{{ bbox[1] }}</code> to <code>{{ bbox[3] }}</code>
+</p>
+<p>
+  <strong>Longitude:</strong> <code>{{ bbox[0] }}</code> to <code>{{ bbox[2] }}</code>
+</p>
+
+
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+<script>
+  var map = L.map('map', { zoomControl: false, scrollWheelZoom: false }).setView([61.0, -151.505], 5);
+  map.attributionControl.setPrefix('');
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+
+  var bbox = {{ bbox }}
+  var southWest = L.latLng(bbox[1], bbox[0]),
+    northEast = L.latLng(bbox[3], bbox[2]),
+    bounds = L.latLngBounds(southWest, northEast);
+
+  L.rectangle(bounds, { color: "#F1891E", weight: 3 }).addTo(map);
+
+  map.fitBounds(bounds);
+</script>
+{% endblock %}

--- a/validate_request.py
+++ b/validate_request.py
@@ -12,7 +12,7 @@ from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
 
 
-def validate_latlon(lat, lon):
+def validate_latlon(lat, lon, bbox=None):
     """Validate the lat and lon values.
     Return True if valid or HTTP status code if validation failed
     """
@@ -26,8 +26,14 @@ def validate_latlon(lat, lon):
     if not lat_in_world or not lon_in_world:
         return 400  # HTTP status code
 
+    # Use bbox if provided, otherwise default to WEST_BBOX and EAST_BBOX
+    if bbox:
+        bboxes = [bbox]
+    else:
+        bboxes = [WEST_BBOX, EAST_BBOX]
+
     # Validate against two different BBOXes to deal with antimeridian issues
-    for bbox in [WEST_BBOX, EAST_BBOX]:
+    for bbox in bboxes:
         valid_lat = bbox[1] <= lat_float <= bbox[3]
         valid_lon = bbox[0] <= lon_float <= bbox[2]
         if valid_lat and valid_lon:


### PR DESCRIPTION
Closes #493.

This PR validates lat/lon coordinates for CMIP6-based endpoints against a CMIP6-specific BBOX, which includes everything above ~49.95 latitude. Without this change, CMIP6 endpoints were being validated against the same Alaska-centric East/West BBOXes as the other endpoints, which is just a small subset of the CMIP6 extent.

To test, verify that the following example URLs return data:

http://localhost:5000/indicators/cmip6/point/85/175
http://localhost:5000/cmip6/point/85/175?vars=tas,pr

And also verify that the following two URLs return an error page describing the valid CMIP6 BBOX:

http://localhost:5000/indicators/cmip6/point/30/175
http://localhost:5000/cmip6/point/30/175

@charparr, I'm tagging you for this review since (if memory serves) you were working on an overhaul of the BBOX validation error page recently, and I want to make sure this doesn't conflict with your work. Feel free to modify this PR as needed if so!