### PR TITLE
CMIP6 endpoint documentation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -33,6 +33,14 @@ table.data-source th {
 	white-space: nowrap;
 }
 
+dt {
+	font-weight: 600;
+}
+
+dd {
+	margin-bottom: 1.25rem;
+}
+
 #map {
 	height: 400px;
 	width: 400px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,8 +2,9 @@
 <html lang="en">
 
 <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.3/css/bulma.min.css">
+    <!-- include our stylesheet after so we can override Bulma -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <title>Alaska + Arctic Geospatial Data API</title>
 </head>

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -200,23 +200,9 @@
   <tbody>
     <tr>
       <td>
-        <a
-          href="www.snap.uaf.edu/data"
-        >
-          Link to the source data.
-        </a>
+        Publication in progress. For more information about our CMIP6 dataset, please <a href="mailto:uaf-snap-data-tools@alaska.edu">contact us</a> directly.
       </td>
-      <td>Full citation for source</td>
-    </tr>
-    <tr>
-      <td rowspan="2" style="vertical-align: middle; border-bottom: none">
-        <a href="www.snap.uaf.edu/data"
-          >Link to more source data.</a
-        >
-      </td>
-      <td>
-        Full citation for source.
-      </td>
+      <td>TBD</td>
     </tr>
   </tbody>
 </table>

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -66,15 +66,13 @@
 
 <p>Results from point queries will look like this:</p>
 
