### PR TITLE
permit underscores, numbers, longer string in vars query param valida…

### DIFF
--- a/application.py
+++ b/application.py
@@ -132,7 +132,7 @@ def validate_get_params():
             """
             # 200 is arbitrary, but endpoints (e.g., era5wrf) have many vars
             climate_var_regex = re.compile(
-                r"^(?=.{1,200}$)[A-Za-z0-9_]+(?:,[A-Za-z0-9_]+)*$"
+                r"^(?=.{1,200}$)[A-Za-z0-9,_]+$"
             )
             if not climate_var_regex.match(value):
                 raise ValidationError("Invalid var(s) provided.")


### PR DESCRIPTION
This PR is motivated by #663 

Some of the endpoints are going to have boatloads of `vars` i.e. climate variables available.
Coarse-grid-CMIP6 and ERA5-WRF are the two that come to mind. A user (real world version: ERA5-Xray item in ARDAC) may want many variables, but not all! For example, 9 variables, instead of 11. At this time, that ARDAC item doesn't use max wind speed or sea ice. So, we need to be a bit looser with our `var` query param validation.

I've modified the regex such that numbers and underscores are now valid characters within the `vars` query param string such that `t2_mean,t2_max` and the like will return `True`, and we've bumped the allowable length from 100 to 200 to pad for longer `vars`string.

I've added a docstring for this function as well, just to help with my own readability of regex-ese.

Edit, here is the query to try on `main` and on this branch:

http://127.0.0.1:5000/era5wrf/point/63.3366/-142.985?vars=t2_max,t2_mean,t2_min,rh2_max,rh2_mean,rh2_min,rainnc_sum,wspd10_mean,wdir10_mean
