### PR TITLE
Add workaround for Zeus NoData/0 WCS bug

### DIFF
--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -108,6 +108,12 @@ def package_cmip6_monthly_data(
                 di[model] = dict()
 
             for si, scenario_li in enumerate(model_li):
+                # Rasdaman Enterprise (as of v10.4.7) returns missing model/scenario NoData gaps
+                # as arrays full of 0s, which get converted to 0.0 somewhere along the way.
+                # Treat any array that is full of nothing but 0.0s as NoData and skip over it.
+                if all(value == 0.0 for value in scenario_li):
+                    continue
+
                 scenario = dim_encodings["scenario"][si]
                 if scenario not in di[model]:
                     di[model][scenario] = dict()


### PR DESCRIPTION
This PR implements a few lines of code to skip over `cmip6_monthly` data arrays received over WCS from Zeus that consist entirely of 0s, as described in my recent email.

This fix is based on the assumption that it is safe to treat a scenario's time series (years * months) array as NoData if it contains nothing but 0s. Note that this fix applies to only the `cmip6_monthly` coverage/endpoint. This is deliberate because (as far as I know) other coverages don't have this problem, and it's also easier to imagine other coverages legitimately having arrays full of 0s (`cmip6_indicators` summer days for coastal locations comes to mind).

For any of the `cmip6_monthly` scenario time series arrays, if we encounter 1,812 zeros in a row (151 years * 12 months), we can safely assume this to be a NoData pocket for any of the 18 `cmip6_monthly` variables, but please give this some thought in case I am mistaken. Are there any CMIP6 variables where 1,812 zeros in a row could be real data?

To test, first change the coverage name in the `routes/cmip6.py` file to this:

```
cmip6_monthly_coverage_id = "cmip6_monthly_crstephenson"
```

The `cmip6_monthly_crstephenson` coverage has been ingested on both Apollo and Zeus using the same ingest script and data files and are functionally identical.

You'll also need to comment out the `temperature_anomolies` route from `routes/__init__.py` since this coverage hasn't been ingested onto Zeus yet:

```
# from .temperature_anomalies import *
```

Now, run the Data API against Apollo first:

```
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then, download data for a "problem variable" at a point location and save it as a "prettified" JSON file:

```
wget 'http://127.0.0.1:5000/cmip6/point/61.5/-147?vars=tas' -O - | python -m json.tool > apollo.json
```

Next, run the Data API against Zeus:

```
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
pipenv run flask run
```

And run the same `wget` command, but saving the "prettified" JSON to a different file for Zeus:

```
wget 'http://127.0.0.1:5000/cmip6/point/61.5/-147?vars=tas' -O - | python -m json.tool > zeus.json
```

Finally, perform a diff of the two files. There should be no output, and thus no differences:

```
diff apollo.json zeus.json
```

This means that we are successfully detecting and removing the NoData-turned-0 data from Zeus' WCS URL.