### PR TITLE
Landfastice update

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -77,8 +77,8 @@ def create_csv(
         properties = gipl_csv(data, endpoint)
     elif endpoint in ["ncar12km_indicators"]:
         properties = ncar12km_indicators_csv(data)
-    elif endpoint == "landfastice":
-        properties = landfastice_csv(data)
+    elif endpoint == "landfast_sea_ice":
+        properties = landfast_sea_ice_csv(data)
     elif endpoint == "permafrost":
         properties = permafrost_csv(data, source_metadata)
     elif endpoint.startswith("places_"):
@@ -558,18 +558,16 @@ def ncar12km_indicators_csv(data):
     }
 
 
-def landfastice_csv(data):
+def landfast_sea_ice_csv(data):
     # Reformat data to nesting structure expected by other CSV functions.
     for key, value in data.items():
-        data[key] = {"status": value}
+        data[key] = {"value": value}
     coords = ["date"]
-    values = ["status"]
+    values = ["value"]
     fieldnames = coords + values
     csv_dicts = build_csv_dicts(data, fieldnames, values=values)
-    metadata = (
-        "# Landfast Ice Status: A 0 value indicates absence and 1 indicates presence.\n"
-    )
-    filename_data_name = "Landfast Ice Extent"
+    metadata = "# Landfast Sea Ice Value Key: 0: Open ocean or non-landfast sea ice; 128: Land; 255: Landfast Sea Ice\n"
+    filename_data_name = "Landfast Sea Ice"
 
     return {
         "csv_dicts": csv_dicts,

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -20,13 +20,18 @@ from aiohttp import ClientSession
 from flask import current_app as app
 from rasterstats import zonal_stats
 from config import RAS_BASE_URL
-from generate_requests import generate_wcs_getcov_str, generate_netcdf_wcs_getcov_str
+from generate_requests import (
+    generate_wcs_getcov_str,
+    generate_netcdf_wcs_getcov_str,
+    generate_wcps_describe_coverage_str,
+)
 from generate_urls import (
     generate_wcs_query_url,
     generate_base_wms_url,
     generate_base_wfs_url,
     generate_wms_and_wfs_query_urls,
     generate_wfs_places_url,
+    generate_describe_coverage_url,
 )
 
 
@@ -586,3 +591,18 @@ def replace_nans(json_str):
     # This is to prevent matches against strings that contain 'nan' within them.
     json_str = re.sub(r"(?<=[,\[\]])nan(?=[,\[\]])", "-9999", json_str)
     return json_str
+
+
+async def describe_via_wcps(cov_id):
+    """Get the metadata in JSON format via a WCPS describe() query request.
+
+    Args:
+        cov_id (str): rasdaman coverage ID
+
+    Returns:
+        json_description (dict): coverage description in JSON format
+    """
+    req_str = generate_wcps_describe_coverage_str(cov_id)
+    req_url = generate_describe_coverage_url(req_str)
+    json_description = await fetch_data([req_url])
+    return json_description

--- a/generate_requests.py
+++ b/generate_requests.py
@@ -196,3 +196,17 @@ def generate_netcdf_average_wcps_str(bbox_bounds, generate_average_wcps_str_kwar
         **generate_average_wcps_str_kwargs,
     )
     return netcdf_avg_wcps_str
+
+
+def generate_wcps_describe_coverage_str(cov_id):
+    """Generate a WCPS DescribeCoverage request for a given coverage.
+
+    The describe() operation returns a description of the coverage equivalent to a WCS DescribeCoverage request, and the output adheres to the same WCS schema, but we're able to get it in JSON format instead of only XML, GML, or string.
+
+    Args:
+        cov_id (str): rasdaman coverage ID
+    Returns:
+        describe_coverage_str (str): encoded WCPS string fragment to append to a query URL
+    """
+    query_str = f'for $c in ({cov_id}) return describe($c, "application/json", "outputType=GeneralGridCoverage")'
+    return quote(query_str)

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -98,3 +98,14 @@ def generate_wms_and_wfs_query_urls(wms, wms_base, wfs, wfs_base):
     for veclyr in wfs:
         urls.append(wfs_base.format(veclyr, wfs[veclyr]))
     return urls
+
+
+def generate_describe_coverage_url(describe_coverage_str):
+    """Generate a WCPS describe() URL from a query string.
+
+    Args:
+        describe_coverage_str (str): encoded WCPS describe() query string
+    Returns:
+        URL for a WCPS describe() request
+    """
+    return f"{RAS_BASE_URL}/ows?&SERVICE=WCS&VERSION=2.1.0&REQUEST=ProcessCoverages&query={describe_coverage_str}"

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -10,6 +10,7 @@ nodata_values = {
     "permafrost": [-9999, -9999.0],
     "taspr": [-9999, -9.223372e18, -9.223372036854776e18],
     "seaice": [120, 253, 254, 255],
+    "landfast_sea_ice": [32, 64, 111],
 }
 
 nodata_mappings = {
@@ -32,7 +33,7 @@ nodata_mappings = {
     "heating_degree_days_Fdays_all": nodata_values["default"],
     "hydrology": nodata_values["hydrology"],
     "hydrology_mmm": nodata_values["hydrology"],
-    "landfastice": [],
+    "landfast_sea_ice": nodata_values["landfast_sea_ice"],
     "ncar12km_indicators": nodata_values["ncar12km_indicators"],
     "permafrost": nodata_values["permafrost"],
     "physiography": [],

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -110,12 +110,11 @@ def run_point_fetch_all_landfastice(lat, lon):
         )
     # next, project the lat lon and determine which coverage to query
     x, y = project_latlon(lat, lon, 3338)
-
-    if validate_xy_in_coverage_extent(x, y, beaufort_meta):
+    # 10 km buffer query for locations at edges of the 3338 projection
+    if validate_xy_in_coverage_extent(x, y, beaufort_meta, tolerance=10000):
         target_coverage = beaufort_daily_slie_id
         target_meta = beaufort_meta
-    elif validate_xy_in_coverage_extent(x, y, chukchi_meta, tolerance=5000):
-        # tolerance of 5 km for the Chukchi Sea region because it at the edge of the bounds for the 3338 projection system
+    elif validate_xy_in_coverage_extent(x, y, chukchi_meta, tolerance=10000):
         target_coverage = chukchi_daily_slie_id
         target_meta = chukchi_meta
     else:
@@ -134,3 +133,12 @@ def run_point_fetch_all_landfastice(lat, lon):
         if hasattr(exc, "status") and exc.status == 404:
             return render_template("404/no_data.html"), 404
         return render_template("500/server_error.html"), 500
+
+
+##
+# rasdaman_response = asyncio.run(fetch_wcs_point_data(x, y, target_coverage))
+# landfastice_time_series = package_landfastice_data(rasdaman_response, target_meta)
+# postprocessed = postprocess(landfastice_time_series, "landfast_sea_ice")
+# if request.args.get("format") == "csv":
+#     return create_csv(postprocessed, "landfast_sea_ice", lat=lat, lon=lon)
+# return postprocessed

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -96,7 +96,7 @@ def run_point_fetch_all_landfastice(lat, lon):
     validation = latlon_is_numeric_and_in_geodetic_range(lat, lon)
     if validation == 400:
         return render_template("400/bad_request.html"), 400
-    # now, we can construct the bboxes to check if the point is within the specific coverage extents
+    # now construct bboxes to check if the point is within any coverage extent
     beaufort_bbox = construct_latlon_bbox_from_coverage_bounds(beaufort_meta)
     chukchi_bbox = construct_latlon_bbox_from_coverage_bounds(chukchi_meta)
     within_bounds = validate_latlon_in_bboxes(lat, lon, [beaufort_bbox, chukchi_bbox])
@@ -110,10 +110,12 @@ def run_point_fetch_all_landfastice(lat, lon):
         )
     # next, project the lat lon and determine which coverage to query
     x, y = project_latlon(lat, lon, 3338)
+
     if validate_xy_in_coverage_extent(x, y, beaufort_meta):
         target_coverage = beaufort_daily_slie_id
         target_meta = beaufort_meta
-    elif validate_xy_in_coverage_extent(x, y, chukchi_meta):
+    elif validate_xy_in_coverage_extent(x, y, chukchi_meta, tolerance=5000):
+        # tolerance of 5 km for the Chukchi Sea region because it at the edge of the bounds for the 3338 projetion system
         target_coverage = chukchi_daily_slie_id
         target_meta = chukchi_meta
     else:

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -110,10 +110,14 @@ def run_point_fetch_all_landfastice(lat, lon):
     # next, project the lat lon and determine which coverage to query
     x, y = project_latlon(lat, lon, 3338)
     # 10 km buffer query for locations at edges of the 3338 projection
-    if validate_xy_in_coverage_extent(x, y, beaufort_meta, tolerance=10000):
+    if validate_xy_in_coverage_extent(
+        x, y, beaufort_meta, east_tolerance=10000, north_tolerance=10000
+    ):
         target_coverage = beaufort_daily_slie_id
         target_meta = beaufort_meta
-    elif validate_xy_in_coverage_extent(x, y, chukchi_meta, tolerance=10000):
+    elif validate_xy_in_coverage_extent(
+        x, y, chukchi_meta, west_tolerance=10000, north_tolerance=10000
+    ):
         target_coverage = chukchi_daily_slie_id
         target_meta = chukchi_meta
     else:

--- a/routes/landfastice.py
+++ b/routes/landfastice.py
@@ -115,7 +115,7 @@ def run_point_fetch_all_landfastice(lat, lon):
         target_coverage = beaufort_daily_slie_id
         target_meta = beaufort_meta
     elif validate_xy_in_coverage_extent(x, y, chukchi_meta, tolerance=5000):
-        # tolerance of 5 km for the Chukchi Sea region because it at the edge of the bounds for the 3338 projetion system
+        # tolerance of 5 km for the Chukchi Sea region because it at the edge of the bounds for the 3338 projection system
         target_coverage = chukchi_daily_slie_id
         target_meta = chukchi_meta
     else:

--- a/templates/422/invalid_latlon_outside_coverage.html
+++ b/templates/422/invalid_latlon_outside_coverage.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %} {% block content %}
+<h3>
+  Requested coordinates are not within the spatial bounds for this endpoint
+</h3>
+
+<div id="map"></div>
+
+<p>
+  The provided coordinates are not within the spatial bounds of the data.
+  Coordinates must be within a bounding prescribed below.
+</p>
+
+{% for bbox in bboxes %}
+<h4 class="mt-4">Bounding box {{ loop.index }}:</h4>
+<p>
+  <strong>Latitude:</strong> <code>{{ bbox[1] }}</code> to
+  <code>{{ bbox[3] }}</code>
+</p>
+<p>
+  <strong>Longitude:</strong> <code>{{ bbox[0] }}</code> to
+  <code>{{ bbox[2] }}</code>
+</p>
+{% endfor %}
+
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+<script>
+  var map = L.map("map", {
+    zoomControl: false,
+    scrollWheelZoom: false,
+  }).setView([61.0, -151.505], 5);
+  map.attributionControl.setPrefix("");
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
+
+  var bboxes = {{ bboxes|tojson }};
+  var allMinLats = [];
+  var allMinLons = [];
+  var allMaxLats = [];
+  var allMaxLons = [];
+  bboxes.forEach(function(bbox) {
+    // create one rectangle for each bounding box
+    allMinLats.push(bbox[1]);
+    allMinLons.push(bbox[0]);
+    allMaxLats.push(bbox[3]);
+    allMaxLons.push(bbox[2]);
+    var southWest = L.latLng(bbox[1], bbox[0]),
+      northEast = L.latLng(bbox[3], bbox[2]),
+      bounds = L.latLngBounds(southWest, northEast);
+
+    L.rectangle(bounds, { color: "#F1891E", weight: 3 }).addTo(map);
+  });
+  // create bounds using smallest of minLats and minLons, largest of maxLats and maxLons
+  var minLat = Math.min.apply(null, allMinLats);
+  var minLon = Math.min.apply(null, allMinLons);
+  var maxLat = Math.max.apply(null, allMaxLats);
+  var maxLon = Math.max.apply(null, allMaxLons);
+  var southWest = L.latLng(minLat, minLon),
+      northEast = L.latLng(maxLat, maxLon),
+      biggest_bounds = L.latLngBounds(southWest, northEast);
+
+
+  map.fitBounds(biggest_bounds);
+</script>
+{% endblock %}

