### PR TITLE
Add extra Temperature Anomaly value check for Zeus compatibility

### DIFF
--- a/routes/temperature_anomalies.py
+++ b/routes/temperature_anomalies.py
@@ -57,7 +57,9 @@ def package_anomaly_data(point_data_list):
                 di[model]["temperature_anomalies"][scenario] = dict()
             for yi, value in enumerate(scenario_li):
                 year = years[yi]
-                di[model]["temperature_anomalies"][scenario][year] = round(value, 2)
+                if value is not None:
+                    value = round(value, 2)
+                di[model]["temperature_anomalies"][scenario][year] = value
     return di
 
 


### PR DESCRIPTION
This PR is a small fix to the Temperature Anomalies endpoint that is necessary for Zeus compatibility. On Apollo, NoData values from the Temperature Anomalies coverages are returned from WCS as `-9999`. On Zeus, the same values are returned as a `null`. This change makes sure that a value is not `None` (converted from JSON `null`) before attempting to round it.

To test, run the Data API against Zeus:

```
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then verify that a Temperature Anomalies URL like this returns data, not a server error:

http://127.0.0.1:5000/temperature_anomalies/point/63.73/-166.32