### PR TITLE
Adds cftime to required packages installed in production.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - jaro-winkler
   - pytest
   - pytest-html
+  - cftime


### PR DESCRIPTION
This adds cftime, a requirement of the CMIP6 fire weather indices API endpoint to the list of installed packages in production.