### PR TITLE
Fixes issues with permafrost when no data exists

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -200,7 +200,8 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp):
             gipl1km_dim_encodings["variable"].values(),
             summary_op_resp,
         ):
-            gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][k] = round(v, 1)
+            if v is not None:
+                gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][k] = round(v, 1)
 
     return gipl1km_wcps_point_pkg
 


### PR DESCRIPTION
This PR fixes the permafrost returns when there is no data available. The previous endpoints were hitting 500 errors due to the values of the returned data being shown as strings rather than a dictionary for pulling out the values from the keys.

An example of this can be seen on the current main branch:

[http://localhost:5000/eds/permafrost/59.8164/-151.0895](http://localhost:5000/eds/permafrost/59.8164/-151.0895)
[2025-02-03 09:19:35,036] ERROR in app: Exception on /eds/permafrost/59.8164/-151.0895 [GET]
Traceback (most recent call last):
  File "/Users/rltorgerson/.local/share/virtualenvs/cw-5qLQ3xep/lib/python3.11/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.local/share/virtualenvs/cw-5qLQ3xep/lib/python3.11/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.local/share/virtualenvs/cw-5qLQ3xep/lib/python3.11/site-packages/flask_cors/extension.py", line 194, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.local/share/virtualenvs/cw-5qLQ3xep/lib/python3.11/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.local/share/virtualenvs/cw-5qLQ3xep/lib/python3.11/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/GitHub/SNAP/new-data-api/data-api/routes/permafrost.py", line 622, in permafrost_eds_request
    summary = permafrost_ncr_request(lat, lon, ncr=False)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/GitHub/SNAP/new-data-api/data-api/routes/permafrost.py", line 652, in permafrost_ncr_request
    permafrostData = asyncio.run(run_ncr_requests(lat, lon, ncr))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.pyenv/versions/3.11.7/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.pyenv/versions/3.11.7/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/.pyenv/versions/3.11.7/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/GitHub/SNAP/new-data-api/data-api/routes/permafrost.py", line 570, in run_ncr_requests
    results = await asyncio.gather(*tasks)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/GitHub/SNAP/new-data-api/data-api/routes/permafrost.py", line 484, in run_fetch_gipl_1km_point_data
    gipl_1km_point_package = package_gipl1km_wcps_data(gipl_1km_point_data)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rltorgerson/GitHub/SNAP/new-data-api/data-api/routes/permafrost.py", line 186, in package_gipl1km_wcps_data
    for k, v in zip(gipl1km_dim_encodings["variable"].values(), summary_op_resp):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'values'