### PR TITLE
test cmip6_monthly_e3sm coverage

### DIFF
--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -18,7 +18,7 @@ from . import routes
 
 cmip6_api = Blueprint("cmip6_api", __name__)
 
-cmip6_monthly_coverage_id = "cmip6_monthly"
+cmip6_monthly_coverage_id = "cmip6_monthly_e3sm"
 
 
 async def get_cmip6_metadata():
@@ -99,27 +99,15 @@ def package_cmip6_monthly_data(
         if var_id != None:
             varname = var_id
         else:
-
-            # TODO: fix cryo coverage so we can delete this line below
-            # temporary fix for "string key" issue
-            var_coord = str(var_coord)
             varname = dim_encodings["varname"][var_coord]
-
+        
         for mi, model_li in enumerate(var_li):
-
-            # TODO: fix cryo coverage so we can delete this line below
-            # temporary fix for "string key" issue
-            mi = str(mi)
-
             model = dim_encodings["model"][mi]
+
             if model not in di:
                 di[model] = dict()
+
             for si, scenario_li in enumerate(model_li):
-
-                # TODO: fix cryo coverage so we can delete this line below
-                # temporary fix for "string key" issue
-                si = str(si)
-
                 scenario = dim_encodings["scenario"][si]
                 if scenario not in di[model]:
                     di[model][scenario] = dict()
@@ -175,6 +163,7 @@ def package_cmip6_monthly_data(
     # all 0 values are replaced with -9999 and will be pruned from the response.
     # If the scenario is not historical, and the year is less than 2015,
     # all 0 values are replaced with -9999 and will be pruned from the response.
+                    
 
     for model, scenarios in di.items():
         for scenario, months in scenarios.items():
@@ -295,6 +284,7 @@ def run_fetch_cmip6_monthly_point_data(lat, lon, start_year=None, end_year=None)
                 new_results = package_cmip6_monthly_data(
                     point_data_list, var_id, start_year, end_year
                 )
+
                 for model, scenarios in new_results.items():
                     results.setdefault(model, {})
                     for scenario, months in scenarios.items():

--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -18,7 +18,7 @@ from . import routes
 
 cmip6_api = Blueprint("cmip6_api", __name__)
 
-cmip6_monthly_coverage_id = "cmip6_monthly_e3sm"
+cmip6_monthly_coverage_id = "cmip6_monthly"
 
 
 async def get_cmip6_metadata():
@@ -100,7 +100,7 @@ def package_cmip6_monthly_data(
             varname = var_id
         else:
             varname = dim_encodings["varname"][var_coord]
-        
+
         for mi, model_li in enumerate(var_li):
             model = dim_encodings["model"][mi]
 
@@ -163,7 +163,6 @@ def package_cmip6_monthly_data(
     # all 0 values are replaced with -9999 and will be pruned from the response.
     # If the scenario is not historical, and the year is less than 2015,
     # all 0 values are replaced with -9999 and will be pruned from the response.
-                    
 
     for model, scenarios in di.items():
         for scenario, months in scenarios.items():

--- a/validate_request.py
+++ b/validate_request.py
@@ -398,10 +398,10 @@ def get_coverage_encodings(coverage_metadata):
         slices = metadata.get("slices", {}).get("slice", [])
 
         if not slices:
-            raise ValueError("No slices found in coverage metadata")
-
-        # get encoding string from first slice (all slices contain the same encoding)
-        encoding_str = slices[0].get("Encoding")
+            encoding_str = metadata.get("Encoding")
+        else:
+            # get encoding string from first slice (all slices contain the same encoding)
+            encoding_str = slices[0].get("Encoding")
 
         if not encoding_str:
             raise ValueError("No encoding information found in coverage metadata")


### PR DESCRIPTION
This PR makes the changes necessary to fetch data from the `cmip6_monthly` coverage on Apollo, which now has E3SM model data included. 

This coverage differs from the production `cmip6_monthly` on Zeus in that it has an encoding dictionary with integer keys rather than string keys. Previously, we had to convert the keys to strings in order to fetch values from the encodings dictionary, but this branch removes that temporary patch. 

For this reason, even though the `validate_request.get_coverage_encodings()` function has been changed to find the encodings dictionary in both production and development coverage metadata (which ensures the app will start no matter which Rasdaman server its pointed at), the actual data fetching from production `cmip6_monthly` coverage will fail if this is merged into `main`. **So we should wait until the production `cmip6_monthly` coverage is replaced with the dev coverage before merging this branch into `main`!**

To test:

Basically we just want to be sure the API will fetch data as usual from the new CMIP6 monthly coverage that contains the E3SM models.

Point the API at Apollo and fetch some data from the CMIP6 endpoint. Search the JSON return for "E3SM" to make sure the data shows up. Try running the same queries from `earthmaps.io/cmip6` and spot checking to make sure the other models are returning the same data. **Note that `pr` and `prsn` variables will return slightly different values between production and development here!** @Kyle and I discussed this and we think the interpolation parameters in the regridding pipeline have changed since the production ingest, and that is the cause of the discrepancy. No need for alarm here, we are going to commit to the newest interpolation method.

Note that there is a small difference in the encodings dictionary between production and dev: the production coverage will return `swe` instead of `snw` as a variable (`swe` data is not actually a CMIP6 variable id - the variable id is technically `snw` which is mathematically equivalent to `swe` .... we may have to rectify this when pushing the `cmip6_monthly` into production).