### PR TITLE
Add CMIP6 endpoint, using "cryo" coverage

### DIFF
--- a/application.py
+++ b/application.py
@@ -21,6 +21,7 @@ def get_service_categories():
     will be passed to the index.html template.
     """
     return [
+        ("CMIP6", "/cmip6"),
         ("Climate Indicators", "/indicators"),
         ("Climate Protection from Spruce Beetles", "/beetles"),
         ("Degree Days", "/degree_days"),

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]
 INDICATORS_BBOX = [0, 49.94, 359.37, 90]
+CMIP6_BBOX = [-180, 50, 180, 90]
 WEB_APP_URL = os.getenv("WEB_APP_URL") or "https://northernclimatereports.org/"
 
 if os.getenv("SITE_OFFLINE"):

--- a/config.py
+++ b/config.py
@@ -10,7 +10,6 @@ WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]
 INDICATORS_BBOX = [0, 49.94, 359.37, 90]
-CMIP6_BBOX = [-180, 50, 180, 90]
 WEB_APP_URL = os.getenv("WEB_APP_URL") or "https://northernclimatereports.org/"
 
 if os.getenv("SITE_OFFLINE"):

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -19,12 +19,11 @@ cmip6_monthly_coverage_id = "cmip6_monthly_cryo_test"
 async def get_cmip6_metadata():
     """Get the coverage metadata and encodings for CMIP6 monthly coverage"""
     metadata = await describe_via_wcps(cmip6_monthly_coverage_id)
+    return metadata
 
-    return get_coverage_encodings(metadata)
 
-
-dim_encodings = asyncio.run(get_cmip6_metadata())
-
+metadata = asyncio.run(get_cmip6_metadata())
+dim_encodings = get_coverage_encodings(metadata)
 # TODO: fix cryo coverage so we can delete this line below
 # temporary fix for "dictionary inside a string" issue
 for dim, value in dim_encodings.items():

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -1,4 +1,5 @@
 import asyncio
+import ast
 from flask import Blueprint, render_template, request
 
 # local imports
@@ -29,7 +30,7 @@ dim_encodings = asyncio.run(get_cmip6_metadata())
 # temporary fix for "dictionary inside a string" issue
 for dim, value in dim_encodings.items():
     if isinstance(value, str):
-        dim_encodings[dim] = eval(value)
+        dim_encodings[dim] = ast.literal_eval(value)
     else: pass
 
 # TODO: fix cryo coverage so we can delete this line below

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -5,11 +5,11 @@ from flask import Blueprint, render_template, request
 from generate_urls import generate_wcs_query_url
 from generate_requests import generate_wcs_getcov_str
 from fetch_data import fetch_data, describe_via_wcps
-from validate_request import validate_latlon, get_coverage_encodings
+from validate_request import validate_cmip6_latlon, get_coverage_encodings
 from postprocessing import postprocess, prune_nulls_with_max_intensity
 from csv_functions import create_csv
 from . import routes
-from config import WEST_BBOX, EAST_BBOX
+from config import CMIP6_BBOX
 
 cmip6_api = Blueprint("cmip6_api", __name__)
 
@@ -247,13 +247,13 @@ def run_fetch_cmip6_monthly_point_data(lat, lon, start_year=None, end_year=None)
             )
 
     # Validate the lat/lon values
-    validation = validate_latlon(lat, lon)
+    validation = validate_cmip6_latlon(lat, lon)
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 422:
         return (
             render_template(
-                "422/invalid_latlon.html", west_bbox=WEST_BBOX, east_bbox=EAST_BBOX
+                "422/invalid_latlon_outside_coverage.html", bboxes=[CMIP6_BBOX]
             ),
             422,
         )

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -132,6 +132,11 @@ def package_cmip6_monthly_data(point_data_list, var_id=None, start_year=None, en
     return di
 
 
+@routes.route("/cmip6/")
+def cmip6_about():
+    return render_template("/documentation/cmip6.html")
+
+
 @routes.route("/cmip6/point/<lat>/<lon>")
 @routes.route("/cmip6/point/<lat>/<lon>/<start_year>/<end_year>")
 def run_fetch_cmip6_monthly_point_data(lat, lon, start_year=None, end_year=None):

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -26,6 +26,8 @@ async def get_cmip6_metadata():
 dim_encodings = asyncio.run(get_cmip6_metadata())
 varnames = dim_encodings["varname"]
 
+print(varnames)
+
 async def fetch_cmip6_monthly_point_data(lat, lon, var_coord=None, time_slice=None):
     """
     Make an async request for CMIP6 monthly data for a range of models, scenarios, and years at a specified point

--- a/templates/422/invalid_latlon_outside_coverage.html
+++ b/templates/422/invalid_latlon_outside_coverage.html
@@ -7,7 +7,7 @@
 
 <p>
   The provided coordinates are not within the spatial bounds of the data.
-  Coordinates must be within a bounding prescribed below.
+  Coordinates must be within a bounding box prescribed below.
 </p>
 
 {% for bbox in bboxes %}

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -1,11 +1,10 @@
 {% extends 'base.html' %} {% block content %}
-<h2>Climate Indicators</h2>
+<h2>CMIP6</h2>
 
 <p>
