### PR TITLE
Remove HUC12s from /places endpoints for now

### DIFF
--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -82,6 +82,11 @@ def find_via_gs(lat, lon):
     # For each returned area, place it inside the correct area type.
     # We want to collect the area's geometry, id, name, and type.
     for ai in range(len(nearby_areas)):
+        # HUC12s do not play well with Northern Climate Reports.
+        # Remove them from /places endpoints for now.
+        if nearby_areas[ai]["properties"]["area_type"] == "HUC12":
+            continue
+
         current_area_type = areas_near[nearby_areas[ai]["properties"]["type"]]
         current_index = len(proximal_di[current_area_type])
         proximal_di[current_area_type][current_index] = gather_nearby_area(
@@ -275,6 +280,11 @@ def get_json_for_type(type, recurse=False):
             # For each feature, put the properties (name, id, type) into the
             # list for creation of a JSON object to be returned.
             for ai in range(len(all_areas)):
+                # HUC12s do not play well with Northern Climate Reports.
+                # Remove them from /places endpoints for now.
+                if all_areas[ai]["properties"]["area_type"] == "HUC12":
+                    continue
+
                 # If this area is a protected_area, keep area_type in
                 # returned output.
                 if all_areas[ai]["properties"]["area_type"] != "":


### PR DESCRIPTION
This PR attempts to fix an issue we discovered today with the soon-to-launch Northern Climate Reports webapp.

The inclusion of HUC12s in the `/places/all?tags=ncr` endpoint increases the number of options in the place selector input from 4,233 to 18,403, and this seems to be causing issues with Chrome's memory heap size, causing huge slowdowns in performance and sometimes erasing the app state while a report is loading. The good news is that it's easy to skip over HUC12s in the Data API code without changing the shapefile in GeoServer, so that is what I've done here.

Originally I was planning to keep HUC12s as a result option for NCR's map click search interface, but I realized while testing this that NCR does not support HUC12s at all, so there's more work to do here if we want to include HUC12s in NCR directly. I've removed HUC12s from the `/places/search` endpoint, but confirmed that HUC12s are still working as intended for the enclosing area of point-based ALFRESCO queries.