### PR TITLE
add int and None to conditions for dealing with single var return

### DIFF
--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -142,9 +142,11 @@ def package_cmip6_monthly_data(
                 di[model][scenario][time] = dict()
 
                 # split the space-separated string of values into a list
-                # first check if its a float (occurs if only 1 variable is requested)
-                if isinstance(time_str, float):
+                # first check if its a float, int, or None (occurs if only 1 variable is requested)
+                if isinstance(time_str, float) or isinstance(time_str, int):
                     value_list = [str(time_str)]
+                elif time_str is None:
+                    value_list = [None for _ in vars]
                 else:
                     value_list = time_str.split(" ")
                 for vi, varname in enumerate(vars):
@@ -172,7 +174,7 @@ def package_cmip6_monthly_data(
     # The code below replaces NaNs with -9999 for entire years that have no data.
     # Consider the -9999 value as a flag to indicate that the prune_nulls_with_max_intensity()
     # function should drop the entire scenario / year combo from the response.
-    
+
     # If the scenario is historical and the year is greater than 2014,
     # all NaN values are replaced with -9999 and will be pruned from the response.
     # If the scenario is not historical, and the year is less than 2015,


### PR DESCRIPTION
If you are running `main`, you will find that using a single variable in the request like so gives a 500:

http://127.0.0.1:5000/cmip6/point/61.5/-146/2030/2050?vars=tas

but a list of multiple variables works fine:

http://127.0.0.1:5000/cmip6/point/61.5/-146/2030/2050?vars=tas,pr

This PR fixes this bug, which occurs in the packaging function when there is a single variable and the value is `int` or `None`. Previously we only checked for `floats`. Parsing the list of space-separated values from a multi-variable request passed thru this logic OK, but it turns out that we need the more explicit parsing of single values returned by Rasdaman. 