### PR TITLE
Add missing units for the "cd", "hd", "rx1day", and "rx5day" indicators

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -542,12 +542,12 @@ def ncar12km_indicators_csv(data):
     values = ["min", "mean", "max"]
     fieldnames = coords + values
     csv_dicts = build_csv_dicts(reordered, fieldnames, values=values)
-    metadata = "# cd is the Very Cold Day Threshold. Only 5 days in a year are colder than this.\n"
+    metadata = "# cd is the Very Cold Day Threshold (deg C). Only 5 days in a year are colder than this.\n"
     metadata += "# cdd are Consecutive Dry Days. This is the number of consecutive days with less than 1mm precipitation.\n"
     metadata += "# csdi is the Cold Spell Duration Index. This is a cold spell metric: the number of cold days (<10th percentile) occurring in a row following an initial cold spell period of six days.\n"
     metadata += "# cwd are Consecutive Wet Days. This is the number of consecutive days with more than 1mm precipitation.\n"
     metadata += "# dw are Deep Winter Days. This is the number of days with mean temperature below -30 (deg C).\n"
-    metadata += "# hd is the Very Hot Day Threshold. Only 5 days in a year are warmer than this.\n"
+    metadata += "# hd is the Very Hot Day Threshold (deg C). Only 5 days in a year are warmer than this.\n"
     metadata += "# r10mm are Heavy Precipitation Days. This is the number of individual days with 10mm or more precipitation.\n"
     metadata += "# rx1day is the Maximum 1-day Precipitation. This is the maximum precipitation total for a single day in mm.\n"
     metadata += "# rx5day is the Maximum 5-day Precipitation. This is the maximum precipitation total for a 5-day period in mm.\n"

--- a/templates/documentation/indicators.html
+++ b/templates/documentation/indicators.html
@@ -35,7 +35,9 @@
         Yearly climate indicator values at a given latitude and longitude.
       </td>
       <td>
-        <a href="/indicators/cmip6/point/61.5/-147">/indicators/cmip6/point/61.5/-147</a>
+        <a href="/indicators/cmip6/point/61.5/-147"
+          >/indicators/cmip6/point/61.5/-147</a
+        >
       </td>
     </tr>
   </tbody>
@@ -122,7 +124,9 @@
         latitude and longitude.
       </td>
       <td>
-        <a href="/indicators/base/point/61.5/-147">/indicators/base/point/61.5/-147</a>
+        <a href="/indicators/base/point/61.5/-147"
+          >/indicators/base/point/61.5/-147</a
+        >
       </td>
     </tr>
     <tr>
@@ -131,7 +135,9 @@
         specific area
       </td>
       <td>
-        <a href="/indicators/base/area/1903040601">/indicators/base/area/1903040601</a>
+        <a href="/indicators/base/area/1903040601"
+          >/indicators/base/area/1903040601</a
+        >
       </td>
     </tr>
   </tbody>
@@ -256,39 +262,42 @@
 
 <p>
   <strong>cdd</strong>: Consecutive dry days &mdash; number of the most
-  consecutive days with precipitation < 1 mm </p>
-    <h3>Source data</h3>
+  consecutive days with precipitation < 1 mm
+</p>
+<h3>Source data</h3>
 
-    <table>
-      <thead>
-        <tr>
-          <th>Metadata & source data access</th>
-          <th>Academic reference</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <a
-              href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/1c1de476-cc9d-4c7b-b8ab-25e8f68a317e">
-              Historical and projected climate indicators for Alaska at 12km
-            </a>
-          </td>
-          <td></td>
-        </tr>
-        <tr>
-          <td rowspan="2" style="vertical-align: middle; border-bottom: none">
-            <a href="https://doi.org/10.1016/j.cliser.2022.100312">New projections of 21st century climate and hydrology
-              for Alaska and
-              Hawaiʻi</a>
-          </td>
-          <td>
-            Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
-            A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijssen, B., Clark,
-            M. P., and Arnold, J. R. (2022).
-          </td>
-        </tr>
-      </tbody>
-    </table>
+<table>
+  <thead>
+    <tr>
+      <th>Metadata & source data access</th>
+      <th>Academic reference</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a
+          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/1c1de476-cc9d-4c7b-b8ab-25e8f68a317e"
+        >
+          Historical and projected climate indicators for Alaska at 12km
+        </a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="vertical-align: middle; border-bottom: none">
+        <a href="https://doi.org/10.1016/j.cliser.2022.100312"
+          >New projections of 21st century climate and hydrology for Alaska and
+          Hawaiʻi</a
+        >
+      </td>
+      <td>
+        Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
+        A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijssen, B., Clark,
+        M. P., and Arnold, J. R. (2022).
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-    {% endblock %}
+{% endblock %}

--- a/templates/documentation/indicators.html
+++ b/templates/documentation/indicators.html
@@ -222,7 +222,7 @@
   or less than this value.
 </p>
 
