### PR TITLE
Updates permafrost endpoint to use NetCDF coverage

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -118,8 +118,8 @@ def make_ncr_gipl1km_wcps_request_str(x, y, years, model, scenario, summary_oper
         x -- (float) x-coordinate for the point query
         y -- (float) y-coordinate for the point query
         years -- (str) colon-separated ISO date-time, e.g., "\"2040-01-01T00:00:00.000Z\":\"2069-01-01T00:00:00.000Z\""
-        model (int) -- Integer representing model (0 = 5ModelAvg, 1 = GFDL-CM3, 2 = NCAR-CCSM4)
-        scenario (int) -- Integer representing scenario (0 = RCP 4.5, 1 = RCP 8.5)
+        model -- (int) Integer representing model (0 = 5ModelAvg, 1 = GFDL-CM3, 2 = NCAR-CCSM4)
+        scenario -- (int) Integer representing scenario (0 = RCP 4.5, 1 = RCP 8.5)
         summary_operation -- (str) one of 'min', 'avg', or 'max'
     Returns:
         gipl1km_wcps_str -- (str) fragment used to construct the WCPS request


### PR DESCRIPTION
This PR updates the permafrost endpoints that use the crrel_gipl_outputs coverage to use the improved crrel_gipl_outputs_nc version that is contained within a single NetCDF file rather than 6,000 GeoTIFFs. This leads to a massive boost in performance for the various endpoints while still returning the same result as the previous coverage. 

The change that has been made is in the WCPS queries that are sent to the Rasdaman server, since the new coverage does not have an axis for variables, and instead has bands of data that represent each of those variables now. Additionally, the JSON packaging functions needed to be updated to work with the returned data format.

For testing, there are a few API endpoints to confirm still return the same data.

**GIPL Point Query**
http://localhost:5000/permafrost/point/gipl/65/-164
https://testcache.earthmaps.io/permafrost/point/gipl/65/-164

**GIPL Point Query with Year Range**
http://localhost:5000/permafrost/point/gipl/65/-164/2040/2080
https://testcache.earthmaps.io/permafrost/point/gipl/65/-164/2040/2080

**GIPL Point Query with MMM summary**
http://localhost:5000/permafrost/point/gipl/65/-163?summarize=mmm
https://testcache.earthmaps.io/permafrost/point/gipl/65/-163?summarize=mmm

**GIPL Point Query with Year Range and MMM summary**
http://localhost:5000/permafrost/point/gipl/65/-163/2030/2060?summarize=mmm
https://testcache.earthmaps.io/permafrost/point/gipl/65/-163/2030/2060?summarize=mmm

**NCR Point Query**
http://localhost:5000/ncr/permafrost/point/65/-152
https://testcache.earthmaps.io/ncr/permafrost/point/65/-152

**EDS Point Query**
http://localhost:5000/eds/permafrost/65/-153
https://testcache.earthmaps.io/eds/permafrost/65/-153

Please try some other endpoints similar to these to ensure we are still getting expected values!