### PR TITLE
Fix intermittent demographics CSV column misordering issue

### DIFF
--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1123,7 +1123,10 @@ def demographics_csv(data):
 
     # specify the order of the CSV columns
     fieldnames = ["variable", "Alaska", "United States", "description", "source"]
-    community_fieldname = [key for key in value_cols if key not in fieldnames][0]
+    community_keys = [key for key in value_cols if key not in fieldnames]
+    if not community_keys:
+        raise ValueError("No valid community fieldname found in value_cols.")
+    community_fieldname = community_keys[0]
     fieldnames.insert(1, community_fieldname)
     csv_dicts = build_csv_dicts(data, fieldnames, values=value_cols)
 


### PR DESCRIPTION
While testing PR #572 several times for several different communities, I noticed that the columns were only in the correct order some of the time.

It's still a bit of a mystery why this is so intermittent without digging deeply into the code, but if you run the Data API from the `demo_csv_order` branch as described in PR #572 and download the same CSV for the same community ~10 times, you'll probably encounter the same thing I did. I like to use `wget` to make sure I'm not getting the same cached CSV every time due to aggressive browser caching:

```
wget 'http://127.0.0.1:5000/demographics/AK124?format=csv' -O AK124.csv
```

Sometimes "Fairbanks" appears to the right of "Alaska" and "United States".

The good news is that the CSV column order is controlled by the `fieldnames` variable that is returned from the `demographics_csv` function, so as long as the column keys are ordered correctly in the `fieldnames` list, they will be ordered correctly in the CSV download every time without any need to reorder the keys of the individual CSV dicts. That's what this sub-PR does.

To test, follow the same testing instructions in PR #572 but make sure to run the Data API from this `demo_csv_order_fix` branch.