### PR TITLE
Places & Boundary documentation

### DIFF
--- a/application.py
+++ b/application.py
@@ -16,7 +16,7 @@ app.register_blueprint(routes)
 
 def get_service_categories():
     """
-    This is the new location for the service_categories on the main page.
+    This is the location for the service_categories on the main page.
     This will function will be called on the default route and the list
     will be passed to the index.html template.
     """
@@ -30,14 +30,27 @@ def get_service_categories():
         ("Hydrology", "/hydrology"),
         ("Landfast Sea Ice", "/landfastice"),
         ("Permafrost", "/permafrost"),
-        ("Physical and Administrative Boundary Polygons", "/boundary"),
-        ("Ecoregions", "/ecoregions"),
+        # ("Physical and Administrative Boundary Polygons", "/boundary"),
+        # ("Ecoregions", "/ecoregions"),
         ("Sea Ice Concentration", "/seaice"),
         ("Snowfall Equivalent", "/snow"),
         ("Temperature and Precipitation", "/taspr"),
         ("Wet Days Per Year", "/wet_days_per_year"),
         ("Wildfire", "/fire"),
         ("Demographics", "/demographics"),
+    ]
+
+
+def get_geospatial_categories():
+    """
+    This is the location for the geospatial_categories on the main page.
+    This will function will be called on the default route and the list
+    will be passed to the index.html template.
+    """
+    return [
+        ("Communities, Places, and Areas of Interest", "/places"),
+        ("GeoJSON Polygon Data", "/boundary"),
+        # ("Ecoregions", "/ecoregions"),
     ]
 
 
@@ -96,8 +109,12 @@ def index():
     """Render index page"""
     # Sort the service categories by category name
     service_categories = sorted(get_service_categories(), key=lambda x: x[0])
+    geospatial_categories = sorted(get_geospatial_categories(), key=lambda x: x[0])
     return render_template(
-        "index.html", service_categories=service_categories, SITE_OFFLINE=SITE_OFFLINE
+        "index.html",
+        service_categories=service_categories,
+        geospatial_categories=geospatial_categories,
+        SITE_OFFLINE=SITE_OFFLINE,
     )
 
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -36,3 +36,4 @@ from .indicators import *
 from .hydrology import *
 from .demographics import *
 from .cmip6 import *
+from .places import *

--- a/routes/places.py
+++ b/routes/places.py
@@ -1,0 +1,14 @@
+from flask import (
+    Blueprint,
+    render_template,
+)
+
+# local imports
+from . import routes
+
+places_api = Blueprint("places_api", __name__)
+
+
+@routes.route("/places/")
+def places_about():
+    return render_template("documentation/places.html")

--- a/templates/documentation/boundary.html
+++ b/templates/documentation/boundary.html
@@ -29,11 +29,11 @@
       <td><a href="/boundary/area/1901010301">/boundary/area/1901010301</a>
       </td>
     </tr>
-    <tr>
+    <!-- <tr>
       <td>Polygon of a HUC-12</td>
       <td><a href="/boundary/area/190202011303">/boundary/area/190202011303</a>
       </td>
-    </tr>
+    </tr> -->
     <tr>
       <td>Polygon of an Alaska, British Columbia, or Yukon protected area</td>
       <td><a href="/boundary/area/NPS12">/boundary/area/NPS12</a>

--- a/templates/documentation/boundary.html
+++ b/templates/documentation/boundary.html
@@ -49,6 +49,11 @@
       <td><a href="/boundary/area/CD3">/boundary/area/CD3</a>
       </td>
     </tr>
+    <!-- <tr>
+      <td>Polygon of an Alaska EPA Level III Ecoregion</td>
+      <td><a href="/boundary/area/ECO3">/boundary/area/ECO3</a>
+      </td>
+    </tr> -->
     <tr>
       <td>Polygon of a fire management zone</td>
       <td><a href="/boundary/area/FIRE2">/boundary/area/FIRE2</a>

--- a/templates/documentation/boundary.html
+++ b/templates/documentation/boundary.html
@@ -1,95 +1,15 @@
 {% extends 'base.html' %} {% block content %}
 <h2>Boundary Data</h2>
 <p>
