### PR TITLE
Fix indicator point queries

### DIFF
--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -461,7 +461,7 @@ def run_fetch_cmip6_indicators_point_data(lat, lon):
         return render_template("400/bad_request.html"), 400
     cmip6_bbox = construct_latlon_bbox_from_coverage_bounds(cmip6_metadata)
     within_bounds = validate_latlon_in_bboxes(
-        lat, lon, [cmip6_bbox], [cmip6_indicators_coverage_id]
+        lat, lon, [cmip6_bbox], [var_ep_lu["cmip6_indicators"]["cov_id_str"]]
     )
     if within_bounds == 422:
         return (
@@ -515,7 +515,9 @@ def run_fetch_cmip5_indicators_point_data(lat, lon):
     Notes:
         example request: http://localhost:5000/indicators/cmip5/point/65.06/-146.16
     """
-    validation = validate_latlon(lat, lon, [indicators_coverage_id])
+    validation = validate_latlon(
+        lat, lon, [var_ep_lu["cmip5_indicators"]["cov_id_str"]]
+    )
     if validation == 400:
         return render_template("400/bad_request.html"), 400
     if validation == 404:

--- a/routes/indicators.py
+++ b/routes/indicators.py
@@ -334,6 +334,8 @@ def package_cmip6_point_data(rasdaman_response):
         for indicator_name, indicator_value in zip(
             var_ep_lu["cmip6_indicators"]["bandnames"], indicator_values
         ):
+            if indicator_name == "rx1day":
+                indicator_value = round(indicator_value)
             indicator_dict[indicator_name] = indicator_value
 
         results[dim_combo[0]][dim_combo[1]][dim_combo[2]] = indicator_dict


### PR DESCRIPTION
Closes #569.

Somewhere along the way, both the CMIP6 indicators and CMIP5 indicators point query endpoints stopped working, producing server errors. Looks like this was just a case of the corresponding Rasdaman coverage string variables not getting updated during a code refactor, or maybe an automerge glitch. This PR fixes this.

After fixing this, I also noticed that the CMIP6 `rx1day` indicator values were not rounded. All values had ~13 decimal points, like `14.3096173647791`. I went ahead and rounded these values to the nearest whole number, since that's how we generally display values that are in millimeters.

To test, make sure each of these two endpoints are working and the `rx1day` values in the CMIP6 indicator endpoint have a sane level of precision:

http://127.0.0.1:5000/indicators/cmip6/point/65/-147
http://127.0.0.1:5000/indicators/cmip5/point/65/-147