--- a/templates/documentation/landfastice.html
+++ b/templates/documentation/landfastice.html
@@ -2,19 +2,21 @@
 <h2>Landfast Sea Ice Extent</h2>
 
 <p>
-  This endpoint provides access to daily landfast ice extent information for the Alaska coastline at a resolution of
-  100m. Daily data are available from October 1996 &ndash; April 2008. Data were provided by Mahoney et al.
+  This endpoint provides access to daily landfast sea ice extent data at a
+  spatial resolution of 100 m. Data are available October 1996 &ndash; July 2023
+  for the Beaufort Sea region and the Chukchi Sea region.
 </p>
 
-<p>
-  A link to an academic reference is included at the bottom of this page.
-</p>
+<p>Links to academic references are included at the bottom of this page.</p>
 
 <h3>Service endpoints</h3>
 
 <h4>Point query</h4>
 
-<p>Query the daily landfast ice extent for a single point specified by latitude and longitude.</p>
+<p>
+  Query the daily landfast sea ice extent for a single point specified by
+  latitude and longitude.
+</p>
 
 <table class="endpoints">
   <thead>
@@ -26,13 +28,19 @@
   <tbody>
     <tr>
       <td>Landfast sea ice extent point query</td>
-      <td><a href="/landfastice/point/70.6123/-149.8869">/landfastice/point/70.6123/-149.8869</a>
+      <td>
+        <a href="/landfastice/point/70.6123/-149.8869"
+          >/landfastice/point/70.6123/-149.8869</a
+        >
       </td>
     </tr>
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
+      <td colspan="2">
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL.
+      </td>
     </tr>
   </tfoot>
 </table>
