### PR TITLE
Update community nearest ocean lat/lon field names

### DIFF
--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -243,7 +243,7 @@ def get_json_for_type(type, recurse=False):
                     [
                         generate_wfs_places_url(
                             "all_boundaries:all_communities",
-                            "name,alt_name,id,region,country,type,latitude,longitude,tags,is_coastal,ocean_lati,ocean_long",
+                            "name,alt_name,id,region,country,type,latitude,longitude,tags,is_coastal,ocean_lat1,ocean_lon1",
                         )
                     ]
                 )


### PR DESCRIPTION
This PR is a tiny change that simply updates these `all_communities` field names from their old truncated names:

- `ocean_lati`
- `ocean_long`

To their new, non-truncated names:

- `ocean_lat1`
- `ocean_lon1`

The shapefile has already been updated on gs.earthmaps.io, so the the API needs this fix ASAP to continue working as expected. This is a trivial change, so I'm going to self-merge this.