### PR TITLE
Disable Bulma dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <title>Alaska + Arctic Geospatial Data API</title>
 </head>
 
-<body>
+<body data-theme="light">
     <div class="headerbanner">
         University of Alaska Fairbanks • Scenarios Network for Alaska + Arctic Planning
     </div>


### PR DESCRIPTION
This PR forces the Data API's HTML pages to use light mode. I double checked that there's only one `<body>` tag throughout the entire webapp, and added the `data-theme="light"` attribute to it to force Bulma to use light mode.

I tried going the CSS route before this and it turned into a very long series of manual CSS rule tweaks for each title, subtitle, heading, quotation block, etc. So this is definitely the more bulletproof and cleaner solution.

This fix works for me in Chrome, Firefox, and Safari.