@@ -43,19 +51,13 @@
 
 <pre>
 {
-  "01-01-1997": null,
-  "01-01-1998": null,
-  "01-01-1999": null,
-  "01-01-2000": 1,
-  "01-01-2001": 1,
-  "01-01-2002": 1,
-  "01-01-2003": 1,
-  "01-01-2004": 1,
-  "01-01-2005": 1,
-  "01-01-2006": 1,
-  "01-01-2007": 1,
-  "01-01-2008": null,
+  "1996-10-27": 255,
+  "1996-10-28": 255,
+  "1996-10-29": 255,
   ...
+  "2023-07-29": 0,
+  "2023-07-30": 0,
+  "2023-07-31": 0,
 }
 </pre>
 
@@ -63,7 +65,7 @@
 
 <pre>
 {
-  "&lt;month&gt;-&lt;day&gt;-&lt;year&gt;": &lt;landfast ice presence (1) or absence (null) for a specific date in the time series&gt;,
+  "&lt;year&gt;-&lt;month&gt;-&lt;day&gt;": &lt;landfast ice presence (255) or absence (0) or grid cell classified as land (128) for a specific date in the time series&gt;,
   ...
 }
 </pre>
@@ -73,21 +75,102 @@
 <table>
   <thead>
     <tr>
-      <th>Dataset information</th>
-      <th>Paper</th>
+      <th>Metadata & source data access</th>
+      <th>Academic references</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>Landfast sea ice</td>
-      <td><a href="https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2006JC003559">Link</a></td>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/047e91c7-35c6-410a-a1ef-95539c1ee328"
+          >GeoNetwork PLACEHOLDER</a
+        >
+      </td>
+      <td>
+        Mahoney, A., Eicken, H., Shapiro, L., & Graves, A. (2005). Defining and
+        locating the seaward landfast ice edge in northern Alaska. In 18th
+        International Conference on Port and Ocean Engineering under Arctic
+        Conditions (POAC’05), Potsdam, NY (pp. 991-1001).
+        <a
+          href="https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=a5467a7bbec6a6e31e9898f89041fbb5378a26c2"
+          >https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=a5467a7bbec6a6e31e9898f89041fbb5378a26c2</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        Eicken, H., L. Shapiro, A. G. Gaylord, A. Mahoney, and P. Cotter. 2006.
+        Mapping and Characterization of Recurring Spring Leads and Landfast Ice
+        in the Beaufort and Chukchi Seas. Final Report, Minerals Management
+        Service OCS Study MMS 2005-068.
+        <a
+          href="https://www.boem.gov/sites/default/files/boem-newsroom/Library/Publications/2012/BOEM-2012-067.pdf"
+          >https://www.boem.gov/sites/default/files/boem-newsroom/Library/Publications/2012/BOEM-2012-067.pdf</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        Mahoney, A., Eicken, H., Gaylord, A. G., and Shapiro, L. (2007), Alaska
+        landfast sea ice: Links with bathymetry and atmospheric circulation, J.
+        Geophys. Res., 112, C02001, doi:10.1029/2006JC003559.
+        <a href="https://doi.org/10.1029/2006JC003559"
+          >https://doi.org/10.1029/2006JC003559</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        Eicken, H., L. Shapiro, A. G. Gaylord, A. Mahoney, and P. W. Cotter.
+        2009. Recurring Spring Leads and Landfast Ice in the Beaufort and
+        Chukchi Seas, 1993-2004, Version 1. Boulder, Colorado USA. NSIDC:
+        National Snow and Ice Data Center. doi:
+        <a href="https://doi.org/10.7265/N5SB43P0"
+          >https://doi.org/10.7265/N5SB43P0</a
+        >.
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        Mahoney, A. R., Eicken, H., Gaylord, A. G., & Gens, R. (2014). Landfast
+        sea ice extent in the Chukchi and Beaufort Seas: The annual cycle and
+        decadal variability. Cold Regions Science and Technology, 103, 41-56.
+        <a href="https://doi.org/10.1016/j.coldregions.2014.03.003"
+          >https://doi.org/10.1016/j.coldregions.2014.03.003</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        Mahoney, A. R. (2018), Landfast Sea Ice in a Changing Arctic, in Arctic
+        Report Card 2018, edited by E. Osborne, J. A. Richter-Menge and M. O.
+        Jeffries.
+        <a
+          href="https://arctic.noaa.gov/Report-Card/Report-Card-2018/ArtMID/7878/ArticleID/788/Landfast-Sea-Ice-in-a-Changing-Arctic"
+          >https://arctic.noaa.gov/Report-Card/Report-Card-2018/ArtMID/7878/ArticleID/788/Landfast-Sea-Ice-in-a-Changing-Arctic</a
+        >.
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        Einhorn, A. H. (2024). Continuous Landfast Ice Climatology from
+        1996-2023 and Interferometric Classification of Landfast Ice Stability
+        Along the Outer Alaska Continental Shelf (Master's thesis, University of
+        Alaska Fairbanks).
+        <a
+          href="http://uaf.idm.oclc.org/login?url=https://www.proquest.com/dissertations-theses/continuous-landfast-ice-climatology-1996-2023/docview/3092562275/se-2?accountid=14470"
+          >http://uaf.idm.oclc.org/login?url=https://www.proquest.com/dissertations-theses/continuous-landfast-ice-climatology-1996-2023/docview/3092562275/se-2?accountid=14470</a
+        >
+      </td>
     </tr>
   </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="3"></td>
