### PR TITLE
Adds fuzzy matching to /places/search/communities endpoint

### DIFF
--- a/.platform/hooks/prebuild/install-conda.sh
+++ b/.platform/hooks/prebuild/install-conda.sh
@@ -27,7 +27,7 @@ else
   conda create -y -n api-env -c conda-forge python=3.11 \
     flask flask-cors gunicorn aiohttp requests marshmallow \
     numpy xarray h5py h5netcdf rioxarray rasterio \
-    pyproj shapely geopandas rtree fiona
+    pyproj shapely geopandas rtree fiona thefuzz
 fi
 
 # Always ensure EB will activate the environment on app startup

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ pygeos = "*"
 lxml = "*"
 marshmallow = "*"
 fiona = "*"
+thefuzz = "*"
 
 [dev-packages]
 black = "*"

--- a/routes/vectordata.py
+++ b/routes/vectordata.py
@@ -367,18 +367,17 @@ def get_communities():
             name = community["properties"].get("name", "").lower()
             alt_name = community["properties"].get("alt_name", "").lower()
             community_id = community["properties"].get("id")
-            # Exact substring match
             if substring in name or substring in alt_name:
                 if community_id not in seen_ids:
                     filtered_exact.append(community)
                     seen_ids.add(community_id)
-            # Fuzzy match
-            ratio_name = fuzz.ratio(substring, name) if name else 0
+
+            ratio_name = fuzz.ratio(substring, name)
             ratio_alt = fuzz.ratio(substring, alt_name) if alt_name else 0
             if (ratio_name >= 85 or ratio_alt >= 85) and community_id not in seen_ids:
                 filtered_fuzzy.append(community)
                 seen_ids.add(community_id)
-        # Combine both lists (order: exact matches first, then fuzzy matches)
+
         all_communities = filtered_exact + filtered_fuzzy
 
     output = [c["properties"] for c in all_communities]


### PR DESCRIPTION
This PR adds fuzzy matching to the /places/search/communities endpoint that is used by the ARDAC Gimme search boxes. The Levenshtein ratio is set to match above 85% currently, which means that one letter can be wrong, missing, or added to get a returned match. This is using the library "thefuzz" for the fuzzy matching, because I did not find a library that did exactly what we wanted and thefuzz is very easy to implement and to understand what it is doing. 

To test, you will want to pipenv install the new Pipfile:
`pipenv install`

Run Flask:
`export FLASK_APP=application.py`
`pipenv run flask run`

Test a variety of substrings for exact and fuzzy matching:

**Exact and Fuzzy Matching**
http://localhost:5000/places/search/communities?substring=Fairbanks <-- Note that Fairbank is returned from Canada
https://earthmaps.io/places/search/communities?substring=Fairbanks <-- Fairbank will not be listed in the returned communities

**Wrong Character Used**
http://localhost:5000/places/search/communities?substring=Utqiagvik  <-- Returns Utqiaġvik
https://earthmaps.io/places/search/communities?substring=Utqiagvik <-- Returns nothing

**Missing Character**
http://localhost:5000/places/search/communities?substring=Anhorage <-- Returns Anchorage
https://earthmaps.io/places/search/communities?substring=Anhorage <-- Returns nothing

**Added Character**
http://localhost:5000/places/search/communities?substring=Palmert <-- Returns Palmer for AK, Ontario, and Saskatchewan
https://earthmaps.io/places/search/communities?substring=Palmert <-- Returns nothing

I've left this in a draft PR for now to be reviewed and determined if this is the direction we want to go with fuzzy substring matching.