-  These endpoints provide access to a common set of areas, and their respective boundary data, used across SNAP tools
+  These endpoints provide access to polygon boundaries used across SNAP tools
   and data.
 </p>
 
 <h3>Service endpoints</h3>
-
-<h4>Available places</h4>
-
-<p>Query a list of community or areas of interest by type.</p>
-
-<table class="endpoints">
-  <thead>
-    <tr>
-      <th class="endpoint-label">Endpoint</th>
-      <th class="endpoint-url">Example URL</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>All available areas of interest</td>
-      <td><a href="/places/all">/places/all</a></td>
-    </tr>
-    <tr>
-      <td>Communities</td>
-      <td><a href="/places/communities">/places/communities</a></td>
-    </tr>
-    <tr>
-      <td>Hydrological unit codes (HUCs)</td>
-      <td><a href="/places/hucs">/places/hucs</a></td>
-    </tr>
-    <tr>
-      <td>Alaska, British Columbia, or Yukon protected areas</td>
-      <td><a href="/places/protected_areas">/places/protected_areas</a></td>
-    </tr>
-    <tr>
-      <td>Alaska Native corporations</td>
-      <td><a href="/places/corporations">/places/corporations</a></td>
-    </tr>
-    <tr>
-      <td>Alaska climate divisions</td>
-      <td><a href="/places/climate_divisions">/places/climate_divisions</a></td>
-    </tr>
-    <tr>
-      <td>Fire management zones</td>
-      <td><a href="/places/fire_zones">/places/fire_zones</a></td>
-    </tr>
-    <tr>
-      <td>Alaska ethnolinguistic regions</td>
-      <td><a href="/places/ethnolinguistic_regions">/places/ethnolinguistic_regions</a></td>
-    </tr>
-    <tr>
-      <td>Alaska boroughs (county equivalent)</td>
-      <td><a href="/places/boroughs">/places/boroughs</a></td>
-    </tr>
-    <tr>
-      <td>Alaska census areas for the Unorganized Borough</td>
-      <td><a href="/places/census_areas">/places/census_areas</a></td>
-    </tr>
-    <tr>
-      <td>Game management units</td>
-      <td><a href="/places/game_management_units">/places/game_management_units</a></td>
-    </tr>
-    <tr>
-      <td>First nations</td>
-      <td><a href="/places/first_nations">/places/first_nations</a></td>
-    </tr>
-    <tr>
-      <td>Yukon fire districts</td>
-      <td><a href="/places/yt_fire_districts">/places/yt_fire_districts</a></td>
-    </tr>
-    <tr>
-      <td>Yukon game management subzones</td>
-      <td><a href="/places/yt_game_management_subzones">/places/yt_game_management_subzones</a></td>
-    </tr>
-    <tr>
-      <td>Yukon watersheds</td>
-      <td><a href="/places/yt_watersheds">/places/yt_watersheds</a></td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
-    </tr>
-  </tfoot>
-</table>
-
+<br/>
 <h4>GeoJSON polygons</h4>
 
-<p>Query the GeoJSON polygon(s) for a provided boundary identifier.</p>
+<p>Query the GeoJSON polygon(s) for a provided boundary identifier. See documentation for the <a href="/places">/places</a> endpoint to find identifiers.</p>
 
 <table class="endpoints">
   <thead>
@@ -102,6 +22,11 @@
     <tr>
       <td>Polygon of a HUC-8</td>
       <td><a href="/boundary/area/19070506">/boundary/area/19070506</a>
+      </td>
+    </tr>
+    <tr>
+      <td>Polygon of a HUC-10</td>
+      <td><a href="/boundary/area/1901010301">/boundary/area/1901010301</a>
       </td>
     </tr>
     <tr>
@@ -174,52 +99,7 @@
 </table>
 
 <h3>Source data</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th style="min-width: 30%;">Metadata & source data access</th>
