### PR TITLE
update dataset name and access date

### DIFF
--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -5,7 +5,7 @@
 <p>
   The endpoints here provide access to demographic data derived from the 2020 US Census Demographics and 
   Housing Characteristics File (DHC), the 2019&ndash;2023 US Census American Community Survey (ACS) 5-year dataset,
-   the 2023 CDC PLACES dataset, and the 2017&ndash;2021 CDC Social Determinants of Health (SDOH) dataset. 
+   the 2023 CDC PLACES dataset, and the 2017&ndash;2021 CDC Non-Medical Factor Measures dataset. 
    Data is returned for individual Alaskan communities, and also includes contextual data for the state of
     Alaska and the United States.
 </p>
@@ -280,9 +280,9 @@
             </td>
         </tr>
         <tr>
-            <td>2017-2021 CDC Social Determinants of Health (SDOH) dataset</td>
+            <td>2017-2021 CDC Non-Medical Factor Measures dataset</td>
             <td>Healthy People 2030, U.S. Department of Health and Human Services, Office of Disease Prevention and Health Promotion. 
-                Accessed May 2024, from <a href="https://health.gov/healthypeople/objectives-and-data/social-determinants-health">https://health.gov/healthypeople/objectives-and-data/social-determinants-health</a></td>
+                Accessed February 2025, from <a href="https://health.gov/healthypeople/objectives-and-data/social-determinants-health">https://health.gov/healthypeople/objectives-and-data/social-determinants-health</a></td>
             <td> 
                 <code>pct_no_bband</code>,
                 <code>pct_no_bband_low</code>,


### PR DESCRIPTION
closes #552 

Note that the source data link still points to the SDOH homepage. This is because the "Non-Medical Factor Measures" does not have a homepage. Basically, the dataset name changed in the CDC API and online data explorer, but the over-arching project name still seems to be SDOH.

Clear as mud :) 