-    </tr>
-  </tfoot>
 </table>
 
 {% endblock %}

--- a/templates/documentation/landfastice.html
+++ b/templates/documentation/landfastice.html
@@ -83,8 +83,9 @@
     <tr>
       <td>
         <a
-          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/047e91c7-35c6-410a-a1ef-95539c1ee328"
-          >GeoNetwork PLACEHOLDER</a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/5adee563-786d-4b54-bbec-56dea055ec9a"
+          >Beaufort Sea Landfast Sea Ice: Daily Seaward Landfast Ice Edge (SLIE)
+          Extent October 1996 &ndash; July 2023</a
         >
       </td>
       <td>
@@ -99,7 +100,13 @@
       </td>
     </tr>
     <tr>
-      <td></td>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/a6323019-0023-4e0d-98dc-a01b13bb7114"
+          >Chukchi Sea Landfast Sea Ice: Daily Seaward Landfast Ice Edge (SLIE)
+          Extent October 1996 &ndash; July 2023</a
+        >
+      </td>
       <td>
         Eicken, H., L. Shapiro, A. G. Gaylord, A. Mahoney, and P. Cotter. 2006.
         Mapping and Characterization of Recurring Spring Leads and Landfast Ice

--- a/validate_request.py
+++ b/validate_request.py
@@ -208,24 +208,30 @@ def get_x_y_axes(coverage_metadata):
         raise ValueError("Unexpected coverage metadata: 'X' or 'Y' axis not found")
 
 