-<!-- TODO: [After SWE units are changed to mm, regenerate the example values below from the demo coordinates!] -->
-
 <pre>
     {
         "CESM2": {
           "historical": {
             "1950-01": {
               "clt": 76.84,
-              "evspsbl": -5.3e-7,
+              "evspsbl": -5.3e-07,
               "hfls": -1.5,
               "hfss": -18.73,
               "pr": 94.92,
@@ -83,14 +81,13 @@
               "rlds": 217.55,
               "rsds": 14.36,
               "sfcWind": 3.43,
-              "snd": 1.85,
               "swe": 525.12,
               "tas": -15.23,
               "ts": -17.3
             },
             "1950-02": {
               "clt": 93.58,
-              "evspsbl": -2.7e-7,
+              "evspsbl": -2.7e-07,
               "hfls": -0.81,
               "hfss": -9.39,
               "pr": 96.64,
@@ -99,7 +96,6 @@
               "rlds": 235.57,
               "rsds": 40.72,
               "sfcWind": 3.13,
-              "snd": 2.14,
               "swe": 627.79,
               "tas": -12.7,
               "ts": -14.04
@@ -134,64 +130,61 @@
 
 <h3 id="cmip6-variable-information">CMIP6 Variable Information</h3>
 
-<h4>Below is the list of CMIP6 variables that are found in this endpoint</h4>
+<h4>Below is the list of CMIP6 variables that are found in this endpoint. For complete variable definitions, see the official CMIP6 documentation <a href="https://wcrp-cmip.org/cmip-model-and-experiment-documentation/">here</a>.</h4>
 
 <p>
-  <strong>clt</strong>: Cloud area fraction &mdash; Total cloud area fraction (reported as a percentage) for the whole atmospheric column, as seen from the surface or the top of the atmosphere; includes both large-scale and convective clouds.
+  <strong>clt</strong>: Cloud area fraction (%)
 </p>
 <p>
-  <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration &mdash; Evaporation at surface (also known as evapotranspiration) in kg m-2 s-1; flux of water into the atmosphere due to conversion of both liquid and solid phases to vapor (from underlying surface and vegetation).
+  <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration (kg/m<sup>2</sup>s)
 </p>
 <p>
-  <strong>hfls</strong>: Surface upward latent heat flux &mdash; The surface latent heat flux in W m-2; is the exchange of heat between the surface and the air on account of evaporation (including sublimation).
+  <strong>hfls</strong>: Surface upward latent heat flux (W/m<sup>2</sup>)
 </p>
 <p>
-  <strong>hfss</strong>: Surface upward sensible heat flux &mdash; The surface sensible heat flux in W m-2; also called turbulent heat flux, is the exchange of heat between the surface and the air by motion of air.
+  <strong>hfss</strong>: Surface upward sensible heat flux (W/m<sup>2</sup>)
 </p>
 <p>
-  <strong>pr</strong>: Precipitation &mdash; Total precipitation kg m-2 s-1; includes both liquid and solid phases.
+  <strong>pr</strong>: Precipitation, including both liquid and solid phases (kg/m<sup>2</sup>s)
 </p>
 <p>
-  <strong>prsn</strong>: Precipitation as snow &mdash; Precipitation as snow at surface in kg m-2 s-1; includes precipitation of all forms of water in the solid phase. 
+  <strong>prsn</strong>: Precipitation as snow, including all forms of water in the solid phase (kg/m<sup>2</sup>s)
 </p>
 <p>
-  <strong>psl</strong>: Sea level pressure &mdash; Sea level pressure in Pa.
+  <strong>psl</strong>: Sea level pressure (Pa)
 </p>
 <p>
-  <strong>rlds</strong>: Surface downwelling longwave radiation &mdash; Downwelling longwave radiation from the lower boundary of the atmosphere in W m-2.
+  <strong>rlds</strong>: Surface downwelling longwave radiation (W/m<sup>2</sup>)
 </p>
 <p>
-  <strong>rsds</strong>: Surface downwelling shortwave radiation &mdash; Surface solar irradiance in W m-2, for UV calculations.
+  <strong>rsds</strong>: Surface downwelling shortwave radiation (W/m<sup>2</sup>)
 </p>
 <p>
-  <strong>sfcWind</strong>: Surface wind &mdash; near-surface (usually, 10 meters) wind speed, in m s-1.
+  <strong>sfcWind</strong>: Surface wind speed (m/s)
 </p>
 <p>
-  <strong>siconc</strong>: Sea ice concentration &mdash; Percentage of grid cell covered by sea ice.
+  <strong>siconc</strong>: Sea ice concentration (%)
 </p>
 <p>
-  <strong>snd</strong>: Snow depth &mdash; mean thickness of snow in the land portion of the grid cell, in meters; averaged over the entire land portion, including the snow-free fraction.
+  <strong>swe</strong>: Snow water equivalent (mm)
 </p>
 <p>
-  <strong>swe</strong>: Snow water equivalent &mdash; The volume of the snowpack expressed as the equivalent depth of liquid water on the surface, in mm.
+  <strong>tas</strong>: Near surface air temperature (&deg;C)
 </p>
 <p>
-  <strong>tas</strong>: Near surface air temperature &mdash; mean near-surface (usually, 2 meter) air temperature, in degrees K.  
+  <strong>tasmax</strong>: Maximum near surface air temperature (&deg;C)
 </p>
 <p>
-  <strong>tasmax</strong>: Maximum near surface air temperature &mdash; maxmimum near-surface (usually, 2 meter) air temperature, in degrees K.
+  <strong>tasmin</strong>: Minimum near surface air temperature (&deg;C)
 </p>
 <p>
-  <strong>tasmin</strong>: Minimum near surface air temperature &mdash; minimum near-surface (usually, 2 meter) air temperature, in degrees K.
+  <strong>ts</strong>: Surface air temperature (&deg;C)
 </p>
 <p>
-  <strong>ts</strong>: Surface air temperature &mdash; Temperature of the lower boundary of the atmosphere, in degrees K.
+  <strong>uas</strong>: Near-surface eastward wind (m/s)
 </p>
 <p>
-  <strong>uas</strong>: Near-surface eastward wind &mdash; Eastward component of the near-surface (usually, 10 meters) wind, in m s-1.
-</p>
-<p>
-  <strong>vas</strong>: Near-surface northward wind &mdash; Northward component of the near-surface (usually, 10 meters) wind, in m s-1.
+  <strong>vas</strong>: Near-surface northward wind (m/s)
 </p>
 
 

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -2,9 +2,11 @@
 <h2>CMIP6</h2>
 
 <p>
-  These endpoints provide access to monthly data for select CMIP6 variables, models, and scenarios.
-  Read more about our CMIP6 subset <a href="https://arcticdatascience.org/item/story-arctic-climate-data-node">here</a>.
-  This dataset covers years 1950&ndash;2100 and is pan-Arctic in extent.
+  These endpoints provide access to monthly data for select CMIP6 variables,
+  models, and scenarios. Read more about our CMIP6 subset
+  <a href="https://arcticdatascience.org/item/story-arctic-climate-data-node"
+    >here</a
+  >. This dataset covers years 1950&ndash;2100 and is pan-Arctic in extent.
 </p>
 
 <p>
@@ -17,8 +19,8 @@
 <h4>CMIP6 monthly data</h4>
 
 <p>
-  Query CMIP6 variables for all models and scenarios. These
-  variables are defined <a href="#cmip6-variable-information">below</a>.
+  Query CMIP6 variables for all models and scenarios. These variables are
+  defined <a href="#cmip6-variable-information">below</a>.
 </p>
 
 <table class="endpoints">
@@ -30,33 +32,31 @@
   </thead>
   <tbody>
     <tr>
+      <td>Monthly values at a given latitude and longitude (all years).</td>
       <td>
-        Monthly values at a given latitude and longitude (all years).
-      </td>
-      <td>
-        <a href="/cmip6/point/61.5/-147"
-          >/cmip6/point/61.5/-147</a
-        >
+        <a href="/cmip6/point/61.5/-147">/cmip6/point/61.5/-147</a>
       </td>
     </tr>
     <tr>
-        <td>
-          Monthly values at a given latitude and longitude (select years).
-        </td>
-        <td>
-          <a href="/cmip6/point/61.5/-147/2030/2050"
-            >/cmip6/point/61.5/-147/2030/2050</a
-          >
-        </td>
-      </tr>
+      <td>Monthly values at a given latitude and longitude (select years).</td>
+      <td>
+        <a href="/cmip6/point/61.5/-147/2030/2050"
+          >/cmip6/point/61.5/-147/2030/2050</a
+        >
+      </td>
+    </tr>
   </tbody>
   <tfoot>
     <tr>
       <td colspan="2">
-        The list of variables can be limited by appending <code>?vars=&lt;var_id&gt;</code> to the URL.<br />
-        Multiple variables can be requested by appending a comma-separated string like <code>?vars=&lt;var_id_1&gt;,&lt;var_id_2&gt;</code>.<br />
-        CSV output is also available by appending <code>?format=csv</code> to the URL.<br />
-        Chaining of multiple arguments is supported (e.g., <code>?vars=pr,tas&format=csv</code>).
+        The list of variables can be limited by appending
+        <code>?vars=&lt;var_id&gt;</code> to the URL.<br />
+        Multiple variables can be requested by appending a comma-separated
+        string like <code>?vars=&lt;var_id_1&gt;,&lt;var_id_2&gt;</code>.<br />
+        CSV output is also available by appending <code>?format=csv</code> to
+        the URL.<br />
+        Chaining of multiple arguments is supported (e.g.,
+        <code>?vars=pr,tas&format=csv</code>).
       </td>
     </tr>
   </tfoot>
@@ -109,7 +109,10 @@
 
 </pre>
 
-<p>Note that if variable data is unavailable at the requested point, the variable ID will not appear in the return.</p>
+<p>
+  Note that if variable data is unavailable at the requested point, the variable
+  ID will not appear in the return.
+</p>
 <p>The above output is structured like this:</p>
 
 <pre>
@@ -130,63 +133,59 @@
 
 <h3 id="cmip6-variable-information">CMIP6 Variable Information</h3>
 
-<h4>Below is the list of CMIP6 variables that are found in this endpoint. For complete variable definitions, see the official CMIP6 documentation <a href="https://wcrp-cmip.org/cmip-model-and-experiment-documentation/">here</a>.</h4>
-
 <p>
-  <strong>clt</strong>: Cloud area fraction (%)
-</p>
-<p>
-  <strong>evspsbl</strong>: Evaporation, including sublimation and transpiration (kg/m<sup>2</sup>s)
-</p>
-<p>
-  <strong>hfls</strong>: Surface upward latent heat flux (W/m<sup>2</sup>)
-</p>
-<p>
-  <strong>hfss</strong>: Surface upward sensible heat flux (W/m<sup>2</sup>)
-</p>
-<p>
-  <strong>pr</strong>: Precipitation, including both liquid and solid phases (kg/m<sup>2</sup>s)
-</p>
-<p>
-  <strong>prsn</strong>: Precipitation as snow, including all forms of water in the solid phase (kg/m<sup>2</sup>s)
-</p>
-<p>
-  <strong>psl</strong>: Sea level pressure (Pa)
-</p>
-<p>
-  <strong>rlds</strong>: Surface downwelling longwave radiation (W/m<sup>2</sup>)
-</p>
-<p>
-  <strong>rsds</strong>: Surface downwelling shortwave radiation (W/m<sup>2</sup>)
-</p>
-<p>
-  <strong>sfcWind</strong>: Surface wind speed (m/s)
-</p>
-<p>
-  <strong>siconc</strong>: Sea ice concentration (%)
-</p>
-<p>
-  <strong>swe</strong>: Snow water equivalent (mm)
-</p>
-<p>
-  <strong>tas</strong>: Near surface air temperature (&deg;C)
-</p>
-<p>
-  <strong>tasmax</strong>: Maximum near surface air temperature (&deg;C)
-</p>
-<p>
-  <strong>tasmin</strong>: Minimum near surface air temperature (&deg;C)
-</p>
-<p>
-  <strong>ts</strong>: Surface air temperature (&deg;C)
-</p>
-<p>
-  <strong>uas</strong>: Near-surface eastward wind (m/s)
-</p>
-<p>
-  <strong>vas</strong>: Near-surface northward wind (m/s)
+  Below is the list of CMIP6 variables that are found in this endpoint. For
+  complete variable definitions, see the official CMIP6 documentation
+  <a href="https://wcrp-cmip.org/cmip-model-and-experiment-documentation/"
+    >here</a
+  >.
 </p>
 
+<dl>
+  <dt>clt</dt>
+  <dd>Cloud area fraction (%)</dd>
+  <dt>evspsbl</dt>
+  <dd>
+    Evaporation, including sublimation and transpiration (kg m<sup>-2</sup> s<sup>-1</sup>)
+  </dd>
+  <dt>hfls</dt>
+  <dd>Surface upward latent heat flux (W m<sup>-2</sup>)</dd>
+  <dt>hfss</dt>
+  <dd>Surface upward sensible heat flux (W m<sup>-2</sup>)</dd>
+  <dt>pr</dt>
+  <dd>
+    Precipitation, including both liquid and solid phases (kg m<sup>-2</sup> s<sup>-1</sup>)
+  </dd>
+  <dt>prsn</dt>
+  <dd>
+    Precipitation as snow, including all forms of water in the solid phase
+    (kg m<sup>-2</sup> s<sup>-1</sup>)
+  </dd>
+  <dt>psl</dt>
+  <dd>Sea level pressure (Pa)</dd>
+  <dt>rlds</dt>
+  <dd>Surface downwelling longwave radiation (W m<sup>-2</sup>)</dd>
+  <dt>rsds</dt>
+  <dd>Surface downwelling shortwave radiation (W m<sup>-2</sup>)</dd>
+  <dt>sfcWind</dt>
+  <dd>Surface wind speed (m s<sup>-1</sup>)</dd>
+  <dt>siconc</dt>
+  <dd>Sea ice concentration (%)</dd>
+  <dt>swe</dt>
+  <dd>Snow water equivalent (mm)</dd>
+  <dt>tas</dt>
+  <dd>Near surface air temperature (&deg;C)</dd>
+  <dt>tasmax</dt>
+  <dd>Maximum near surface air temperature (&deg;C)</dd>
+  <dt>tasmin</dt>
+  <dd>Minimum near surface air temperature (&deg;C)</dd>
+  <dt>ts</dt>
+  <dd>Surface air temperature (&deg;C)</dd>
+  <dt>uas</dt>
+  <dd>Near-surface eastward wind (m s<sup>-1</sup>)</dd>
+  <dt>vas</dt>
+  <dd>Near-surface northward wind (m s<sup>-1</sup>)</dd>
+</dl>
 
 <h3>Source data</h3>
 
@@ -200,7 +199,9 @@
   <tbody>
     <tr>
       <td>
-        Publication in progress. For more information about our CMIP6 dataset, please <a href="mailto:uaf-snap-data-tools@alaska.edu">contact us</a> directly.
+        Publication in progress. For more information about our CMIP6 dataset,
+        please
+        <a href="mailto:uaf-snap-data-tools@alaska.edu">contact us</a> directly.
       </td>
       <td>TBD</td>
     </tr>


### PR DESCRIPTION
closes #514 

This PR completes basic documentation for the CMIP6 endpoint with V1 variables. Source citation is TBD and will be returned to after consultation with Jeremy Litell.

To test: 

Start up the API, being sure to set environmental variables like so:
```
export API_GS_BASE_URL=http://earthmaps.io/geoserver/
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
```

Review the documentation at `http://localhost:5000/cmip6/`