### PR TITLE
Add a vectorized zonal stats implementation

### DIFF
--- a/routes/era5wrf.py
+++ b/routes/era5wrf.py
@@ -24,7 +24,7 @@ from zonal_stats import (
     get_scale_factor,
     rasterize_polygon,
     interpolate,
-    calculate_zonal_stats_vectorized,
+    calculate_zonal_means_vectorized,
 )
 from postprocessing import postprocess, prune_nulls_with_max_intensity
 from csv_functions import create_csv
@@ -251,7 +251,7 @@ def process_era5wrf_zonal_stats(polygon, datasets_dict, variables):
         da_i_3d = interpolate(ds, var_name, "X", "Y", scale_factor, method="nearest")
 
         # calculate zonal stats for the entire time series
-        time_series_means = calculate_zonal_stats_vectorized(
+        time_series_means = calculate_zonal_means_vectorized(
             da_i_3d, rasterized_polygon_array, "X", "Y"
         )
         zonal_results[var_name] = time_series_means

--- a/zonal_stats.py
+++ b/zonal_stats.py
@@ -126,9 +126,9 @@ def calculate_zonal_stats(da_i, polygon_array, x_dim, y_dim):
     return zonal_stats
 
 
-def calculate_zonal_stats_vectorized(da_i, polygon_array, x_dim, y_dim):
+def calculate_zonal_means_vectorized(da_i, polygon_array, x_dim, y_dim):
     """
-    Calculate zonal statistics for a 3D xarray data array (time, y, x)
+    Calculate zonal means for a 3D xarray data array (time, y, x)
     and a 2D rasterized polygon array of the same shape.
     Args:
         da_i (xarray.DataArray): 3D xarray data array, probably interpolated


### PR DESCRIPTION
This PR adds a new function to improve the performance of the ERA5-WRF area endpoint.

Previously, zonal statistics were calculated by iterating through each of the ~23,000 time slices serially, making the endpoint very slow. Now, a "vectorized" approach via NumPy reduces the processing time by a factor of ~10X.

The function is called `calculate_zonal_means_vectorized` ( in the  `zonal_stats.py` )
As I understand, we avoid the Python loops because the array selection and reduction happens in larger chunks in C, via NumPy.

The `process_era5wrf_zonal_stats` function in `routes/era5wrf.py` is the only place we call this new vectorized function. The for loop over the time indices is now gone.

I've added some logging in here as well for better visibility into where we are budgeting our response time.

To test this PR:

Mimic the queries suggested in #643, both in that branch, and in this one:

Verify that the content of the JSONs are identical
Verify that the repsonse time in this branch is substanially more rapid than in `era5_wrf_polygons`
