### PR TITLE
Refactor the ArcticEDS endpoint for use in Elastic Beanstalk

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: . /opt/conda/etc/profile.d/conda.sh && conda deactivate && conda activate api-env && gunicorn --timeout 600 -b 0.0.0.0:8000 application:app
+web: . /opt/conda/etc/profile.d/conda.sh && conda deactivate && conda activate api-env && gunicorn --workers 5 --timeout 600 -b 0.0.0.0:8000 application:app


### PR DESCRIPTION
This PR is a refactoring of the ArcticEDS endpoint /eds/all/ which now will make requests directly to the functions contained within the routes rather than using asyncio to call the endpoints at the URL of the API. This was done because the ArcticEDS functionality was broken in the new API on Elastic Beanstalk and would never return any values, instead timing out after waiting for a response that would never return. 

The data returned between the main branch and this branch should be identical as they are calling the same functions with the same input data, so try a few locations between the main branch and the refactor_eds branch. 

Note: The /eds/all endpoint still takes a very long time to complete (3-5 minutes), so get yourself a drink while you wait for the end results.