-<p><strong>rx1day</strong>: Maximum 1&ndash;day precipitation</p>
+<p><strong>rx1day</strong>: Maximum 1&ndash;day precipitation (mm)</p>
 
 <p>
   <strong>su</strong>: "Summer Days" &mdash; Annual number of days with maximum
@@ -245,7 +245,7 @@
   daily mean 2 m air temperature below 10th percentile
 </p>
 
-<p><strong>rx5day</strong>: Maximum 5&ndash;day precipitation</p>
+<p><strong>rx5day</strong>: Maximum 5&ndash;day precipitation (mm)</p>
 
 <p><strong>r10mm</strong>: Number of days with precipitation > 10 mm</p>
 

--- a/templates/documentation/indicators.html
+++ b/templates/documentation/indicators.html
@@ -35,9 +35,7 @@
         Yearly climate indicator values at a given latitude and longitude.
       </td>
       <td>
-        <a href="/indicators/cmip6/point/61.5/-147"
-          >/indicators/cmip6/point/61.5/-147</a
-        >
+        <a href="/indicators/cmip6/point/61.5/-147">/indicators/cmip6/point/61.5/-147</a>
       </td>
     </tr>
   </tbody>
@@ -124,9 +122,7 @@
         latitude and longitude.
       </td>
       <td>
-        <a href="/indicators/base/point/61.5/-147"
-          >/indicators/base/point/61.5/-147</a
-        >
+        <a href="/indicators/base/point/61.5/-147">/indicators/base/point/61.5/-147</a>
       </td>
     </tr>
     <tr>
@@ -135,9 +131,7 @@
         specific area
       </td>
       <td>
-        <a href="/indicators/base/area/1903040601"
-          >/indicators/base/area/1903040601</a
-        >
+        <a href="/indicators/base/area/1903040601">/indicators/base/area/1903040601</a>
       </td>
     </tr>
   </tbody>
@@ -217,13 +211,13 @@
 <h4>Below is the list of climate indicators that are found in this endpoint</h4>
 
 <p>
-  <strong>hd</strong>: “Hot day” threshold &mdash; the highest observed daily
+  <strong>hd</strong>: “Hot day” threshold (degrees C) &mdash; the highest observed daily
   maximum 2 m air temperature such that there are 5 other observations equal to
   or greater than this value.
 </p>
 
 <p>
-  <strong>cd</strong>: “Cold day” threshold &mdash; the lowest observed daily
+  <strong>cd</strong>: “Cold day” threshold (degrees C) &mdash; the lowest observed daily
   minimum 2 m air temperature such that there are 5 other observations equal to
   or less than this value.
 </p>
@@ -262,42 +256,39 @@
 
 <p>
   <strong>cdd</strong>: Consecutive dry days &mdash; number of the most
-  consecutive days with precipitation < 1 mm
-</p>
-<h3>Source data</h3>
+  consecutive days with precipitation < 1 mm </p>
+    <h3>Source data</h3>
 
-<table>
-  <thead>
-    <tr>
-      <th>Metadata & source data access</th>
-      <th>Academic reference</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <a
-          href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/1c1de476-cc9d-4c7b-b8ab-25e8f68a317e"
-        >
-          Historical and projected climate indicators for Alaska at 12km
-        </a>
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td rowspan="2" style="vertical-align: middle; border-bottom: none">
-        <a href="https://doi.org/10.1016/j.cliser.2022.100312"
-          >New projections of 21st century climate and hydrology for Alaska and
-          Hawaiʻi</a
-        >
-      </td>
-      <td>
-        Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
-        A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijssen, B., Clark,
-        M. P., and Arnold, J. R. (2022).
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <table>
+      <thead>
+        <tr>
+          <th>Metadata & source data access</th>
+          <th>Academic reference</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <a
+              href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/1c1de476-cc9d-4c7b-b8ab-25e8f68a317e">
+              Historical and projected climate indicators for Alaska at 12km
+            </a>
+          </td>
+          <td></td>
+        </tr>
+        <tr>
+          <td rowspan="2" style="vertical-align: middle; border-bottom: none">
+            <a href="https://doi.org/10.1016/j.cliser.2022.100312">New projections of 21st century climate and hydrology
+              for Alaska and
+              Hawaiʻi</a>
+          </td>
+          <td>
+            Mizukami, N., Newman, A. J., Littell, J. S., Giambelluca, T. W., Wood,
+            A. W., Gutmann, E. D., Hamman, J. J., Gergel, D. R., Nijssen, B., Clark,
+            M. P., and Arnold, J. R. (2022).
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
-{% endblock %}
+    {% endblock %}


### PR DESCRIPTION
Closes #527.
Closes #531.

This PR:

- Adds missing units for the `cd`, `hd`, `rx1day`, and `rx5day` NCAR indicators on the http://127.0.0.1:5000/indicators/ documentation page.
- Adds missing units for `cd` and `hd` in NCAR indicators CSV metadata. For example: http://127.0.0.1:5000/indicators/base/point/61.5/-147?format=csv

To test:

```
export FLASK_APP=application.py 
pipenv run flask run
```

No other environment variables are necessary.