### PR TITLE
Propagate HTTP 500 errors from child EDS endpoints to /eds/all parent endpoint

### DIFF
--- a/routes/eds.py
+++ b/routes/eds.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, current_app as app, jsonify, render_template
+from flask import Blueprint, request, current_app as app, jsonify
 from . import routes
 from .taspr import get_temperature_plate, get_precipitation_plate, proj_precip_point
 from .snow import eds_snow_data


### PR DESCRIPTION
This PR refactors the `/eds/all` endpoint to return the HTTP 500 error code/template if any of its child endpoints returns an HTTP 500 response. HTTP 404s, etc., are still treated as null/nodata responses as before, and as intended.

To test this, I ran the Data API locally (pointed at Zeus + gs-dev.earthmaps.io), and then ran this throwaway Python script in a different terminal window to verify that HTTP 500 status codes were occasionally returned from the `/eds/all` endpoint:

```python
#!/usr/bin/env python3
import requests
import random
from time import sleep

while True:
    lat = round(random.uniform(60, 70), 2)
    lon = round(random.uniform(-160, -140), 2)
    url = f"http://127.0.0.1:5000/eds/all/{lat}/{lon}"
    response = requests.get(url)
    print(f"{url}: {response.status_code}")
    sleep(3)
```

I also added `print(status_code)` in this `if` statement to verify that the number of 500 status codes I received from the throwaway Python script above corresponded to the number of 500 status codes found in this `if` statement:

https://github.com/ua-snap/data-api/blob/6fbcc972064027d88355be2a5e980dc005bc91ac/routes/eds.py#L31-L32