-def validate_xy_in_coverage_extent(x, y, coverage_metadata):
+def validate_xy_in_coverage_extent(x, y, coverage_metadata, tolerance=None):
     """Validate if the x and y coordinates are within the bounding box of the coverage.
 
     Args:
         x (float): x-coordinate
         y (float): y-coordinate
         coverage_metadata (dict): JSON-like dictionary containing coverage metadata
+        tolerance (float): Optional tolerance to expand the bounding box, will be in units native to the coverage, e.g. meters for EPSG:3338. This parameter is included to hedge against the edge: query locations where the query is within the geographic bounding box, but not the projected bounding box due to distortion at the edges of conical projections.
 
     Returns:
         bool: True if the coordinates are within the bounding box, False otherwise
     """
     try:
         x_axis, y_axis = get_x_y_axes(coverage_metadata)
+        if tolerance:
+            x_axis["lowerBound"] -= tolerance
+            x_axis["upperBound"] += tolerance
+            y_axis["lowerBound"] -= tolerance
+            y_axis["upperBound"] += tolerance
 
         x_in_bounds = x_axis["lowerBound"] <= x <= x_axis["upperBound"]
         y_in_bounds = y_axis["lowerBound"] <= y <= y_axis["upperBound"]
-
         return x_in_bounds and y_in_bounds