-      <th>Citation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/">
-          Yukon Fire Districts
-        </a>
-      </td>
-      <td>GeoYukon, Government of Yukon.
-        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/">
-          https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/
-        </a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Game_Management_Areas_250k/">
-          Yukon Game Management Subzones
-        </a>
-      </td>
-      <td>GeoYukon, Government of Yukon.
-        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Game_Management_Areas_250k/">
-          https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Game_Management_Areas_250k/
-        </a>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="https://open.canada.ca/data/en/dataset/a4b190fe-e090-4e6d-881e-b87956c07977">
-          Yukon Watersheds
-        </a>
-      </td>
-      <td>National Hydro Network (NHN) - GeoBase Series, Natural Resources Canada.<br />
-        <a href="https://open.canada.ca/data/en/dataset/a4b190fe-e090-4e6d-881e-b87956c07977">
-          https://open.canada.ca/data/en/dataset/a4b190fe-e090-4e6d-881e-b87956c07977
-        </a>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<br/>
+<p>See documentation for the <a href="/places">/places</a> endpoint for data sources and citations.</p>
 
 {% endblock %}

--- a/templates/documentation/places.html
+++ b/templates/documentation/places.html
@@ -1,0 +1,139 @@
+{% extends 'base.html' %} {% block content %}
+<h2>Places Data</h2>
+<p>
+  These endpoints provide access to a common set of communities and areas used across SNAP tools
+  and data.
+</p>
+
+<h3>Service endpoints</h3>
+
+<h4>Available places</h4>
+
+<p>Query a list of community or areas of interest by type.</p>
+
+<table class="endpoints">
+  <thead>
+    <tr>
+      <th class="endpoint-label">Endpoint</th>
+      <th class="endpoint-url">Example URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>All available areas of interest</td>
+      <td><a href="/places/all">/places/all</a></td>
+    </tr>
+    <tr>
+      <td>Communities</td>
+      <td><a href="/places/communities">/places/communities</a></td>
+    </tr>
+    <tr>
+      <td>Hydrological unit codes (HUCs)</td>
+      <td><a href="/places/hucs">/places/hucs</a></td>
+    </tr>
+    <tr>
+      <td>Alaska, British Columbia, or Yukon protected areas</td>
+      <td><a href="/places/protected_areas">/places/protected_areas</a></td>
+    </tr>
+    <tr>
+      <td>Alaska Native corporations</td>
+      <td><a href="/places/corporations">/places/corporations</a></td>
+    </tr>
+    <tr>
+      <td>Alaska climate divisions</td>
+      <td><a href="/places/climate_divisions">/places/climate_divisions</a></td>
+    </tr>
+    <tr>
+      <td>Fire management zones</td>
+      <td><a href="/places/fire_zones">/places/fire_zones</a></td>
+    </tr>
+    <tr>
+      <td>Alaska ethnolinguistic regions</td>
+      <td><a href="/places/ethnolinguistic_regions">/places/ethnolinguistic_regions</a></td>
+    </tr>
+    <tr>
+      <td>Alaska boroughs (county equivalent)</td>
+      <td><a href="/places/boroughs">/places/boroughs</a></td>
+    </tr>
+    <tr>
+      <td>Alaska census areas for the Unorganized Borough</td>
+      <td><a href="/places/census_areas">/places/census_areas</a></td>
+    </tr>
+    <tr>
+      <td>Game management units</td>
+      <td><a href="/places/game_management_units">/places/game_management_units</a></td>
+    </tr>
+    <tr>
+      <td>First nations</td>
+      <td><a href="/places/first_nations">/places/first_nations</a></td>
+    </tr>
+    <tr>
+      <td>Yukon fire districts</td>
+      <td><a href="/places/yt_fire_districts">/places/yt_fire_districts</a></td>
+    </tr>
+    <tr>
+      <td>Yukon game management subzones</td>
+      <td><a href="/places/yt_game_management_subzones">/places/yt_game_management_subzones</a></td>
+    </tr>
+    <tr>
+      <td>Yukon watersheds</td>
+      <td><a href="/places/yt_watersheds">/places/yt_watersheds</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">CSV output is also available by appending <code>?format=csv</code> to the URL.</td>
+    </tr>
+  </tfoot>
+</table>
+
+<h3>Source data</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th style="min-width: 30%;">Metadata & source data access</th>
+      <th>Citation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/">
+          Yukon Fire Districts
+        </a>
+      </td>
+      <td>GeoYukon, Government of Yukon.
+        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/">
+          https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Game_Management_Areas_250k/">
+          Yukon Game Management Subzones
+        </a>
+      </td>
+      <td>GeoYukon, Government of Yukon.
+        <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Game_Management_Areas_250k/">
+          https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Game_Management_Areas_250k/
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://open.canada.ca/data/en/dataset/a4b190fe-e090-4e6d-881e-b87956c07977">
+          Yukon Watersheds
+        </a>
+      </td>
+      <td>National Hydro Network (NHN) - GeoBase Series, Natural Resources Canada.<br />
+        <a href="https://open.canada.ca/data/en/dataset/a4b190fe-e090-4e6d-881e-b87956c07977">
+          https://open.canada.ca/data/en/dataset/a4b190fe-e090-4e6d-881e-b87956c07977
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{% endblock %}

