### PR TITLE
Replace all instances of <strong> to fix dark mode issues

### DIFF
--- a/templates/422/invalid_latlon.html
+++ b/templates/422/invalid_latlon.html
@@ -11,17 +11,17 @@
 </p>
 <h4 class="mt-4">Western bounding box:</h4>
 <p>
-  <strong>Latitude:</strong> <code>{{ west_bbox[1] }}</code> to <code>{{ west_bbox[3] }}</code>
+  <span class="has-text-weight-bold">Latitude:</span> <code>{{ west_bbox[1] }}</code> to <code>{{ west_bbox[3] }}</code>
 </p>
 <p>
-  <strong>Longitude:</strong> <code>{{ west_bbox[0] }}</code> to <code>{{ west_bbox[2] }}</code>
+  <span class="has-text-weight-bold">Longitude:</span> <code>{{ west_bbox[0] }}</code> to <code>{{ west_bbox[2] }}</code>
 </p>
 <h4 class="mt-5">Eastern bounding box:</h4>
 <p>
-  <strong>Latitude:</strong> <code>{{ east_bbox[1] }}</code> to <code>{{ east_bbox[3] }}</code>
+  <span class="has-text-weight-bold">Latitude:</span> <code>{{ east_bbox[1] }}</code> to <code>{{ east_bbox[3] }}</code>
 </p>
 <p>
-  <strong>Longitude:</strong> <code>{{ east_bbox[0] }}</code> to <code>{{ east_bbox[2] }}</code>
+  <span class="has-text-weight-bold">Longitude:</span> <code>{{ east_bbox[0] }}</code> to <code>{{ east_bbox[2] }}</code>
 </p>
 
 

--- a/templates/422/invalid_latlon_outside_coverage.html
+++ b/templates/422/invalid_latlon_outside_coverage.html
@@ -13,11 +13,11 @@
 {% for bbox in bboxes %}
 <h4 class="mt-4">Bounding box {{ loop.index }}:</h4>
 <p>
-  <strong>Latitude:</strong> <code>{{ bbox[1] }}</code> to
+  <span class="has-text-weight-bold">Latitude:</span> <code>{{ bbox[1] }}</code> to
   <code>{{ bbox[3] }}</code>
 </p>
 <p>
-  <strong>Longitude:</strong> <code>{{ bbox[0] }}</code> to
+  <span class="has-text-weight-bold">Longitude:</span> <code>{{ bbox[0] }}</code> to
   <code>{{ bbox[2] }}</code>
 </p>
 {% endfor %}

--- a/templates/documentation/elevation.html
+++ b/templates/documentation/elevation.html
@@ -109,7 +109,7 @@
                     and Reflection Radiometer (ASTER) Global Digital Elevation Model (GDEM) Version 3 (ASTGTM)</a></td>
             <td>NASA/METI/AIST/Japan Spacesystems and U.S./Japan ASTER Science Team (2019). <i>ASTER Global Digital Elevation Model V003</i> [Data set]. NASA EOSDIS Land Processes Distributed Active Archive Center. Accessed 2023-09-08 from <a href="https://doi.org/10.5067/ASTER/ASTGTM.003">https://doi.org/10.5067/ASTER/ASTGTM.003</a>
             </td>
-            <td><strong><code>0</code></strong> indicates sea level. Negative values are expected and indicate
+            <td><code>0</code> indicates sea level. Negative values are expected and indicate
                 depressions below sea level.</td>
         </tr>
     </tbody>

--- a/templates/documentation/indicators.html
+++ b/templates/documentation/indicators.html
@@ -217,51 +217,51 @@
 <h4>Below is the list of climate indicators that are found in this endpoint</h4>
 
 <p>
-  <strong>hd</strong>: “Hot day” threshold (degrees C) &mdash; the highest observed daily
+  <span class="has-text-weight-bold">hd</span>: “Hot day” threshold (degrees C) &mdash; the highest observed daily
   maximum 2 m air temperature such that there are 5 other observations equal to
   or greater than this value.
 </p>
 
 <p>