+
     except ValueError:
         return False
 

--- a/validate_request.py
+++ b/validate_request.py
@@ -208,25 +208,39 @@ def get_x_y_axes(coverage_metadata):
         raise ValueError("Unexpected coverage metadata: 'X' or 'Y' axis not found")
 
 
-def validate_xy_in_coverage_extent(x, y, coverage_metadata, tolerance=None):
+def validate_xy_in_coverage_extent(
+    x,
+    y,
+    coverage_metadata,
+    east_tolerance=None,
+    west_tolerance=None,
+    north_tolerance=None,
+    south_tolerance=None,
+):
     """Validate if the x and y coordinates are within the bounding box of the coverage.
 
     Args:
         x (float): x-coordinate
         y (float): y-coordinate
         coverage_metadata (dict): JSON-like dictionary containing coverage metadata
-        tolerance (float): Optional tolerance to expand the bounding box, will be in units native to the coverage, e.g. meters for EPSG:3338. This parameter is included to hedge against the edge: query locations where the query is within the geographic bounding box, but not the projected bounding box due to distortion at the edges of conical projections. Without this, users may experience errors because it is possible for a geographic point to be within the geographic bounding box, but the same point, projected, to be outside the projected bounding box.
+        east_tolerance (float): Optional tolerance to expand the bounding box to the east, will be in units native to the coverage, e.g. meters for EPSG:3338. This parameter is included to hedge against the edge: query locations where the query is within the geographic bounding box, but not the projected bounding box due to distortion at the edges of conical projections. Without this, users may experience errors because it is possible for a geographic point to be within the geographic bounding box, but the same point, projected, to be outside the projected bounding box.
+        west_tolerance (float): Optional tolerance to expand the bounding box to the west
+        north_tolerance (float): Optional tolerance to expand the bounding box to the north
+        south_tolerance (float): Optional tolerance to expand the bounding box to the south
 
     Returns:
         bool: True if the coordinates are within the bounding box, False otherwise
     """
     try:
         x_axis, y_axis = get_x_y_axes(coverage_metadata)
-        if tolerance:
-            x_axis["lowerBound"] -= tolerance
-            x_axis["upperBound"] += tolerance
-            y_axis["lowerBound"] -= tolerance
-            y_axis["upperBound"] += tolerance
+        if west_tolerance:
+            x_axis["lowerBound"] -= west_tolerance
+        if east_tolerance:
+            x_axis["upperBound"] += east_tolerance
+        if north_tolerance:
+            y_axis["upperBound"] += north_tolerance
+        if south_tolerance:
+            y_axis["upperBound"] -= south_tolerance
 
         x_in_bounds = x_axis["lowerBound"] <= x <= x_axis["upperBound"]
         y_in_bounds = y_axis["lowerBound"] <= y <= y_axis["upperBound"]

--- a/validate_request.py
+++ b/validate_request.py
@@ -215,7 +215,7 @@ def validate_xy_in_coverage_extent(x, y, coverage_metadata, tolerance=None):
         x (float): x-coordinate
         y (float): y-coordinate
         coverage_metadata (dict): JSON-like dictionary containing coverage metadata
