### PR TITLE
Fixes errors with permafrost and beetles coverages near coastal and Canadian communities

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,8 +4,8 @@ Configuration common to multiple routes.
 
 import os
 
-GS_BASE_URL = os.getenv("API_GS_BASE_URL") or "https://gs.mapventure.org/geoserver/"
-RAS_BASE_URL = os.getenv("API_RAS_BASE_URL") or "https://apollo.snap.uaf.edu/rasdaman/"
+GS_BASE_URL = os.getenv("API_GS_BASE_URL") or "https://gs.earthmaps.io/geoserver/"
+RAS_BASE_URL = os.getenv("API_RAS_BASE_URL") or "https://zeus.snap.uaf.edu/rasdaman/"
 WEST_BBOX = [-180, 51.3492, -122.8098, 71.3694]
 EAST_BBOX = [172.4201, 51.3492, 180, 71.3694]
 SEAICE_BBOX = [-180, 30.98, 180, 90]

--- a/routes/beetles.py
+++ b/routes/beetles.py
@@ -88,9 +88,12 @@ def package_beetle_data(beetle_resp, beetle_percents=None):
     for sni in range(len(beetle_resp[0][0][0])):
         snowpack = dim_encodings["snowpack"][sni]
         di["1988-2017"]["Daymet"]["Historical"][snowpack] = dict()
-        di["1988-2017"]["Daymet"]["Historical"][snowpack]["climate-protection"] = (
-            dim_encodings["climate_protection"][int(beetle_resp[0][0][0][sni])]
-        )
+        if beetle_resp[0][0][0][sni] is not None:
+            di["1988-2017"]["Daymet"]["Historical"][snowpack]["climate-protection"] = (
+                dim_encodings["climate_protection"][int(beetle_resp[0][0][0][sni])]
+            )
+        else:
+            di["1988-2017"]["Daymet"]["Historical"][snowpack]["climate-protection"] = 0
         if beetle_percents is not None:
             # This conditional will check to see if all percentages are 0% meaning that there is no data.
             # We must set the returned data dictionary values explicitly to 0 to ensure the pruning function
@@ -133,9 +136,12 @@ def package_beetle_data(beetle_resp, beetle_percents=None):
                 for sni, risk_level in enumerate(sn_li):
                     snowpack = dim_encodings["snowpack"][sni]
                     di[era][model][scenario][snowpack] = dict()
-                    di[era][model][scenario][snowpack]["climate-protection"] = (
-                        dim_encodings["climate_protection"][int(risk_level)]
-                    )
+                    if risk_level is not None:
+                        di[era][model][scenario][snowpack]["climate-protection"] = (
+                            dim_encodings["climate_protection"][int(risk_level)]
+                        )
+                    else:
+                        di[era][model][scenario][snowpack]["climate-protection"] = 0
                     if beetle_percents is not None:
                         # This conditional will check to see if all percentages are 0% meaning that there is no data.
                         # We must set the returned data dictionary values explicitly to 0 to ensure the pruning function

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -1,6 +1,10 @@
 import asyncio
 from urllib.parse import quote
+<<<<<<< HEAD
 import json
+=======
+import ast
+>>>>>>> 2ae2bfc (Fixes permafrost coverage when data is all no data.)
 
 import pandas as pd
 from flask import Blueprint, render_template, request, jsonify, Response
@@ -153,10 +157,24 @@ def package_ncr_gipl1km_wcps_data(gipl1km_wcps_resp):
             summary_methods = ["min", "mean", "max"]
             for resp, stat_type in zip(scenario_resp, summary_methods):
                 gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"] = dict()
-                for k, v in zip(gipl1km_dim_encodings["variable"].values(), resp):
-                    gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
-                        k
-                    ] = round(v, 1)
+                # Check if gipl1km_dim_encodings["variable"] is a string
+                variable_encodings = gipl1km_dim_encodings["variable"]
+                if isinstance(variable_encodings, str):
+                    try:
+                        variable_encodings = ast.literal_eval(variable_encodings)
+                    except (SyntaxError, ValueError) as e:
+                        raise ValueError(f"Failed to parse encoding string: {str(e)}")
+
+                # Now iterate over the variable_encodings dictionary
+                for k, v in zip(variable_encodings.values(), resp):
+                    if v is None:
+                        gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
+                            k
+                        ] = None
+                    else:
+                        gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
+                            k
+                        ] = round(v, 1)
     return gipl1km_wcps_point_pkg
 
 

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -1,10 +1,7 @@
 import asyncio
 from urllib.parse import quote
-<<<<<<< HEAD
 import json
-=======
 import ast
->>>>>>> 2ae2bfc (Fixes permafrost coverage when data is all no data.)
 
 import pandas as pd
 from flask import Blueprint, render_template, request, jsonify, Response


### PR DESCRIPTION
This PR fixes the slowdowns seen by the cache returns for coastal and Canadian communities in the NCR for both the permafrost and beetle API endpoints. 

In both cases, we were returning 500 errors that get translated as 503s from the cache, and these 500 errors were not being cached, thus causing a constant need to retry those endpoints on each request. They both had logic errors that required a small fix to allow for them to return 404 errors which is really what these endpoints are supposed to return for these locations. 

Closes #533 