--- a/templates/documentation/places.html
+++ b/templates/documentation/places.html
@@ -99,25 +99,25 @@
   <tbody>
     <tr>
         <td>
-            <a href="https://tbd.com">
+            <a href="https://github.com/ua-snap/geospatial-vector-veracity">
                 Communities
             </a>
         </td>
-        <td>SNAP, Scenarios Network for Alaska and Arctic Planning.
-            <a href="https://tbd.com">
-                https://tbd.com
+        <td>SNAP (Scenarios Network for Alaska and Arctic Planning).
+            <a href="https://uaf-snap.org/">
+                https://uaf-snap.org/
             </a>
         </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://www.usgs.gov/national-hydrography/watershed-boundary-dataset">
           Hydrological unit codes (HUCs)
         </a>
       </td>
-      <td>USGS, United States Geological Survey.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>U.S. Geological Survey Watershed Boundary Dataset (HUC8 and HUC10 processed 9/8/2020, HUC12 processed 3/6/2023). 
+        <a href="https://www.usgs.gov/national-hydrography/watershed-boundary-dataset">
+            https://www.usgs.gov/national-hydrography/watershed-boundary-dataset
         </a>
       </td>
     </tr>
@@ -127,7 +127,7 @@
           Alaska, British Columbia, or Yukon protected areas
         </a>
       </td>
-      <td>Protected Areas Database of the United States (PAD-US), U.S. Geological Survey.
+      <td>Protected Areas Dataset.
         <a href="https://tbd.com">
           https://tbd.com
         </a>
@@ -147,61 +147,61 @@
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://www.ncei.noaa.gov/pub/data/cirs/climdiv/">
           Alaska climate divisions
         </a>
       </td>
-      <td>Alaska Climate Research Center, University of Alaska Fairbanks.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>National Centers for Environmental Information, National Oceanic and Atmospheric Administration.
+        <a href="https://www.ncei.noaa.gov/pub/data/cirs/climdiv/">
+            https://www.ncei.noaa.gov/pub/data/cirs/climdiv/
         </a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://fire.ak.blm.gov/predsvcs/maps.php">
           Fire management zones
         </a>
       </td>
       <td>Alaska Interagency Coordination Center.
-        <a href="https://tbd.com">
-          https://tbd.com
+        <a href="https://fire.ak.blm.gov/predsvcs/maps.php">
+            https://fire.ak.blm.gov/predsvcs/maps.php
         </a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://www.uaf.edu/anla/record.php?identifier=G961K2010">
           Alaska ethnolinguistic regions
         </a>
       </td>
-      <td>Alaska Native Language Center, University of Alaska Fairbanks.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>"Indigenous Peoples and Languages of Alaska", Alaska Native Language Archive, University of Alaska Fairbanks.
+        <a href="https://www.uaf.edu/anla/record.php?identifier=G961K2010">
+            https://www.uaf.edu/anla/record.php?identifier=G961K2010
         </a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://gis.data.alaska.gov/datasets/DCCED::alaska-borough-and-census-area-boundaries/about">
           Alaska boroughs (county equivalent)
         </a>
       </td>