-        tolerance (float): Optional tolerance to expand the bounding box, will be in units native to the coverage, e.g. meters for EPSG:3338. This parameter is included to hedge against the edge: query locations where the query is within the geographic bounding box, but not the projected bounding box due to distortion at the edges of conical projections.
+        tolerance (float): Optional tolerance to expand the bounding box, will be in units native to the coverage, e.g. meters for EPSG:3338. This parameter is included to hedge against the edge: query locations where the query is within the geographic bounding box, but not the projected bounding box due to distortion at the edges of conical projections. Without this, users may experience errors because it is possible for a geographic point to be within the geographic bounding box, but the same point, projected, to be outside the projected bounding box.
 
     Returns:
         bool: True if the coordinates are within the bounding box, False otherwise

--- a/validate_request.py
+++ b/validate_request.py
@@ -184,7 +184,7 @@ def project_latlon(lat1, lon1, dst_crs, lat2=None, lon2=None):
 def get_x_y_axes(coverage_metadata):
     """Extract the X and Y axes from the coverage metadata.
 
-    We're doing this because we won't always know the axis ordering and posiition that come from Rasdaman. They are usually the last two axes, but their exact numbering might depend on on how many axes the coverage has. So we can iterate through the axes and find the ones with the axisLabel "X" and "Y" and grab them with `next()`.
+    We're doing this because we won't always know the axis ordering and position that come from Rasdaman. They are usually the last two axes, but their exact numbering might depend on on how many axes the coverage has. So we can iterate through the axes and find the ones with the axisLabel "X" and "Y" and grab them with `next()`.
 
     Args:
         coverage_metadata (dict): JSON-like dictionary containing coverage metadata


### PR DESCRIPTION
This PR basically swaps the backend for the landfast sea ice endpoint. The endpoint is functionally quite similar, but the geographic and temporal ranges are extended. The possible set of returned values is also a bit different. Check the refreshed template for details. Here's what to look for in this review (some of this was foreshadowed in our tech gardening / show+tell chat):

#### A new implementation of the DescribeCoverage request

* Checkout the new function `generate_wcps_describe_coverage_str` in the `generate_requests` module. We're forming a request to describe the coverage using the WCPS `describe()` operator because we can get a response that is a well-formatted JSON that is far easier to parse than the prior XML/string babble. We'll see how this is used later on.
* Next, look at the new `generate_describe_coverage_url` function in the `generate_urls` module - this just inserts the previous function's return into a URL so we can make the request.
* Now, look at the new `describe_via_wcps` function in the `fetch_data` module  - this function is responsible for firing off the awaitable request and receiving the response.
* None of these three functions are that much different that what we've been doing already, and some of the other functions could probably have been extended to accomplish the goal of describing coverages via the WCPS `describe()` operator - but I'm personally in favor of having functions that do one thing and one thing only when possible: this chain of execution where `describe_via_wcps()` calls `generate_wcps_describe_coverage_str()` and `generate_describe_coverage_url()`
has the sole purpose of fetching a coverage description in JSON format.

#### A new implementation of lat-lon request validation

The JSON-ified coverage description makes it so much easier to determine what spatial bounding box is valid for a coverage. With such bounding boxes, we can validate requests more precisely on a coverage-by-coverage basis, and can leverage the self-describing nature of OGC Coverages. Our current practice is to prescribe ad hoc bounding box prescriptions in `config` that are decoupled from the coverage they are referencing. So, there are **a few new functions in the `validate_request` module to know about!**

* First, look at the `get_x_y_axes()` function - this will just ID and return which axes of the coverage have the spatial (i.e. X and Y) information.
* Second, see the `construct_latlon_bbox_from_coverage_bounds()` function that constructs a lat-lon bounding box from the metadata returned by `describe_via_wcps`. These bounding boxes are just like those prescribed in our `config.py` and used in our existing validation scheme. Note that this function just returns the bounding box, and doesn't do any validation.
* Third, take a look at the `validate_latlon_in_bboxes()` function that iterates through a list of bounding boxes and so long as the given lat and lon are within **at least one of those boxes** a `True` value is returned, and otherwise a `422` code is thrown. A list of bounding boxes is implemented because the landfast sea ice data is split between two coverages, and we need to know if a query lands in either one.
* Next, look at `validate_xy_in_coverage_extent()` - at first glance this function might seem a bit redundant with the previous function. But this function is specific: it returns a boolean based on whether or not an x-y coordinate is within a single coverage's bounding box. One way to distinguish this function from the previous could be to think of it this way: This asks "Am in the bounding box for this specific coverage?" while the previous function asks "Am in the possible set of bounding boxes encompassed by this endpoint?"
* Finally, there is a function called `latlon_is_numeric_and_in_geodetic_range()` that does the “bad request” part of the validation. This function splits out part of the existing functionality of the `validate_lat_lon` function, because the `validate_lat_lon` function actually doing two things: checking the bbox against the config prescription, and ensuring that the lat-lon is numeric and on planet Earth. Observe the repeated code between `validate_lat_lon` and `validate_seaice_lat_lon`. The new `latlon_is_numeric_and_in_geodetic_range()` function is a step toward DRY-ing the request validation, and is the first function in the validation tree for the updated landfast sea ice endpoint. Also, just to avoid confusion, the `validate_seaice_lat_lon` is **not** for the landfast sea ice endpoint considered in this PR.


#### Whew, OK, now to test the endpoint itself:

* First, you need to modify the imports in `routes/__init__.py` to look like this (for details XREF #481):
```python
# from .fire import *
# from .permafrost import *
# from .seaice import *
# from .taspr import *
# from .physiography import *
# from .boundary import *
# from .vectordata import *
# from .recache import *
# from .elevation import *
# from .alfresco import *
# from .degree_days import *
# from .snow import *

from .landfastice import *

# from .beetles import *
# from .eds import *
# from .wet_days_per_year import *
# from .indicators import *
# from .hydrology import *
# from .demographics import *
# from .cmip6 import *
```

* Point the API at Datacubes aka Zeus:
```sh
export API_RAS_BASE_URL=https://datacubes.earthmaps.io/rasdaman
```

- Now, try some requests that **should not yield a valid data response.**
  - Requests like these should trigger a 400 Bad Request template:
    - http://localhost:5000/landfastice/point/400/-12345/
    - http://localhost:5000/landfastice/point/foo/bar/
  - Requests like these should trigger a 422 and send you to a brand new `invalid_latlon_outside_coverage` template! Check out this template - what do you think? Suggestions? Also, please look at the code for the template itself closely as I had to lean on AI heavily here to figure out the leaflet JS part.
    - http://localhost:5000/landfastice/point/65/-145/
    - http://localhost:5000/landfastice/point/62/-172/
  - Requests like these should trigger a 404 No Data template.
    - http://localhost:5000/landfastice/point/71/-134/
    - http://localhost:5000/landfastice/point/71/-172/
- Now, try some requests that **should yield a valid data response.** Some of these might take a while to complete, so you may need to refresh if it seems like they time out.
  - http://localhost:5000/landfastice/point/70.6123/-149.8869/
  - http://localhost:5000/landfastice/point/71.2926/-156.7956?format=csv
  - And here are some other lat-lons you might try for pixels that are in the ocean, but are near a named community:
```python
Deadhorse: {'latitude': 70.2993, 'longitude': -148.4942}
Kaktovik: {'latitude': 70.1056, 'longitude': -143.6875}
Nuiqsut: {'latitude': 70.3527, 'longitude': -151.1869}
Prudhoe Bay: {'latitude': 70.3028, 'longitude': -148.3779}
Utqiaġvik: {'latitude': 71.2926, 'longitude': -156.7956}
Wainwright: {'latitude': 70.6301, 'longitude': -160.2603}
Candle: {'latitude': 66.0019, 'longitude': -161.933}
Cape Lisburne: {'latitude': 68.8687, 'longitude': -166.2243}
Deering: {'latitude': 66.0759, 'longitude': -162.7157}
Diomede: {'latitude': 65.7769, 'longitude': -168.8938}
Elephant Point: {'latitude': 66.2676, 'longitude': -161.3338}
Kivalina: {'latitude': 67.7282, 'longitude': -164.532}
Kiwalik: {'latitude': 66.0336, 'longitude': -161.8338}
Kotzebue: {'latitude': 66.8995, 'longitude': -162.5982}
Point Hope: {'latitude': 68.3447, 'longitude': -166.7331}
Point Lay: {'latitude': 69.7577, 'longitude': -163.052}
Shishmaref: {'latitude': 66.2569, 'longitude': -166.0729}
Tin City: {'latitude': 65.5707, 'longitude': -168.048}
Wales: {'latitude': 65.6087, 'longitude': -168.0923}
```

Closes #220 
Closes #221