-  These endpoints provide access to yearly CMIP6 climate indicators and
-  era-based summaries of the NCAR 12km climate indicators. The eras for this
-  dataset are historical (1980&ndash;2009), mid&ndash;century (2040&ndash;2069),
-  and late&ndash;century (2070&ndash;2099).
+  These endpoints provide access to monthly data for select CMIP6 variables, models, and scenarios.
+  Read more about our CMIP6 subset <a href="https://arcticdatascience.org/item/story-arctic-climate-data-node">here</a>.
+  This dataset covers years 1950&ndash;2100 and is pan-Arctic in extent.
 </p>
 
 <p>
@@ -15,11 +14,11 @@
 
 <h3>Service endpoints</h3>
 
-<h4>CMIP6 climate indicator variables</h4>
+<h4>CMIP6 monthly data</h4>
 
 <p>
-  Query CMIP6 climate indicator variables for all models and scenarios. These
-  indicators are defined <a href="#climate-indicators-information">below</a>.
+  Query CMIP6 variables for all models and scenarios. These
+  variables are defined <a href="#cmip6-variable-information">below</a>.
 </p>
 
 <table class="endpoints">
@@ -32,11 +31,11 @@
   <tbody>
     <tr>
       <td>
-        Yearly climate indicator values at a given latitude and longitude.
+        Monthly values at a given latitude and longitude.
       </td>
       <td>
-        <a href="/indicators/cmip6/point/61.5/-147"
-          >/indicators/cmip6/point/61.5/-147</a
+        <a href="/cmip6/point/61.5/-147"
+          >/cmip6/point/61.5/-147</a
         >
       </td>
     </tr>
@@ -44,10 +43,9 @@
   <tfoot>
     <tr>
       <td colspan="2">
-        Min/mean/max summaries of historical and projected data over 3 eras are
-        available by appending <code>?summarize=mmm</code> to the URL.<br />
-        CSV output is also available by appending <code>?format=csv</code> to
-        the URL.
+        The list of variables can be limited by appending <code>?vars=&lt;var_id&gt;</code> to the URL.<br />
+        Multiple variables can be requested by appending a comma-separated string like <code>?vars=&lt;var_id_1&gt;,&lt;var_id_2&gt;</code>.<br />
+        CSV output is also available by appending <code>?format=csv</code> to the URL.
       </td>
     </tr>
   </tfoot>
@@ -106,8 +104,8 @@
 
 <p>
   Query min-mean-max climate indicator variables for all models and scenarios.
-  These indicators are defined
-  <a href="#climate-indicators-information">below</a>.
+  These variables are defined
+  <a href="#cmip6-variable-information">below</a>.
 </p>
 
 <table class="endpoints">
@@ -212,9 +210,9 @@
 }
 </pre>
 
-<h3 id="climate-indicators-information">Climate Indicator Information</h3>
+<h3 id="cmip6-variable-information">CMIP6 Variable Information</h3>
 
-<h4>Below is the list of climate indicators that are found in this endpoint</h4>
+<h4>Below is the list of CMIP6 variables that are found in this endpoint</h4>
 
 <p>
   <strong>hd</strong>: “Hot day” threshold &mdash; the highest observed daily

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -66,6 +66,8 @@
 
 <p>Results from point queries will look like this:</p>
 
+<!-- TODO: [After SWE units are changed to mm, regenerate the example values below from the demo coordinates!] -->
+
 <pre>
     {
         "CESM2": {
@@ -82,7 +84,7 @@
               "rsds": 14.36,
               "sfcWind": 3.43,
               "snd": 1.85,
-              "snw": 525.12,
+              "swe": 525.12,
               "tas": -15.23,
               "ts": -17.3
             },
@@ -98,7 +100,7 @@
               "rsds": 40.72,
               "sfcWind": 3.13,
               "snd": 2.14,
-              "snw": 627.79,
+              "swe": 627.79,
               "tas": -12.7,
               "ts": -14.04
             },
@@ -171,7 +173,7 @@
   <strong>snd</strong>: Snow depth &mdash; mean thickness of snow in the land portion of the grid cell, in meters; averaged over the entire land portion, including the snow-free fraction.
 </p>
 <p>
-  <strong>snw</strong>: Snowfall &mdash; The mass of surface snow on the land portion of the grid cell divided by the land area in the grid cell, in kg m-2.
+  <strong>swe</strong>: Snow water equivalent &mdash; The volume of the snowpack expressed as the equivalent depth of liquid water on the surface, in mm.
 </p>
 <p>
   <strong>tas</strong>: Near surface air temperature &mdash; mean near-surface (usually, 2 meter) air temperature, in degrees K.  

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -31,7 +31,7 @@
   <tbody>
     <tr>
       <td>
-        Monthly values at a given latitude and longitude.
+        Monthly values at a given latitude and longitude (all years).
       </td>
       <td>
         <a href="/cmip6/point/61.5/-147"
@@ -39,6 +39,16 @@
         >
       </td>
     </tr>
+    <tr>
+        <td>
+          Monthly values at a given latitude and longitude (select years).
+        </td>
+        <td>
+          <a href="/cmip6/point/61.5/-147/2030/2050"
+            >/cmip6/point/61.5/-147/2030/2050</a
+          >
+        </td>
+      </tr>
   </tbody>
   <tfoot>
     <tr>
@@ -53,154 +63,77 @@
 
 <h4>Output</h4>
 
