### PR TITLE
Add CMIP6 reference page

### DIFF
--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -208,6 +208,11 @@ def cmip6_about():
     return render_template("/documentation/cmip6.html")
 
 
+@routes.route("/cmip6/references")
+def cmip6_references():
+    return render_template("/documentation/cmip6_refs.html")
+
+
 @routes.route("/cmip6/point/<lat>/<lon>")
 @routes.route("/cmip6/point/<lat>/<lon>/<start_year>/<end_year>")
 def run_fetch_cmip6_monthly_point_data(lat, lon, start_year=None, end_year=None):

--- a/templates/documentation/cmip6.html
+++ b/templates/documentation/cmip6.html
@@ -199,11 +199,16 @@
   <tbody>
     <tr>
       <td>
-        Publication in progress. For more information about our CMIP6 dataset,
+        Publication in progress. For more information,
         please
         <a href="mailto:uaf-snap-data-tools@alaska.edu">contact us</a> directly.
       </td>
       <td>TBD</td>
+    </tr>
+    <tr>
+      <td>
+        See <a href="/cmip6/references">this page</a> for a full list of our CMIP6 data sources and suggested citations.
+      </td>
     </tr>
   </tbody>
 </table>

--- a/templates/documentation/cmip6_refs.html
+++ b/templates/documentation/cmip6_refs.html
@@ -1,0 +1,423 @@
+{% extends 'base.html' %} {% block content %}
+<h2>CMIP6 References</h2>
+<br />
+<p>
+    Use the table below to find citations for all members in our CMIP6 model ensemble.
+</p>
+<br />
+
+
+
+<h3>CESM2</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Danabasoglu, Gokhan (2019). NCAR CESM2 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.7627">https://doi.org/10.22033/ESGF/CMIP6.7627</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Danabasoglu, Gokhan (2019). NCAR CESM2 model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.7746">https://doi.org/10.22033/ESGF/CMIP6.7746</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Danabasoglu, Gokhan (2019). NCAR CESM2 model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.7748">https://doi.org/10.22033/ESGF/CMIP6.7748</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Danabasoglu, Gokhan (2019). NCAR CESM2 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.7753">https://doi.org/10.22033/ESGF/CMIP6.7753</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Danabasoglu, Gokhan (2019). NCAR CESM2 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.7768">https://doi.org/10.22033/ESGF/CMIP6.7768</a></td>
+    </tr>
+</table>
+
+
+
+<h3>GFDL-ESM4</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Krasting, John P. et al. (2018). NOAA-GFDL GFDL-ESM4 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8597">https://doi.org/10.22033/ESGF/CMIP6.8597</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>John, Jasmin G et al. (2018). NOAA-GFDL GFDL-ESM4 model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8684">https://doi.org/10.22033/ESGF/CMIP6.8684</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>John, Jasmin G et al. (2018). NOAA-GFDL GFDL-ESM4 model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8686">https://doi.org/10.22033/ESGF/CMIP6.8686</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>John, Jasmin G et al. (2018). NOAA-GFDL GFDL-ESM4 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8691">https://doi.org/10.22033/ESGF/CMIP6.8691</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>John, Jasmin G et al. (2018). NOAA-GFDL GFDL-ESM4 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8706">https://doi.org/10.22033/ESGF/CMIP6.8706</a></td>
+    </tr>
+</table>
+
+
+
+<h3>KACE-1-0-G</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+        <tr>
+            <td>historical</td>
+            <td>Byun, Young-Hwa et al. (2019). NIMS-KMA KACE1.0-G model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8378">https://doi.org/10.22033/ESGF/CMIP6.8378</a></td>
+        </tr>
+        <tr>
+            <td>ssp126</td>
+            <td>Byun, Young-Hwa et al. (2019). NIMS-KMA KACE1.0-G model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8432">https://doi.org/10.22033/ESGF/CMIP6.8432</a></td>
+        </tr>
+        <tr>
+            <td>ssp245</td>
+            <td>Byun, Young-Hwa et al. (2019). NIMS-KMA KACE1.0-G model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8435">https://doi.org/10.22033/ESGF/CMIP6.8435</a></td>
+        </tr>
+        <tr>
+            <td>ssp370</td>
+            <td>Byun, Young-Hwa et al. (2019). NIMS-KMA KACE1.0-G model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8437">https://doi.org/10.22033/ESGF/CMIP6.8437</a></td>
+        </tr>
+        <tr>
+            <td>ssp585</td>
+            <td>Byun, Young-Hwa et al. (2019). NIMS-KMA KACE1.0-G model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8456">https://doi.org/10.22033/ESGF/CMIP6.8456</a></td>
+        </tr>
+</table>
+
+
+<h3>CNRM-CM6-1-HR</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Voldoire, Aurore (2019). CNRM-CERFACS CNRM-CM6-1-HR model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4067">https://doi.org/10.22033/ESGF/CMIP6.4067</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Voldoire, Aurore (2020). CNRM-CERFACS CNRM-CM6-1-HR model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4185">https://doi.org/10.22033/ESGF/CMIP6.4185</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Voldoire, Aurore (2019). CNRM-CERFACS CNRM-CM6-1-HR model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4190">https://doi.org/10.22033/ESGF/CMIP6.4190</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Voldoire, Aurore (2020). CNRM-CERFACS CNRM-CM6-1-HR model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4198">https://doi.org/10.22033/ESGF/CMIP6.4198</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Voldoire, Aurore (2019). CNRM-CERFACS CNRM-CM6-1-HR model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4225">https://doi.org/10.22033/ESGF/CMIP6.4225</a></td>
+    </tr>
+</table>
+
+
+
+<h3>NorESM2-MM</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Bentsen, Mats et al. (2019). NCC NorESM2-MM model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8040">https://doi.org/10.22033/ESGF/CMIP6.8040</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Bentsen, Mats et al. (2019). NCC NorESM2-MM model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8250">https://doi.org/10.22033/ESGF/CMIP6.8250</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Bentsen, Mats et al. (2019). NCC NorESM2-MM model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8255">https://doi.org/10.22033/ESGF/CMIP6.8255</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Bentsen, Mats et al. (2019). NCC NorESM2-MM model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8270">https://doi.org/10.22033/ESGF/CMIP6.8270</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Bentsen, Mats et al. (2019). NCC NorESM2-MM model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.8321">https://doi.org/10.22033/ESGF/CMIP6.8321</a></td>
+    </tr>
+</table>
+
+
+
+<h3>TaiESM1</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Lee, Wei-Liang; Liang, Hsin-Chien (2020). AS-RCEC TaiESM1.0 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.9755">https://doi.org/10.22033/ESGF/CMIP6.9755</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Lee, Wei-Liang; Liang, Hsin-Chien (2020). AS-RCEC TaiESM1.0 model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.9806">https://doi.org/10.22033/ESGF/CMIP6.9806</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Lee, Wei-Liang; Liang, Hsin-Chien (2020). AS-RCEC TaiESM1.0 model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.9808">https://doi.org/10.22033/ESGF/CMIP6.9808</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Lee, Wei-Liang; Liang, Hsin-Chien (2020). AS-RCEC TaiESM1.0 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.9809">https://doi.org/10.22033/ESGF/CMIP6.9809</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Lee, Wei-Liang; Liang, Hsin-Chien (2020). AS-RCEC TaiESM1.0 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.9823">https://doi.org/10.22033/ESGF/CMIP6.9823</a></td>
+    </tr>
+</table>
+
+
+
+<h3>HadGEM3-GC31-LL</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Ridley, Jeff et al. (2019). MOHC HadGEM3-GC31-LL model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6109">https://doi.org/10.22033/ESGF/CMIP6.6109</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Good, Peter (2020). MOHC HadGEM3-GC31-LL model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.10849">https://doi.org/10.22033/ESGF/CMIP6.10849</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Good, Peter (2019). MOHC HadGEM3-GC31-LL model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.10851">https://doi.org/10.22033/ESGF/CMIP6.10851</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Good, Peter (2020). MOHC HadGEM3-GC31-LL model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.10901">https://doi.org/10.22033/ESGF/CMIP6.10901</a></td>
+    </tr>
+</table>
+
+
+
+<h3>HadGEM3-GC31-MM</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Ridley, Jeff et al. (2019). MOHC HadGEM3-GC31-MM model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6112">https://doi.org/10.22033/ESGF/CMIP6.6112</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Jackson, Laura (2020). MOHC HadGEM3-GC31-MM model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.10850">https://doi.org/10.22033/ESGF/CMIP6.10850</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Jackson, Laura (2020). MOHC HadGEM3-GC31-MM model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.10902">https://doi.org/10.22033/ESGF/CMIP6.10902</a></td>
+    </tr>
+</table>
+
+
+
+<h3>MIROC6</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Tatebe, Hiroaki; Watanabe, Masahiro (2018). MIROC MIROC6 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.5603">https://doi.org/10.22033/ESGF/CMIP6.5603</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Shiogama, Hideo et al. (2019). MIROC MIROC6 model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.5746">https://doi.org/10.22033/ESGF/CMIP6.5746</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Shiogama, Hideo et al. (2019). MIROC MIROC6 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.5752">https://doi.org/10.22033/ESGF/CMIP6.5752</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Shiogama, Hideo et al. (2019). MIROC MIROC6 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.5771">https://doi.org/10.22033/ESGF/CMIP6.5771</a></td>
+    </tr>
+</table>
+
+
+
+<h3>EC-Earth3-Veg</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>EC-Earth Consortium (EC-Earth) (2019). EC-Earth-Consortium EC-Earth3-Veg model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4706">https://doi.org/10.22033/ESGF/CMIP6.4706</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>EC-Earth Consortium (EC-Earth) (2019). EC-Earth-Consortium EC-Earth3-Veg model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4876">https://doi.org/10.22033/ESGF/CMIP6.4876</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>EC-Earth Consortium (EC-Earth) (2019). EC-Earth-Consortium EC-Earth3-Veg model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4882">https://doi.org/10.22033/ESGF/CMIP6.4882</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>EC-Earth Consortium (EC-Earth) (2019). EC-Earth-Consortium EC-Earth3-Veg model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4886">https://doi.org/10.22033/ESGF/CMIP6.4886</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>EC-Earth Consortium (EC-Earth) (2019). EC-Earth-Consortium EC-Earth3-Veg model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4914">https://doi.org/10.22033/ESGF/CMIP6.4914</a></td>
+    </tr>
+</table>
+
+
+
+<h3>MPI-ESM1-2-HR</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Jungclaus, Johann et al. (2019). MPI-M MPI-ESM1.2-HR model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6594">https://doi.org/10.22033/ESGF/CMIP6.6594</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Schupfner, Martin et al. (2019). DKRZ MPI-ESM1.2-HR model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4397">https://doi.org/10.22033/ESGF/CMIP6.4397</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Schupfner, Martin et al. (2019). DKRZ MPI-ESM1.2-HR model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4398">https://doi.org/10.22033/ESGF/CMIP6.4398</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Schupfner, Martin et al. (2019). DKRZ MPI-ESM1.2-HR model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4399">https://doi.org/10.22033/ESGF/CMIP6.4399</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Schupfner, Martin et al. (2019). DKRZ MPI-ESM1.2-HR model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.4403">https://doi.org/10.22033/ESGF/CMIP6.4403</a></td>
+    </tr>
+</table>
+
+
+
+<h3>MRI-ESM2-0</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Yukimoto, Seiji et al. (2019). MRI MRI-ESM2.0 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6842">https://doi.org/10.22033/ESGF/CMIP6.6842</a></td>
+    </tr>
+    <tr>
+        <td>ssp126</td>
+        <td>Yukimoto, Seiji et al. (2019). MRI MRI-ESM2.0 model output prepared for CMIP6 ScenarioMIP ssp126. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6909">https://doi.org/10.22033/ESGF/CMIP6.6909</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Yukimoto, Seiji et al. (2019). MRI MRI-ESM2.0 model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6910">https://doi.org/10.22033/ESGF/CMIP6.6910</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Yukimoto, Seiji et al. (2019). MRI MRI-ESM2.0 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6915">https://doi.org/10.22033/ESGF/CMIP6.6915</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Yukimoto, Seiji et al. (2019). MRI MRI-ESM2.0 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.6929">https://doi.org/10.22033/ESGF/CMIP6.6929</a></td>
+    </tr>
+</table>
+
+
+
+<h3>E3SM-1-1</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Bader, David C. et al. (2019). E3SM-Project E3SM1.1 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.11485">https://doi.org/10.22033/ESGF/CMIP6.11485</a></td>
+    </tr>
+    <tr>
+        <td>ssp245</td>
+        <td>Bader, David C. et al. (2020). E3SM-Project E3SM1.1 model output prepared for CMIP6 ScenarioMIP ssp245. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.15164">https://doi.org/10.22033/ESGF/CMIP6.15164</a></td>
+    </tr>
+    <tr>
+        <td>ssp585</td>
+        <td>Bader, David C. et al. (2020). E3SM-Project E3SM1.1 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.15179">https://doi.org/10.22033/ESGF/CMIP6.15179</a></td>
+    </tr>
+</table>
+
+
+
+<h3>E3SM-2-0</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Experiment</th>
+            <th>Citation</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>historical</td>
+        <td>Bader, David C. et al. (2022). E3SM-Project E3SM2.0 model output prepared for CMIP6 CMIP historical. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.16953">https://doi.org/10.22033/ESGF/CMIP6.16953</a></td>
+    </tr>
+    <tr>
+        <td>ssp370</td>
+        <td>Bader, David C. et al. (2023). E3SM-Project E3SM2.0 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.16982">https://doi.org/10.22033/ESGF/CMIP6.16982</a></td>
+    </tr>
+</table>
+
+
+
+
+{% endblock %}