-  <strong>cd</strong>: “Cold day” threshold (degrees C) &mdash; the lowest observed daily
+  <span class="has-text-weight-bold">cd</span>: “Cold day” threshold (degrees C) &mdash; the lowest observed daily
   minimum 2 m air temperature such that there are 5 other observations equal to
   or less than this value.
 </p>
 
-<p><strong>rx1day</strong>: Maximum 1&ndash;day precipitation (mm)</p>
+<p><span class="has-text-weight-bold">rx1day</span>: Maximum 1&ndash;day precipitation (mm)</p>
 
 <p>
-  <strong>su</strong>: "Summer Days" &mdash; Annual number of days with maximum
+  <span class="has-text-weight-bold">su</span>: "Summer Days" &mdash; Annual number of days with maximum
   2 m air temperature above 25 degrees C
 </p>
 
 <p>
-  <strong>dw</strong>: "Deep Winter days" &mdash; Annual number of days with
+  <span class="has-text-weight-bold">dw</span>: "Deep Winter days" &mdash; Annual number of days with
   minimum 2 m air temperature below -30 degrees C
 </p>
 
 <p>
-  <strong>wsdi</strong>: Warm Spell Duration Index &mdash; Annual count of
+  <span class="has-text-weight-bold">wsdi</span>: Warm Spell Duration Index &mdash; Annual count of
   occurrences of at least 5 consecutive days with daily mean 2 m air temperature
   above 90th percentile of historical values for the date
 </p>
 
 <p>
-  <strong>cdsi</strong>: Cold Spell Duration Index &mdash; Same as WDSI, but for
+  <span class="has-text-weight-bold">cdsi</span>: Cold Spell Duration Index &mdash; Same as WDSI, but for
   daily mean 2 m air temperature below 10th percentile
 </p>
 
-<p><strong>rx5day</strong>: Maximum 5&ndash;day precipitation (mm)</p>
+<p><span class="has-text-weight-bold">rx5day</span>: Maximum 5&ndash;day precipitation (mm)</p>
 
-<p><strong>r10mm</strong>: Number of days with precipitation > 10 mm</p>
+<p><span class="has-text-weight-bold">r10mm</span>: Number of days with precipitation > 10 mm</p>
 
 <p>
-  <strong>cwd</strong>: Consecutive wet days &mdash; number of the most
+  <span class="has-text-weight-bold">cwd</span>: Consecutive wet days &mdash; number of the most
   consecutive days with precipitation > 1 mm
 </p>
 
 <p>
-  <strong>cdd</strong>: Consecutive dry days &mdash; number of the most
+  <span class="has-text-weight-bold">cdd</span>: Consecutive dry days &mdash; number of the most
   consecutive days with precipitation < 1 mm
 </p>
 <h3>Source data</h3>

--- a/templates/documentation/seaice.html
+++ b/templates/documentation/seaice.html
@@ -120,7 +120,7 @@
     </tr>
     <tr>
       <td>
-        <strong>For archival reference only.</strong> Data has been updated to
+        <span class="has-text-weight-bold">For archival reference only.</span> Data has been updated to
         use NSIDC-0051, version 2 listed above.<br />
         <a
           href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/047e91c7-35c6-410a-a1ef-95539c1ee328"


### PR DESCRIPTION
Closes #539.

I did some research and it sounds like the dark mode issue relating to the `<strong>` element is an issue/bug with Bulma itself. But because Bulma provides a `has-text-weight-bold` text-weight typography helper, it's easy to get around this by replacing instances of `<strong>` with `<span class="has-text-weight-bold">`, so that's what this PR does on the following pages:

http://127.0.0.1:5000/indicators/
http://127.0.0.1:5000/seaice/

I also discovered that two of our error templates had the same problem and fixed those as well:

http://127.0.0.1:5000/degree_days/heating/45.0628/-136.1627 (invalid lat/lon error page)
http://127.0.0.1:5000/landfastice/point/50.6123/-139.8869 (outside of coverage error page)

I also went ahead and removed the `<strong>` element from the Elevation documentation since it was being overridden by `<code>` element nested below it and wasn't actually doing anything, and I figure this helps future-proof us from unpredictable behavior:

http://127.0.0.1:5000/elevation/

So, this PR basically just removes all `<strong>` elements from all documentation pages and replaces them where needed.