### PR TITLE
Adjust last accessed to match NCR

### DIFF
--- a/templates/documentation/demographics.html
+++ b/templates/documentation/demographics.html
@@ -216,7 +216,7 @@
         <tr>
             <td>2020 US Census Demographics and Housing Characteristics File (DHC)</td>
             <td>U.S. Census Bureau (2020). Demographics and Housing Characteristics File. 
-                Accessed May 2024, from <a href="https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html">https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html</a></td>
+                Accessed November 2024, from <a href="https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html">https://www.census.gov/data/tables/2023/dec/2020-census-dhc.html</a></td>
             <td>
                 <code>total_population</code>, 
                 <code>pct_under_18</code>,
@@ -251,7 +251,7 @@
         <tr>
             <td>2023 CDC PLACES dataset</td>
             <td>PLACES. Centers for Disease Control and Prevention. 
-                Accessed May 2024, from <a href="https://www.cdc.gov/places">https://www.cdc.gov/places</a></td>
+                Accessed November 2024, from <a href="https://www.cdc.gov/places">https://www.cdc.gov/places</a></td>
             <td> 
                 <code>pct_asthma</code>, 
                 <code>pct_asthma_low</code>,


### PR DESCRIPTION
Closes #579 

Test by checking out the documentation endpoint for Demographics.  Ensure that the two datasets referenced in 579 say November and not May.