### PR TITLE
Refactor dim encodings fetch

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -18,7 +18,6 @@ from functools import reduce
 from aiohttp import ClientSession
 from flask import current_app as app
 from rasterstats import zonal_stats
-from config import RAS_BASE_URL
 from generate_requests import (
     generate_wcs_getcov_str,
     generate_netcdf_wcs_getcov_str,

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -15,7 +15,6 @@ import json
 import re
 from collections import defaultdict
 from functools import reduce
-from lxml import etree as ET
 from aiohttp import ClientSession
 from flask import current_app as app
 from rasterstats import zonal_stats

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -444,52 +444,6 @@ def get_from_dict(data_dict, map_list):
     return reduce(operator.getitem, map_list, data_dict)
 
 
-def parse_meta_xml_str(meta_xml_str):
-    """Parse the DescribeCoverage request to get the XML and
-    restructure the block called "Encoding" to a dict.
-
-    Arguments:
-        meta_xml_str (str): string representation of the byte XML response from the WCS DescribeCoverage request
-
-    Returns:
-        dim_encodings (dict): lookup table to match data axes or parameters to integer encodings, e.g., '2': 'GFDL-CM3'
-    """
-    xml_bytes = bytes(bytearray(meta_xml_str, encoding="utf-8"))
-    meta_tree = ET.XML(xml_bytes)
-    encoding_el = meta_tree.findall(".//Encoding")[0]
-
-    dim_encodings = {}
-    for dim in encoding_el.iter():
-        if not dim.text.isspace():
-            encoding_di = eval(dim.text)
-            for key, value in encoding_di.items():
-                if isinstance(value, dict):
-                    dim_encodings[key] = {int(k): v for k, v in value.items()}
-                else:
-                    dim_encodings[dim.tag] = {int(k): v for k, v in encoding_di.items()}
-    return dim_encodings
-
-
-def get_xml_content(meta_xml_str, tag, occurrence=1):
-    """Get content of XML element. Use this function to retrieve time axis values that are not encapsulated by a dictionary and/or are not within the metadata 'Encoding' block.
-
-    Arguments:
-        meta_xml_str (str): string representation of the byte XML response from the WCS DescribeCoverage request
-        tag (str): the xml element that encapsulates the desired content, e.g., 'gmlrgrid:coefficients'
-        occurrence (int): the occurrence of the tag to parse. some tags are repeated several times in the XML response
-
-    Returns:
-        tag_content (str): content of the provided XML tag
-    """
-    xml_bytes = bytes(bytearray(meta_xml_str, encoding="utf-8"))
-    meta_tree = ET.XML(xml_bytes)
-    matches = []
-    for match in meta_tree.findall(f".//{tag}", meta_tree.nsmap):
-        matches.append(match.text)
-    tag_content = matches[occurrence - 1]
-    return tag_content
-
-
 def extract_nested_dict_keys(dict_, result_list=None, in_line_list=None):
     """Extract keys of nested dictionary to list of tuples
 

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -490,33 +490,6 @@ def get_xml_content(meta_xml_str, tag, occurrence=1):
     return tag_content
 
 
-async def get_dim_encodings(cov_id, scrape=None):
-    """Get the dimension encodings that map integer values to descriptive strings from a
-    Rasdaman coverage that stores the encodings in a metadata "encodings" attribute. We handle exceptions where the coverage we are requesting encodings from does not exist on the backend to prevent Rasdaman work from blocking API development. We can use the same request to scrape various other parts of the DescribeCoverage XML response, but this optional.
-
-    Args:
-        cov_id (str): ID of the rasdaman coverage
-        scrape (3-tuple): (description (str), tag to scrape between (str), and the occurrence (int) of the tag to search for)
-
-    Returns:
-        dim_encodings (nested dict): a lookup where coverage axis names are keys that store dicts of integer-keyed categories.
-    """
-    meta_url = generate_wcs_query_url(f"DescribeCoverage&COVERAGEID={cov_id}")
-    try:
-        meta_xml_str = await fetch_data([meta_url])
-        dim_encodings = parse_meta_xml_str(meta_xml_str)
-        if scrape is not None:
-            scrape_desc, scrape_tag, occurrence = scrape
-            dim_encodings[scrape_desc] = get_xml_content(
-                meta_xml_str, scrape_tag, occurrence
-            )
-        return dim_encodings
-    except:
-        print(
-            f"Warning: Coverage '{cov_id}' is missing from the Rasdaman server {RAS_BASE_URL} you are using."
-        )
-
-
 def extract_nested_dict_keys(dict_, result_list=None, in_line_list=None):
     """Extract keys of nested dictionary to list of tuples
 

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -2,7 +2,7 @@ from flask import render_template
 
 nodata_values = {
     "beetles": [0],
-    "cmip6_indicators": [-9999, -9999.0],
+    "cmip6_indicators": [-9999, -9999.0, "null"],
     "cmip6_monthly": [-9999, -9999.0, "nan"],
     "default": [-9999],
     "hydrology": [-9999, "nan"],

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -4,10 +4,8 @@ from flask import Blueprint, render_template, request
 # local imports
 from generate_urls import generate_wcs_query_url
 from generate_requests import generate_wcs_getcov_str
-from fetch_data import fetch_data, get_dim_encodings
-from validate_request import (
-    validate_latlon,
-)
+from fetch_data import fetch_data, get_dim_encodings, describe_via_wcps
+from validate_request import validate_latlon, get_coverage_encodings
 from postprocessing import postprocess, prune_nulls_with_max_intensity
 from csv_functions import create_csv
 from . import routes
@@ -17,6 +15,15 @@ cmip6_api = Blueprint("cmip6_api", __name__)
 
 cmip6_monthly_coverage_id = "cmip6_monthly"
 dim_encodings = asyncio.run(get_dim_encodings(cmip6_monthly_coverage_id))
+
+
+async def get_cmip6_metadata():
+    """Get the coverage metadata and encodings for CMIP6 monthly coverage"""
+    metadata = await describe_via_wcps("cmip6_monthly")
+    return get_coverage_encodings(metadata)
+
+
+dim_encodings = asyncio.run(get_cmip6_metadata())
 varnames = dim_encodings["varname"]
 
 

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -4,7 +4,7 @@ from flask import Blueprint, render_template, request
 # local imports
 from generate_urls import generate_wcs_query_url
 from generate_requests import generate_wcs_getcov_str
-from fetch_data import fetch_data, get_dim_encodings, describe_via_wcps
+from fetch_data import fetch_data, describe_via_wcps
 from validate_request import validate_latlon, get_coverage_encodings
 from postprocessing import postprocess, prune_nulls_with_max_intensity
 from csv_functions import create_csv

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -14,12 +14,11 @@ from config import WEST_BBOX, EAST_BBOX
 cmip6_api = Blueprint("cmip6_api", __name__)
 
 cmip6_monthly_coverage_id = "cmip6_monthly"
-dim_encodings = asyncio.run(get_dim_encodings(cmip6_monthly_coverage_id))
 
 
 async def get_cmip6_metadata():
     """Get the coverage metadata and encodings for CMIP6 monthly coverage"""
-    metadata = await describe_via_wcps("cmip6_monthly")
+    metadata = await describe_via_wcps(cmip6_monthly_coverage_id)
     return get_coverage_encodings(metadata)
 
 

--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -13,18 +13,19 @@ from generate_urls import generate_wcs_query_url
 from generate_requests import generate_wcs_getcov_str
 from fetch_data import (
     fetch_data,
-    get_dim_encodings,
     fetch_bbox_data,
     get_poly_3338_bbox,
     get_poly_mask_arr,
     get_from_dict,
     generate_nested_dict,
     itertools,
+    describe_via_wcps,
 )
 from validate_request import (
     validate_latlon,
     project_latlon,
     validate_var_id,
+    get_coverage_encodings,
 )
 from postprocessing import nullify_and_prune, postprocess
 from csv_functions import create_csv
@@ -36,9 +37,21 @@ indicators_api = Blueprint("indicators_api", __name__)
 indicators_coverage_id = "ncar12km_indicators_era_summaries"
 cmip6_indicators_coverage_id = "cmip6_indicators"
 
-# dim encodings for the NCAR 12km BCSD indicators coverage
-base_dim_encodings = asyncio.run(get_dim_encodings(indicators_coverage_id))
-cmip6_dim_encodings = asyncio.run(get_dim_encodings(cmip6_indicators_coverage_id))
+
+async def get_ncar12km_metadata():
+    """Get the coverage metadata and encodings for NCAR 12km indicators coverage"""
+    metadata = await describe_via_wcps(indicators_coverage_id)
+    return get_coverage_encodings(metadata)
+
+
+async def get_cmip6_metadata():
+    """Get the coverage metadata and encodings for CMIP6 indicators coverage"""
+    metadata = await describe_via_wcps(cmip6_indicators_coverage_id)
+    return get_coverage_encodings(metadata)
+
+
+base_dim_encodings = asyncio.run(get_ncar12km_metadata())
+cmip6_dim_encodings = asyncio.run(get_cmip6_metadata())
 
 
 async def fetch_cmip6_indicators_point_data(lat, lon):

--- a/routes/snow.py
+++ b/routes/snow.py
@@ -1,13 +1,15 @@
 import asyncio
+
 import numpy as np
 from flask import Blueprint, render_template, request, jsonify
 
 # local imports
 from fetch_data import (
     fetch_wcs_point_data,
-    get_dim_encodings,
     deepflatten,
+    describe_via_wcps,
 )
+from validate_request import get_coverage_encodings
 from csv_functions import create_csv
 from validate_request import (
     validate_latlon,
@@ -18,8 +20,13 @@ from . import routes
 from config import WEST_BBOX, EAST_BBOX
 
 snow_api = Blueprint("snow_api", __name__)
-# rasdaman targets
 sfe_coverage_id = "mean_annual_snowfall_mm"
+
+
+async def get_snow_metadata():
+    """Get the coverage metadata and encodings for snow coverage"""
+    metadata = await describe_via_wcps(sfe_coverage_id)
+    return get_coverage_encodings(metadata)
 
 
 def package_sfe_data(sfe_resp):
@@ -32,7 +39,7 @@ def package_sfe_data(sfe_resp):
         di -- a nested dictionary of all SFE values
     """
     # intialize the output dict
-    sfe_encodings = asyncio.run(get_dim_encodings(sfe_coverage_id))
+    sfe_encodings = asyncio.run(get_snow_metadata())
     models = list(sfe_encodings["model"].values())
     scenarios = list(sfe_encodings["scenario"].values())
     decades = list(sfe_encodings["decade"].values())

--- a/routes/wet_days_per_year.py
+++ b/routes/wet_days_per_year.py
@@ -39,7 +39,6 @@ async def get_wet_days_metadata():
 
 
 wet_days_per_year_dim_encodings = asyncio.run(get_wet_days_metadata())
-print(wet_days_per_year_dim_encodings)
 
 # default to min-max temporal range of coverage
 years_lu = {

--- a/routes/wet_days_per_year.py
+++ b/routes/wet_days_per_year.py
@@ -1,4 +1,6 @@
 import asyncio
+import ast
+
 from flask import (
     Blueprint,
     render_template,
@@ -9,12 +11,17 @@ from urllib.parse import quote
 
 # local imports
 from generate_urls import generate_wcs_query_url
-from fetch_data import fetch_data, get_dim_encodings, generate_wcs_getcov_str
-from csv_functions import create_csv
+from fetch_data import (
+    fetch_data,
+    generate_wcs_getcov_str,
+    describe_via_wcps,
+)
 from validate_request import (
     validate_latlon,
     project_latlon,
+    get_coverage_encodings,
 )
+from csv_functions import create_csv
 from postprocessing import (
     nullify_and_prune,
     postprocess,
@@ -23,7 +30,16 @@ from config import WEST_BBOX, EAST_BBOX
 from . import routes
 
 wet_days_per_year_api = Blueprint("wet_days_per_year_api", __name__)
-wet_days_per_year_dim_encodings = asyncio.run(get_dim_encodings("wet_days_per_year"))
+
+
+async def get_wet_days_metadata():
+    """Get the coverage metadata and encodings for wet days per year coverage"""
+    metadata = await describe_via_wcps("wet_days_per_year")
+    return get_coverage_encodings(metadata)
+
+
+wet_days_per_year_dim_encodings = asyncio.run(get_wet_days_metadata())
+print(wet_days_per_year_dim_encodings)
 
 # default to min-max temporal range of coverage
 years_lu = {
@@ -151,8 +167,10 @@ def package_wet_days_per_year_point_data(point_data, horp):
                 max_year = years_lu["projected"]["max"]
                 years = range(min_year, max_year + 1)
 
-            model = wet_days_per_year_dim_encodings["model"][mi]
-            point_pkg[model] = {}
+            # rasdaman returns the model encodings as strings which is a mess we unravel here
+            model_ = ast.literal_eval(wet_days_per_year_dim_encodings["model"])
+            model_name = model_[str(mi)]
+            point_pkg[model_name] = {}
 
             # Responses from Rasdaman include the same array length for both
             # historical and projected data, representing every possible year
@@ -165,7 +183,7 @@ def package_wet_days_per_year_point_data(point_data, horp):
             year_index = 0
             for value in v_li:
                 if year in years:
-                    point_pkg[model][years[year_index]] = {"wdpy": round(value)}
+                    point_pkg[model_name][years[year_index]] = {"wdpy": round(value)}
                     year_index += 1
                 year += 1
     else:

--- a/validate_request.py
+++ b/validate_request.py
@@ -3,9 +3,12 @@ A module to validate request parameters such as latitude and longitude for use a
 """
 
 import asyncio
+import ast
+
 from flask import render_template
 from pyproj import Transformer
 import numpy as np
+
 from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX
 from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
@@ -309,3 +312,56 @@ def validate_latlon_in_bboxes(lat, lon, bboxes):
         if valid_lat and valid_lon:
             return True
     return 422
+
+
+def get_coverage_encodings(coverage_metadata):
+    """Extract the encoding dictionary from a coverage's metadata obtained via describe_via_wcps.
+
+    This function extracts the "Encoding" component from a coverage's metadata, which maps typically matches the integer values used for axis labels and positions to descriptive strings (e.g., mapping coordinate values to model names, scenarios, variables, etc.)
+    Args:
+        coverage_metadata (dict): JSON-like dictionary containing coverage metadata from describe_via_wcps()
+
+    Returns:
+        dict: A dictionary mapping axis names to their encoding dictionaries. Each encoding dictionary maps integer values to their descriptive strings.
+
+    Raises:
+        ValueError: If the coverage metadata doesn't contain the expected encoding information
+
+    Example:
+        >>> metadata = await describe_via_wcps("alfresco_relative_flammability_30yr")
+        >>> encodings = get_coverage_encodings(metadata)
+        >>> print(encodings)
+        {
+            'era': {0: '1950-1979', 1: '1980-2008', ...},
+            'model': {0: 'MODEL-SPINUP', 2: 'GFDL-CM3', ...},
+            'scenario': {0: 'historical', 1: 'rcp45', ...}
+        }
+    """
+    try:
+        # encoding **should** be in the metadata in zeroth slice
+        metadata = coverage_metadata.get("metadata", {})
+        slices = metadata.get("slices", {}).get("slice", [])
+
+        if not slices:
+            raise ValueError("No slices found in coverage metadata")
+
+        # get encoding string from first slice (all slices contain the same encoding)
+        encoding_str = slices[0].get("Encoding")
+
+        if not encoding_str:
+            raise ValueError("No encoding information found in coverage metadata")
+
+        # convert the string representation of dict to actual dict
+        try:
+            encodings = ast.literal_eval(encoding_str)
+        except (SyntaxError, ValueError) as e:
+            raise ValueError(f"Failed to parse encoding string: {str(e)}")
+        # convert string keys to ints
+        for dim in encodings:
+            if isinstance(encodings[dim], dict):
+                encodings[dim] = {int(k): v for k, v in encodings[dim].items()}
+
+        return encodings
+
+    except (KeyError, TypeError) as e:
+        raise ValueError(f"Invalid coverage metadata format: {str(e)}")

--- a/validate_request.py
+++ b/validate_request.py
@@ -317,7 +317,7 @@ def validate_latlon_in_bboxes(lat, lon, bboxes):
 def get_coverage_encodings(coverage_metadata):
     """Extract the encoding dictionary from a coverage's metadata obtained via describe_via_wcps.
 
-    This function extracts the "Encoding" component from a coverage's metadata, which maps typically matches the integer values used for axis labels and positions to descriptive strings (e.g., mapping coordinate values to model names, scenarios, variables, etc.)
+    This function extracts the "Encoding" component from a coverage's metadata, which typically matches the integer values used for axis labels and positions to descriptive strings (e.g., mapping coordinate values to model names, scenarios, variables, etc.)
     Args:
         coverage_metadata (dict): JSON-like dictionary containing coverage metadata from describe_via_wcps()
 


### PR DESCRIPTION
This PR replaces usage of `fetch_data.get_dim_encodings()` with `fetch_data.describe_via_wcps()` across all routes where the former function was used. We are making this PR because something broke between Rasdaman versions, and the prior method of getting the necessary OGC coverage dimensional encodings was failing.

## What to look for
- Created new `get_coverage_encodings()` function in the `validate_request.py` module
- Refactored 8 routes to use the new pattern:
  - `alfresco.py`
  - `degree_days.py` 
  - `snow.py`
  - `cmip6.py`
  - `hydrology.py`
  - `indicators.py`
  - `permafrost.py`
  - `wet_days_per_year.py`

## Detailed notes
- Moved endpoint-specific configurations (like EDS era mappings) to separate configs
- Fixed time index generation in permafrost route to use actual metadata
- Verified `get_dim_encodings()`, `get_xml_content` and `parse_meta_xml_str` functions are no longer called anywhere in the codebase and removed them 

## To test this PR
 - Point the API at Zeus / Datacubes
- Un-comment all routes in your __init__.py file if you were using that hack, and verify the API does not crash. Alternatively, just verify that the API does not crash upon startup. 
- Verify that queries return identical responses between this branch and the deployed API for the routes listed above (check some /eds/ routes too).

Closes #502
Closes #481