-<p>Results from point and area queries will look like this:</p>
+<p>Results from point queries will look like this:</p>
 
 <pre>
-{
-  "historical": {
-    EC-Earth3-Veg": {
-      "1850": {
-        "dw": 71,
-        "ftc": 23,
-        "rx1day": 9,
-        "su": 0
-      },
-      "1851": {
-        "dw": 239,
-        "ftc": 0,
-        "rx1day": 7,
-        "su": 0
-      },
-      ...
-    },
-    ...
-  },
-...
-}
-
-</pre>
-
-<p>The above output is structured like this:</p>
-
-<pre>
-{
-  &lt;scenario&gt;: {
-    &lt;model&gt;: {
-      &lt;year&gt;: {
-        "dw": "Deep Winter days" &mdash; Annual number of days with minimum 2 m air temperature below -30 &deg;C,
-        "ftc": "Freeze-Thaw Cycle" &mdash; Annual number of days with a diurnal freeze-thaw cycle, where maximum daily temperatures are above 0 &deg;C and minimum daily temperatures are at or below 0 &deg;C,
-        "rx1day": Maximum 1&ndash;day precipitation,
-        "su": "Summer Days" &mdash; Annual number of days with maximum 2 m air temperature above 25 &deg;C
-      },
-      ...
-    },
-    ...
-  },
-  ...
-}
-</pre>
-
-<h4>NCAR climate indicator variables</h4>
-
-<p>
-  Query min-mean-max climate indicator variables for all models and scenarios.
-  These variables are defined
-  <a href="#cmip6-variable-information">below</a>.
-</p>
-
-<table class="endpoints">
-  <thead>
-    <tr>
-      <th class="endpoint-label">Endpoint</th>
-      <th class="endpoint-url">Example URL</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        Era-based min-mean-max for all climate indicator variables at a given
-        latitude and longitude.
-      </td>
-      <td>
-        <a href="/indicators/base/point/61.5/-147"
-          >/indicators/base/point/61.5/-147</a
-        >
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Era-based min-mean-max for all climate indicator variables for a
-        specific area
-      </td>
-      <td>
-        <a href="/indicators/base/area/1903040601"
-          >/indicators/base/area/1903040601</a
-        >
-      </td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="2">
-        CSV output is also available by appending <code>?format=csv</code> to
-        the URL. <br />
-      </td>
-    </tr>
-  </tfoot>
-</table>
-
-<h4>Output</h4>
-
-<p>Results from point and area queries will look like this:</p>
-
-<pre>
-{
-  "cd": {
-    "historical": {
-      "Daymet": {
-        "historical": {
-          "max": -30.3,
-          "mean": -37.6,
-          "min": -45.2
-        },
-        longterm": {
-          "MRI-CGCM3": {
-            "rcp45": {
-              "max": -21.9,
-              "mean": -34.0,
-              "min": -42.2
+    {
+        "CESM2": {
+          "historical": {
+            "1950-01": {
+              "clt": 76.84,
+              "evspsbl": -5.3e-07,
+              "hfls": -1.5,
+              "hfss": -18.73,
+              "pr": 94.92,
+              "psl": 101063.2,
+              "rlds": 217.55,
+              "rsds": 14.36,
+              "sfcWind": 3.43,
+              "tas": -15.23,
+              "tasmax": 0.0,
+              "tasmin": 0.0,
+              "ts": -17.3,
+              "uas": 0.0,
+              "vas": 0.0
             },
-            "rcp85": {
-              "max": -27.2,
-              "mean": -33.4,
-              "min": -40.8
-            }
-          },
-          ...
-        },
-        ...
+            "1950-02": {
+              "clt": 93.58,
+              "evspsbl": -2.7e-07,
+              "hfls": -0.81,
+              "hfss": -9.39,
+              "pr": 96.64,
+              "psl": 102463.7,
+              "rlds": 235.57,
+              "rsds": 40.72,
+              "sfcWind": 3.13,
+              "tas": -12.7,
+              "tasmax": 0.0,
+              "tasmin": 0.0,
+              "ts": -14.04,
+              "uas": 0.0,
+              "vas": 0.0
+            },
       },
-    ...
+      ...
     },
     ...
-  },
-  ...
-}
+  }
+
+
 </pre>
 
 <p>The above output is structured like this:</p>
 
 <pre>
 {
-  &lt;variable&gt;: {
-    &lt;era&gt;: {
-      &lt;model&gt;: {
-        &lt;scenario&gt;: {
-          "max": &lt;maximum annual indicator value over summary era&gt;,
-          "mean": &lt;mean annual indicator value over summary era&gt;,
-          "min": &lt;minimum annual indicator value over summary era&gt;
-        },
-        ...
+  &lt;model&gt;: {
+    &lt;scenario&gt;: {
+      &lt;year-month&gt;: {
+        "clt": "definition TBD",
+        "evspsbl": "definition TBD",
+        "hfls": "definition TBD",
+        "hfss": "definition TBD",
+        "pr": "definition TBD",
+        "psl": "definition TBD",
+        "rlds": "definition TBD",
+        "rsds": "definition TBD",
+        "sfcWind": "definition TBD",
+        "tas": "definition TBD",
+        "tasmax": "definition TBD",
+        "tasmin": "definition TBD",
+        "ts": "definition TBD",
+        "uas": "definition TBD",
+        "vas": "definition TBD",
       },
       ...
     },
@@ -215,53 +148,10 @@
 <h4>Below is the list of CMIP6 variables that are found in this endpoint</h4>
 
 <p>
-  <strong>hd</strong>: “Hot day” threshold &mdash; the highest observed daily
-  maximum 2 m air temperature such that there are 5 other observations equal to
-  or greater than this value.
+  <strong>var_id</strong>: Variable Long Name &mdash; the full defintion goes here.
 </p>
 
-<p>
-  <strong>cd</strong>: “Cold day” threshold &mdash; the lowest observed daily
-  minimum 2 m air temperature such that there are 5 other observations equal to
-  or less than this value.
-</p>
 
-<p><strong>rx1day</strong>: Maximum 1&ndash;day precipitation</p>
-
-<p>
-  <strong>su</strong>: "Summer Days" &mdash; Annual number of days with maximum
-  2 m air temperature above 25 degrees C
-</p>
-
-<p>
-  <strong>dw</strong>: "Deep Winter days" &mdash; Annual number of days with
-  minimum 2 m air temperature below -30 degrees C
-</p>
-
-<p>
-  <strong>wsdi</strong>: Warm Spell Duration Index &mdash; Annual count of
-  occurrences of at least 5 consecutive days with daily mean 2 m air temperature
-  above 90th percentile of historical values for the date
-</p>
-
-<p>
-  <strong>cdsi</strong>: Cold Spell Duration Index &mdash; Same as WDSI, but for
-  daily mean 2 m air temperature below 10th percentile
-</p>
-
-<p><strong>rx5day</strong>: Maximum 5&ndash;day precipitation</p>
-
-<p><strong>r10mm</strong>: Number of days with precipitation > 10 mm</p>
-
-<p>
-  <strong>cwd</strong>: Consecutive wet days &mdash; number of the most
-  consecutive days with precipitation > 1 mm
-</p>
-
-<p>
-  <strong>cdd</strong>: Consecutive dry days &mdash; number of the most
-  consecutive days with precipitation < 1 mm
-</p>
 <h3>Source data</h3>
 
 <table>
@@ -275,24 +165,21 @@
     <tr>
       <td>
         <a
-          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/1c1de476-cc9d-4c7b-b8ab-25e8f68a317e"
+          href="www.snap.uaf.edu/data"
         >
-          Historical and projected climate indicators for Alaska at 12km
+          Link to the source data.
         </a>
       </td>
-      <td></td>
+      <td>Full citation for source</td>
     </tr>
     <tr>
       <td rowspan="2" style="vertical-align: middle; border-bottom: none">
-        <a href="https://doi.org/10.1016/j.cliser.2022.100312"
-          >New projections of 21st century climate and hydrology for Alaska and
-          Hawaiʻi</a
+        <a href="www.snap.uaf.edu/data"
+          >Link to more source data.</a
         >
       </td>
       <td>
-        Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
-        A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijssen, B., Clark,
-        M. P., and Arnold, J. R. (2022).
+        Full citation for source.
       </td>
     </tr>
   </tbody>

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -135,61 +135,61 @@
 <h4>Below is the list of CMIP6 variables that are found in this endpoint</h4>
 
 <p>
-  <strong>clt</strong>: Cloud area fraction &mdash; the full defintion goes here.
+  <strong>clt</strong>: Cloud area fraction &mdash; Total cloud area fraction (reported as a percentage) for the whole atmospheric column, as seen from the surface or the top of the atmosphere. Includes both large-scale and convective clouds.
 </p>
 <p>
-  <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration &mdash; the full defintion goes here.
+  <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration &mdash; Evaporation at surface (also known as evapotranspiration) in kg m-2 s-1; flux of water into the atmosphere due to conversion of both liquid and solid phases to vapor (from underlying surface and vegetation).
 </p>
 <p>
-  <strong>hfls</strong>: Surface upward latent heat flux &mdash; the full defintion goes here.
+  <strong>hfls</strong>: Surface upward latent heat flux &mdash; The surface latent heat flux in W m-2; is the exchange of heat between the surface and the air on account of evaporation (including sublimation).
 </p>
 <p>
-  <strong>hfss</strong>: Surface upward sensible heat flux &mdash; the full defintion goes here.
+  <strong>hfss</strong>: Surface upward sensible heat flux &mdash; The surface sensible heat flux in W m-2; also called turbulent heat flux, is the exchange of heat between the surface and the air by motion of air.
 </p>
 <p>
-  <strong>pr</strong>: Precipitation &mdash; the full defintion goes here.
+  <strong>pr</strong>: Precipitation &mdash; Total precipitation kg m-2 s-;, includes both liquid and solid phases.
 </p>
 <p>
-  <strong>prsn</strong>: Precipitation as snow &mdash; the full defintion goes here. 
+  <strong>prsn</strong>: Precipitation as snow &mdash; Precipitation as snow at surface in kg m-2 s-1; includes precipitation of all forms of water in the solid phase. 
 </p>
 <p>
-  <strong>psl</strong>: Sea level pressure &mdash; the full defintion goes here.
+  <strong>psl</strong>: Sea level pressure &mdash; Sea level pressure in Pa.
 </p>
 <p>
-  <strong>rlds</strong>: Surface downwelling longwave radiation &mdash; the full defintion goes here.
+  <strong>rlds</strong>: Surface downwelling longwave radiation &mdash; Downwelling longwave radiation from the lower boundary of the atmosphere in W m-2.
 </p>
 <p>
-  <strong>rsds</strong>: Surface downwelling shortwavewave radiation &mdash; the full defintion goes here.
+  <strong>rsds</strong>: Surface downwelling shortwave radiation &mdash; Surface solar irradiance in W m-2, for UV calculations.
 </p>
 <p>
-  <strong>sfcWind</strong>: Surface wind &mdash; the full defintion goes here.
+  <strong>sfcWind</strong>: Surface wind &mdash; near-surface (usually, 10 meters) wind speed, in m s-1.
 </p>
 <p>
-  <strong>siconc</strong>: Sea ice concentration &mdash; the full defintion goes here.
+  <strong>siconc</strong>: Sea ice concentration &mdash; Percentage of grid cell covered by sea ice.
 </p>
 <p>
-  <strong>snd</strong>: Snow depth &mdash; the full defintion goes here.
+  <strong>snd</strong>: Snow depth &mdash; mean thickness of snow in the land portion of the grid cell, in meters; averaged over the entire land portion, including the snow-free fraction.
 </p>
 <p>
-  <strong>snw</strong>: Snowfall &mdash; the full defintion goes here.
+  <strong>snw</strong>: Snowfall &mdash; The mass of surface snow on the land portion of the grid cell divided by the land area in the grid cell, in kg m-2.
 </p>
 <p>
-  <strong>tas</strong>: Near surface air temperature &mdash; the full defintion goes here.  
+  <strong>tas</strong>: Near surface air temperature &mdash; mean near-surface (usually, 2 meter) air temperature, in degrees K.  
 </p>
 <p>
-  <strong>tasmax</strong>: Maximum near surface air temperature &mdash; the full defintion goes here.
+  <strong>tasmax</strong>: Maximum near surface air temperature &mdash; maxmimum near-surface (usually, 2 meter) air temperature, in degrees K.
 </p>
 <p>
-  <strong>tasmin</strong>: Minimum near surface air temperature &mdash; the full defintion goes here.
+  <strong>tasmin</strong>: Minimum near surface air temperature &mdash; minimum near-surface (usually, 2 meter) air temperature, in degrees K.
 </p>
 <p>
-  <strong>ts</strong>: Surface air temperature &mdash; the full defintion goes here.
+  <strong>ts</strong>: Surface air temperature &mdash; Temperature of the lower boundary of the atmosphere, in degrees K.
 </p>
 <p>
-  <strong>uas</strong>: Near-surface eastward wind &mdash; the full defintion goes here.
+  <strong>uas</strong>: Near-surface eastward wind &mdash; Eastward component of the near-surface (usually, 10 meters) wind, in m s-1.
 </p>
 <p>
-  <strong>vas</strong>: Near-surface northward wind &mdash; the full defintion goes here.
+  <strong>vas</strong>: Near-surface northward wind &mdash; Northward component of the near-surface (usually, 10 meters) wind, in m s-1.
 </p>
 
 

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -1,0 +1,303 @@
+{% extends 'base.html' %} {% block content %}
+<h2>Climate Indicators</h2>
+
+<p>
+  These endpoints provide access to yearly CMIP6 climate indicators and
+  era-based summaries of the NCAR 12km climate indicators. The eras for this
+  dataset are historical (1980&ndash;2009), mid&ndash;century (2040&ndash;2069),
+  and late&ndash;century (2070&ndash;2099).
+</p>
+
+<p>
+  For more detailed information, see the links to academic references and source
+  datasets included at the bottom of this page.
+</p>
+
+<h3>Service endpoints</h3>
+
+<h4>CMIP6 climate indicator variables</h4>
+
+<p>
+  Query CMIP6 climate indicator variables for all models and scenarios. These
+  indicators are defined <a href="#climate-indicators-information">below</a>.
+</p>
+
+<table class="endpoints">
+  <thead>
+    <tr>
+      <th class="endpoint-label">Endpoint</th>
+      <th class="endpoint-url">Example URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Yearly climate indicator values at a given latitude and longitude.
+      </td>
+      <td>
+        <a href="/indicators/cmip6/point/61.5/-147"
+          >/indicators/cmip6/point/61.5/-147</a
+        >
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">
+        Min/mean/max summaries of historical and projected data over 3 eras are
+        available by appending <code>?summarize=mmm</code> to the URL.<br />
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL.
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<h4>Output</h4>
+
+<p>Results from point and area queries will look like this:</p>
+
+<pre>
+{
+  "historical": {
+    EC-Earth3-Veg": {
+      "1850": {
+        "dw": 71,
+        "ftc": 23,
+        "rx1day": 9,
+        "su": 0
+      },
+      "1851": {
+        "dw": 239,
+        "ftc": 0,
+        "rx1day": 7,
+        "su": 0
+      },
+      ...
+    },
+    ...
+  },
+...
+}
+
+</pre>
+
+<p>The above output is structured like this:</p>
+
+<pre>
+{
+  &lt;scenario&gt;: {
+    &lt;model&gt;: {
+      &lt;year&gt;: {
+        "dw": "Deep Winter days" &mdash; Annual number of days with minimum 2 m air temperature below -30 &deg;C,
+        "ftc": "Freeze-Thaw Cycle" &mdash; Annual number of days with a diurnal freeze-thaw cycle, where maximum daily temperatures are above 0 &deg;C and minimum daily temperatures are at or below 0 &deg;C,
+        "rx1day": Maximum 1&ndash;day precipitation,
+        "su": "Summer Days" &mdash; Annual number of days with maximum 2 m air temperature above 25 &deg;C
+      },
+      ...
+    },
+    ...
+  },
+  ...
+}
+</pre>
+
+<h4>NCAR climate indicator variables</h4>
+
+<p>
+  Query min-mean-max climate indicator variables for all models and scenarios.
+  These indicators are defined
+  <a href="#climate-indicators-information">below</a>.
+</p>
+
+<table class="endpoints">
+  <thead>
+    <tr>
+      <th class="endpoint-label">Endpoint</th>
+      <th class="endpoint-url">Example URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Era-based min-mean-max for all climate indicator variables at a given
+        latitude and longitude.
+      </td>
+      <td>
+        <a href="/indicators/base/point/61.5/-147"
+          >/indicators/base/point/61.5/-147</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Era-based min-mean-max for all climate indicator variables for a
+        specific area
+      </td>
+      <td>
+        <a href="/indicators/base/area/1903040601"
+          >/indicators/base/area/1903040601</a
+        >
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL. <br />
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<h4>Output</h4>
+
+<p>Results from point and area queries will look like this:</p>
+
+<pre>
+{
+  "cd": {
+    "historical": {
+      "Daymet": {
+        "historical": {
+          "max": -30.3,
+          "mean": -37.6,
+          "min": -45.2
+        },
+        longterm": {
+          "MRI-CGCM3": {
+            "rcp45": {
+              "max": -21.9,
+              "mean": -34.0,
+              "min": -42.2
+            },
+            "rcp85": {
+              "max": -27.2,
+              "mean": -33.4,
+              "min": -40.8
+            }
+          },
+          ...
+        },
+        ...
+      },
+    ...
+    },
+    ...
+  },
+  ...
+}
+</pre>
+
+<p>The above output is structured like this:</p>
+
+<pre>
+{
+  &lt;variable&gt;: {
+    &lt;era&gt;: {
+      &lt;model&gt;: {
+        &lt;scenario&gt;: {
+          "max": &lt;maximum annual indicator value over summary era&gt;,
+          "mean": &lt;mean annual indicator value over summary era&gt;,
+          "min": &lt;minimum annual indicator value over summary era&gt;
+        },
+        ...
+      },
+      ...
+    },
+    ...
+  },
+  ...
+}
+</pre>
+
+<h3 id="climate-indicators-information">Climate Indicator Information</h3>
+
+<h4>Below is the list of climate indicators that are found in this endpoint</h4>
+
+<p>
+  <strong>hd</strong>: “Hot day” threshold &mdash; the highest observed daily
+  maximum 2 m air temperature such that there are 5 other observations equal to
+  or greater than this value.
+</p>
+
+<p>
+  <strong>cd</strong>: “Cold day” threshold &mdash; the lowest observed daily
+  minimum 2 m air temperature such that there are 5 other observations equal to
+  or less than this value.
+</p>
+
+<p><strong>rx1day</strong>: Maximum 1&ndash;day precipitation</p>
+
+<p>
+  <strong>su</strong>: "Summer Days" &mdash; Annual number of days with maximum
+  2 m air temperature above 25 degrees C
+</p>
+
+<p>
+  <strong>dw</strong>: "Deep Winter days" &mdash; Annual number of days with
+  minimum 2 m air temperature below -30 degrees C
+</p>
+
+<p>
+  <strong>wsdi</strong>: Warm Spell Duration Index &mdash; Annual count of
+  occurrences of at least 5 consecutive days with daily mean 2 m air temperature
+  above 90th percentile of historical values for the date
+</p>
+
+<p>
+  <strong>cdsi</strong>: Cold Spell Duration Index &mdash; Same as WDSI, but for
+  daily mean 2 m air temperature below 10th percentile
+</p>
+
+<p><strong>rx5day</strong>: Maximum 5&ndash;day precipitation</p>
+
+<p><strong>r10mm</strong>: Number of days with precipitation > 10 mm</p>
+
+<p>
+  <strong>cwd</strong>: Consecutive wet days &mdash; number of the most
+  consecutive days with precipitation > 1 mm
+</p>
+
+<p>
+  <strong>cdd</strong>: Consecutive dry days &mdash; number of the most
+  consecutive days with precipitation < 1 mm
+</p>
+<h3>Source data</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>Metadata & source data access</th>
+      <th>Academic reference</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/1c1de476-cc9d-4c7b-b8ab-25e8f68a317e"
+        >
+          Historical and projected climate indicators for Alaska at 12km
+        </a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="vertical-align: middle; border-bottom: none">
+        <a href="https://doi.org/10.1016/j.cliser.2022.100312"
+          >New projections of 21st century climate and hydrology for Alaska and
+          Hawaiʻi</a
+        >
+      </td>
+      <td>
+        Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
+        A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijssen, B., Clark,
+        M. P., and Arnold, J. R. (2022).
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{% endblock %}

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -55,7 +55,8 @@
       <td colspan="2">
         The list of variables can be limited by appending <code>?vars=&lt;var_id&gt;</code> to the URL.<br />
         Multiple variables can be requested by appending a comma-separated string like <code>?vars=&lt;var_id_1&gt;,&lt;var_id_2&gt;</code>.<br />
-        CSV output is also available by appending <code>?format=csv</code> to the URL.
+        CSV output is also available by appending <code>?format=csv</code> to the URL.<br />
+        Chaining of multiple arguments is supported (e.g., <code>?vars=pr,tas&format=csv</code>).
       </td>
     </tr>
   </tfoot>
@@ -71,37 +72,35 @@
           "historical": {
             "1950-01": {
               "clt": 76.84,
-              "evspsbl": -5.3e-07,
+              "evspsbl": -5.3e-7,
               "hfls": -1.5,
               "hfss": -18.73,
               "pr": 94.92,
+              "prsn": 94.88,
               "psl": 101063.2,
               "rlds": 217.55,
               "rsds": 14.36,
               "sfcWind": 3.43,
+              "snd": 1.85,
+              "snw": 525.12,
               "tas": -15.23,
-              "tasmax": 0.0,
-              "tasmin": 0.0,
-              "ts": -17.3,
-              "uas": 0.0,
-              "vas": 0.0
+              "ts": -17.3
             },
             "1950-02": {
               "clt": 93.58,
-              "evspsbl": -2.7e-07,
+              "evspsbl": -2.7e-7,
               "hfls": -0.81,
               "hfss": -9.39,
               "pr": 96.64,
+              "prsn": 92.95,
               "psl": 102463.7,
               "rlds": 235.57,
               "rsds": 40.72,
               "sfcWind": 3.13,
+              "snd": 2.14,
+              "snw": 627.79,
               "tas": -12.7,
-              "tasmax": 0.0,
-              "tasmin": 0.0,
-              "ts": -14.04,
-              "uas": 0.0,
-              "vas": 0.0
+              "ts": -14.04
             },
       },
       ...
@@ -112,6 +111,7 @@
 
 </pre>
 
+<p>Note that if variable data is unavailable at the requested point, the variable ID will not appear in the return.</p>
 <p>The above output is structured like this:</p>
 
 <pre>
@@ -119,21 +119,8 @@
   &lt;model&gt;: {
     &lt;scenario&gt;: {
       &lt;year-month&gt;: {
-        "clt": "definition TBD",
-        "evspsbl": "definition TBD",
-        "hfls": "definition TBD",
-        "hfss": "definition TBD",
-        "pr": "definition TBD",
-        "psl": "definition TBD",
-        "rlds": "definition TBD",
-        "rsds": "definition TBD",
-        "sfcWind": "definition TBD",
-        "tas": "definition TBD",
-        "tasmax": "definition TBD",
-        "tasmin": "definition TBD",
-        "ts": "definition TBD",
-        "uas": "definition TBD",
-        "vas": "definition TBD",
+        &lt;var_id&gt;: monthly value,
+        ...
       },
       ...
     },
@@ -148,7 +135,61 @@
 <h4>Below is the list of CMIP6 variables that are found in this endpoint</h4>
 
 <p>
-  <strong>var_id</strong>: Variable Long Name &mdash; the full defintion goes here.
+  <strong>clt</strong>: Cloud area fraction &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>hfls</strong>: Surface upward latent heat flux &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>hfss</strong>: Surface upward sensible heat flux &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>pr</strong>: Precipitation &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>prsn</strong>: Precipitation as snow &mdash; the full defintion goes here. 
+</p>
+<p>
+  <strong>psl</strong>: Sea level pressure &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>rlds</strong>: Surface downwelling longwave radiation &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>rsds</strong>: Surface downwelling shortwavewave radiation &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>sfcWind</strong>: Surface wind &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>siconc</strong>: Sea ice concentration &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>snd</strong>: Snow depth &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>snw</strong>: Snowfall &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>tas</strong>: Near surface air temperature &mdash; the full defintion goes here.  
+</p>
+<p>
+  <strong>tasmax</strong>: Maximum near surface air temperature &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>tasmin</strong>: Minimum near surface air temperature &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>ts</strong>: Surface air temperature &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>uas</strong>: Near-surface eastward wind &mdash; the full defintion goes here.
+</p>
+<p>
+  <strong>vas</strong>: Near-surface northward wind &mdash; the full defintion goes here.
 </p>
 
 

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -135,7 +135,7 @@
 <h4>Below is the list of CMIP6 variables that are found in this endpoint</h4>
 
 <p>
-  <strong>clt</strong>: Cloud area fraction &mdash; Total cloud area fraction (reported as a percentage) for the whole atmospheric column, as seen from the surface or the top of the atmosphere. Includes both large-scale and convective clouds.
+  <strong>clt</strong>: Cloud area fraction &mdash; Total cloud area fraction (reported as a percentage) for the whole atmospheric column, as seen from the surface or the top of the atmosphere; includes both large-scale and convective clouds.
 </p>
 <p>
   <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration &mdash; Evaporation at surface (also known as evapotranspiration) in kg m-2 s-1; flux of water into the atmosphere due to conversion of both liquid and solid phases to vapor (from underlying surface and vegetation).
@@ -147,7 +147,7 @@
   <strong>hfss</strong>: Surface upward sensible heat flux &mdash; The surface sensible heat flux in W m-2; also called turbulent heat flux, is the exchange of heat between the surface and the air by motion of air.
 </p>
 <p>
-  <strong>pr</strong>: Precipitation &mdash; Total precipitation kg m-2 s-;, includes both liquid and solid phases.
+  <strong>pr</strong>: Precipitation &mdash; Total precipitation kg m-2 s-1; includes both liquid and solid phases.
 </p>
 <p>
   <strong>prsn</strong>: Precipitation as snow &mdash; Precipitation as snow at surface in kg m-2 s-1; includes precipitation of all forms of water in the solid phase. 

--- a/validate_request.py
+++ b/validate_request.py
@@ -9,7 +9,7 @@ from flask import render_template
 from pyproj import Transformer
 import numpy as np
 
-from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX
+from config import WEST_BBOX, EAST_BBOX, SEAICE_BBOX, CMIP6_BBOX
 from generate_urls import generate_wfs_places_url
 from fetch_data import fetch_data
 
@@ -52,6 +52,30 @@ def validate_latlon(lat, lon):
 
     # Validate against two different BBOXes to deal with antimeridian issues
     for bbox in [WEST_BBOX, EAST_BBOX]:
+        valid_lat = bbox[1] <= lat_float <= bbox[3]
+        valid_lon = bbox[0] <= lon_float <= bbox[2]
+        if valid_lat and valid_lon:
+            return True
+
+    return 422
+
+
+def validate_cmip6_latlon(lat, lon):
+    """Validate the lat and lon values.
+    Return True if valid or HTTP status code if validation failed
+    """
+    try:
+        lat_float = float(lat)
+        lon_float = float(lon)
+    except:
+        return 400  # HTTP status code
+    lat_in_world = -90 <= lat_float <= 90
+    lon_in_world = -180 <= lon_float <= 180
+    if not lat_in_world or not lon_in_world:
+        return 400  # HTTP status code
+
+    # Validate against pan-Arctic BBOX
+    for bbox in [CMIP6_BBOX]:
         valid_lat = bbox[1] <= lat_float <= bbox[3]
         valid_lon = bbox[0] <= lon_float <= bbox[2]
         if valid_lat and valid_lon:


### PR DESCRIPTION
This PR is a first shot at the monthly CMIP6 endpoint, which fetches data from the `cmip6_monthly_cryo_test` coverage which currently includes the complete set of "V1" variables. There are a few known issues with this endpoint (listed below) but this should make for a decent start.

## To test:

Fire up the API, being sure to set your environment like so:
```
export API_GS_BASE_URL=http://earthmaps.io/geoserver/
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
```

1. Check out the documentation page at `http://127.0.0.1:5000/cmip6/`. 
**Known issues**: lacks sources/citations. Variable definitions are a bit clunky and may require some reformatting.

2. Test some requests, make sure all the options work, try to break it. This is a pan-Arctic coverage, so anything north of 50 degrees latitude is fair game! Make sure to test `siconc` (sea ice concentration) on definite land points and definite sea points - is the behavior as you would expect? 

3. Specifically do a test with a year range of 2014-2015 (e.g., `http://127.0.0.1:5000/cmip6/point/65/-147/2014/2015?vars=pr`), and review the notes that start [here](https://github.com/ua-snap/data-api/blob/d9a664d43de24d15d9f04cad2ef788b1fec7aff9/routes/cmip6.py#L163). Again, is this what you would expect? @charparr solved this problem in a different way for the wet days per year route [here](https://github.com/ua-snap/data-api/blob/b7e680b0a5ecf25d6e4470ba5a549283bf17c047/routes/wet_days_per_year.py#L169). **Known issue**: Some projected data will still return all 0's if a given scenario lacks data. This happens because all models do not have data for every scenario. I am open to suggestions on how we can improve this part! It's difficult to know what to do when Rasdaman returns 0s for empty arrays instead of NaNs or -9999s. 🤷🏻 

4. Note all the `TODO` items in `cmip6.py` - these are specific spots where I had to make changes to accomodate the strings that have appeared in the Rasdaman coverage encodings. If we ever fix that issue in the coverage, I believe we can zip thru here and just delete these `TODO` sections and the route should work the same as the older `cmip6_monthly` coverage. I was hoping not to bake that stuff into the cake too much here. 

5. Review the new `validate_cmip6_latlon()` function, and verify that a bad request gets routed correctly and shows the map with pan-Arctic bounding box, e.g. `http://127.0.0.1:5000/cmip6/point/49/-147` spits out:
![image](https://github.com/user-attachments/assets/1f2c1b8e-0640-4c73-b306-bfd1c875d40f)

6. Besides bugs with the code, is there anything missing here? Do we want any kind of decadal summaries or `mmm` functionality here? 

One question I think is worth discussing, is how this CMIP6 endpoint is organized around a specific dataset (with multiple variables/themes), while the other endpoints are organized around variables or themes (which may contain one or more datasets). Sometimes this list looks weird to me for that reason:

![image](https://github.com/user-attachments/assets/88391011-ce27-4b82-85fd-467ae69aec34)

