### PR TITLE
Use "cmip5" in addition to "base" for indicators

### DIFF
--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -380,7 +380,12 @@ def run_fetch_cmip6_indicators_point_data(lat, lon):
         return render_template("500/server_error.html"), 500
 
 
-@routes.route("/indicators/base/point/<lat>/<lon>")
+@routes.route(
+    "/indicators/base/point/<lat>/<lon>"
+)  # original route, kept for backwards compatibility
+@routes.route(
+    "/indicators/cmip5/point/<lat>/<lon>/"
+)  # new route, matches API documentation
 def run_fetch_base_indicators_point_data(lat, lon):
     """Query the NCAR 12km indicators_climatologies rasdaman coverage which contains indicators summarized over NCR time eras
 
@@ -540,7 +545,12 @@ def run_aggregate_var_polygon(poly_id):
     return aggr_results
 
 
-@routes.route("/indicators/base/area/<var_id>")
+@routes.route(
+    "/indicators/base/area/<var_id>"
+)  # original route, kept for backwards compatibility
+@routes.route(
+    "/indicators/cmip5/area/<var_id>/"
+)  # new route, matches API documentation
 def indicators_area_data_endpoint(var_id):
     """Area aggregation data endpoint. Fetch data within polygon area for specified variable and return JSON-like dict.
 

--- a/templates/documentation/indicators.html
+++ b/templates/documentation/indicators.html
@@ -102,7 +102,7 @@
 }
 </pre>
 
-<h4>NCAR climate indicator variables</h4>
+<h4>CMIP5 climate indicator variables</h4>
 
 <p>
   Query min-mean-max climate indicator variables for all models and scenarios.
@@ -124,8 +124,8 @@
         latitude and longitude.
       </td>
       <td>
-        <a href="/indicators/base/point/61.5/-147"
-          >/indicators/base/point/61.5/-147</a
+        <a href="/indicators/cmip5/point/61.5/-147"
+          >/indicators/cmip5/point/61.5/-147</a
         >
       </td>
     </tr>
@@ -135,8 +135,8 @@
         specific area
       </td>
       <td>
-        <a href="/indicators/base/area/1903040601"
-          >/indicators/base/area/1903040601</a
+        <a href="/indicators/cmip5/area/1903040601"
+          >/indicators/cmip5/area/1903040601</a
         >
       </td>
     </tr>


### PR DESCRIPTION
This PR adds an alternate "cmip5" route to the indicators endpoint, and includes this route in the API documentation for consistency with the new "cmip6" indicators route.

The old "base" route is left intact, so that no apps break. 

To test, start the API as usual and review the climate indicators documentation. Test some links using the new "cmip5" option, e.g. http://localhost:5000/indicators/cmip5/area/1903040601

closes #515 