--- a/templates/documentation/cmip6_refs.html
+++ b/templates/documentation/cmip6_refs.html
@@ -375,7 +375,7 @@
 
 
 
-<h3>E3SM-1-1</h3>
+<!-- <h3>E3SM-1-1</h3>
 <table>
     <thead>
         <tr>
@@ -395,11 +395,11 @@
         <td>ssp585</td>
         <td>Bader, David C. et al. (2020). E3SM-Project E3SM1.1 model output prepared for CMIP6 ScenarioMIP ssp585. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.15179">https://doi.org/10.22033/ESGF/CMIP6.15179</a></td>
     </tr>
-</table>
+</table> -->
 
 
 
-<h3>E3SM-2-0</h3>
+<!-- <h3>E3SM-2-0</h3>
 <table>
     <thead>
         <tr>
@@ -415,7 +415,7 @@
         <td>ssp370</td>
         <td>Bader, David C. et al. (2023). E3SM-Project E3SM2.0 model output prepared for CMIP6 ScenarioMIP ssp370. Earth System Grid Federation. doi:<a href="https://doi.org/10.22033/ESGF/CMIP6.16982">https://doi.org/10.22033/ESGF/CMIP6.16982</a></td>
     </tr>
-</table>
+</table> -->
 
 
 


### PR DESCRIPTION
This PR adds a standalone CMIP6 reference page linked from CMIP6 documentation. 

To test, start the API as usual and review the CMIP6 documentation. Click some of the DOI links to make sure they point to the right dataset, and that the author information is correct.

Closes #444 