### PR TITLE
Updates where the code should look for the Encoding string in the coverage metadata in Rasdaman.

### DIFF
--- a/validate_request.py
+++ b/validate_request.py
@@ -403,9 +403,6 @@ def get_coverage_encodings(coverage_metadata):
             # get encoding string from first slice (all slices contain the same encoding)
             encoding_str = slices[0].get("Encoding")
 
-        # get encoding string from first slice (all slices contain the same encoding)
-        encoding_str = slices[0].get("Encoding")
-
         if not encoding_str:
             raise ValueError("No encoding information found in coverage metadata")
 

--- a/validate_request.py
+++ b/validate_request.py
@@ -398,7 +398,10 @@ def get_coverage_encodings(coverage_metadata):
         slices = metadata.get("slices", {}).get("slice", [])
 
         if not slices:
-            raise ValueError("No slices found in coverage metadata")
+            encoding_str = metadata.get("Encoding")
+        else:
+            # get encoding string from first slice (all slices contain the same encoding)
+            encoding_str = slices[0].get("Encoding")
 
         # get encoding string from first slice (all slices contain the same encoding)
         encoding_str = slices[0].get("Encoding")


### PR DESCRIPTION
This PR modifies the location in which the code looks for the metadata section "Encoding" when starting up the API. Previously, we had all of our Encoding metadata in the "local" section of the ingests which resulted in redundant copies of that metadata for each slice of the coverage, which could actually slow down response times on given coverages with numerous (thousands) slices. 

To test this change, make sure that you can still start up the API when pointed at Apollo or Zeus. Apollo is currently the server that has the coverages ingested with the global section containing the Encoding string, which is what required this change in the first place.

Testing:
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
pipenv run flask run

Expected: API starts up normally and the endpoints should return data

export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run

Expected: API starts up normally and the endpoints should return data