### PR TITLE
Include is_coastal, ocean_lati, and ocean_long fields in community responses

### DIFF
--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -243,7 +243,7 @@ def get_json_for_type(type, recurse=False):
                     [
                         generate_wfs_places_url(
                             "all_boundaries:all_communities",
-                            "name,alt_name,id,region,country,type,latitude,longitude,tags",
+                            "name,alt_name,id,region,country,type,latitude,longitude,tags,is_coastal,ocean_lati,ocean_long",
                         )
                     ]
                 )


### PR DESCRIPTION
This PR updates the community endpoints to include these new fields in their responses:

- `is_coastal`
- `ocean_lati`
- `ocean_long`

It works with the following endpoints:

http://localhost:5000/places/all
http://localhost:5000/places/communities
http://localhost:5000/places/search/71.1/-156.3

These fields currently are **not** included in CSV exports, however:

http://localhost:5000/places/communities?format=csv

The field name truncation is a little rough, but I figure it's better to fix this upstream (https://github.com/ua-snap/geospatial-vector-veracity/issues/135) rather than clean up the names in the API code.

To run:

```
export FLASK_APP=application.py
export API_GS_BASE_URL=https://gs.earthmaps.io/geoserver/
pipenv run flask run
```