-      <td>Alaska Department of Commerce, Community, and Economic Development.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>State of Alaska Geoportal.
+        <a href="https://gis.data.alaska.gov/datasets/DCCED::alaska-borough-and-census-area-boundaries/about">
+            https://gis.data.alaska.gov/datasets/DCCED::alaska-borough-and-census-area-boundaries/about
         </a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://gis.data.alaska.gov/datasets/DCCED::alaska-borough-and-census-area-boundaries/about">
           Alaska census areas for the Unorganized Borough
         </a>
       </td>
-      <td>Alaska Department of Commerce, Community, and Economic Development.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>State of Alaska Geoportal.
+        <a href="https://gis.data.alaska.gov/datasets/DCCED::alaska-borough-and-census-area-boundaries/about">
+            https://gis.data.alaska.gov/datasets/DCCED::alaska-borough-and-census-area-boundaries/about
         </a>
       </td>
     </tr>
@@ -211,21 +211,21 @@
           Game management units
         </a>
       </td>
-      <td>Alaska Department of Fish and Game.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>State of Alaska Geoportal.
+        <a href="https://gis.data.alaska.gov/datasets/adfg::game-management-units-subunits/about">
+            https://gis.data.alaska.gov/datasets/adfg::game-management-units-subunits/about
         </a>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <a href="https://map-data.service.yukon.ca/GeoYukon/First_Nations/First_Nation_Settlement_Lands_Surveyed/">
           First nations
         </a>
       </td>
-      <td>Indigenous and Northern Affairs Canada.
-        <a href="https://tbd.com">
-          https://tbd.com
+      <td>GeoYukon, Government of Yukon..
+        <a href="https://map-data.service.yukon.ca/GeoYukon/First_Nations/First_Nation_Settlement_Lands_Surveyed/">
+            https://map-data.service.yukon.ca/GeoYukon/First_Nations/First_Nation_Settlement_Lands_Surveyed/
         </a>
       </td>
     </tr>

--- a/templates/documentation/places.html
+++ b/templates/documentation/places.html
@@ -28,7 +28,7 @@
       <td><a href="/places/communities">/places/communities</a></td>
     </tr>
     <tr>
-      <td>Hydrological unit codes (HUCs)</td>
+      <td>Hydrological unit codes (HUCs), levels 8 and 10</td>
       <td><a href="/places/hucs">/places/hucs</a></td>
     </tr>
     <tr>

--- a/templates/documentation/places.html
+++ b/templates/documentation/places.html
@@ -43,7 +43,11 @@
       <td>Alaska climate divisions</td>
       <td><a href="/places/climate_divisions">/places/climate_divisions</a></td>
     </tr>
-    <tr>
+    <!-- <tr>
+        <td>Alaska EPA Level III Ecoregions</td>
+        <td><a href="/places/ecoregions">/places/ecoregions</a></td>
+      </tr>
+    <tr> -->
       <td>Fire management zones</td>
       <td><a href="/places/fire_zones">/places/fire_zones</a></td>
     </tr>
@@ -123,26 +127,26 @@
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <!-- <a href="https://uaf-snap.org"> -->
           Alaska, British Columbia, or Yukon protected areas
-        </a>
+        <!-- </a> -->
       </td>
       <td>Protected Areas Dataset.
-        <a href="https://tbd.com">
-          https://tbd.com
-        </a>
+        <!-- <a href="https://uaf-snap.org"> -->
+          TBD
+        <!-- </a> -->
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://tbd.com">
+        <!-- <a href="https://uaf-snap.org"> -->
           Alaska Native corporations
-        </a>
+        <!-- </a> -->
       </td>
-      <td>Alaska Native Regional Corporations, Alaska Department of Commerce, Community, and Economic Development.
-        <a href="https://tbd.com">
-          https://tbd.com
-        </a>
+      <td>Alaska Native Regional Corporations.
+        <!-- <a href="https://uaf-snap.org"> -->
+          TBD
+        <!-- </a> -->
       </td>
     </tr>
     <tr>
@@ -157,7 +161,19 @@
         </a>
       </td>
     </tr>
-    <tr>
+    <!-- <tr>
+        <td>
+          <a href="https://uaf-snap.org">
+            Alaska EPA Level III Ecoregions
+          </a>
+        </td>
+        <td>EPA Level III Ecoregions.
+          <a href="https://uaf-snap.org">
+              TBD
+          </a>
+        </td>
+      </tr>
+    <tr> -->
       <td>
         <a href="https://fire.ak.blm.gov/predsvcs/maps.php">
           Fire management zones

--- a/templates/documentation/places.html
+++ b/templates/documentation/places.html
@@ -98,6 +98,138 @@
   </thead>
   <tbody>
     <tr>
+        <td>
+            <a href="https://tbd.com">
+                Communities
+            </a>
+        </td>
+        <td>SNAP, Scenarios Network for Alaska and Arctic Planning.
+            <a href="https://tbd.com">
+                https://tbd.com
+            </a>
+        </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Hydrological unit codes (HUCs)
+        </a>
+      </td>
+      <td>USGS, United States Geological Survey.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Alaska, British Columbia, or Yukon protected areas
+        </a>
+      </td>
+      <td>Protected Areas Database of the United States (PAD-US), U.S. Geological Survey.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Alaska Native corporations
+        </a>
+      </td>
+      <td>Alaska Native Regional Corporations, Alaska Department of Commerce, Community, and Economic Development.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Alaska climate divisions
+        </a>
+      </td>
+      <td>Alaska Climate Research Center, University of Alaska Fairbanks.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Fire management zones
+        </a>
+      </td>
+      <td>Alaska Interagency Coordination Center.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Alaska ethnolinguistic regions
+        </a>
+      </td>
+      <td>Alaska Native Language Center, University of Alaska Fairbanks.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Alaska boroughs (county equivalent)
+        </a>
+      </td>
+      <td>Alaska Department of Commerce, Community, and Economic Development.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Alaska census areas for the Unorganized Borough
+        </a>
+      </td>
+      <td>Alaska Department of Commerce, Community, and Economic Development.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          Game management units
+        </a>
+      </td>
+      <td>Alaska Department of Fish and Game.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://tbd.com">
+          First nations
+        </a>
+      </td>
+      <td>Indigenous and Northern Affairs Canada.
+        <a href="https://tbd.com">
+          https://tbd.com
+        </a>
+      </td>
+    </tr>
+    <tr>
       <td>
         <a href="https://map-data.service.yukon.ca/GeoYukon/Administrative_Boundaries/Fire_Districts/">
           Yukon Fire Districts

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,10 +19,18 @@
   to use each data endpoint are given below.
 </p>
 <!-- 
-The service categories are now defined in the application.py in the get_service_categories function. 
+The service categories are defined in the application.py in the get_service_categories and get_geospatial_categories functions. 
 They are alphabetized by category name and passed to this file.
 -->
 <h4>Service categories</h4>
+<br />
+<h5>Geospatial Units</h5>
+<ul>
+  {% for category, url in geospatial_categories %}
+  <li><a href="{{ url }}">{{ category }}</a></li>
+  {% endfor %}
+</ul>
+<h5>Datasets</h5>
 <ul>
   {% for category, url in service_categories %}
   <li><a href="{{ url }}">{{ category }}</a></li>


### PR DESCRIPTION
This PR establishes 2 separate documentation pages for the `/places` and `/boundary` endpoints. Source data references are included in the documentation for `/places`, and this page is referenced in the source data section of the `/boundary` endpoint. 

This PR closes #450 , closes #500 , closes #418 , closes #299 , closes #300

This PR also addresses (but does not close) #536 and #536 by removing the GeoJSON request example for a HUC12, and removing the "Ecoregions" endpoint from the service categories. Read these 2 issues to see how we can fix these endpoints to make them more consistent with the other boundary data.