### PR TITLE
Changes CMIP6 monthly coverage to the new WCS-optimized coverage.

### DIFF
--- a/routes/cmip6.py
+++ b/routes/cmip6.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 cmip6_api = Blueprint("cmip6_api", __name__)
 
-cmip6_monthly_coverage_id = "cmip6_monthly_cf_wms"
+cmip6_monthly_coverage_id = "cmip6_monthly_cf_wcs"
 
 
 async def get_cmip6_metadata():


### PR DESCRIPTION
This PR changes the /cmip6/point/ endpoint to use the new coverage cmip6_monthly_cf_wcs that have been uploaded to Zeus. This coverage has been modified to use improved tiling to allow for much faster response times for the endpoint. One thing to note about this is that with the current coverage, a full return without subsetting by year results in a timeout that gives a 500 error after waiting for 5 minutes for the API to return data. Check out my initial testing results below:

http://localhost:5000/cmip6/point/61.5/-147/2030/2050
**Old Coverage**: 36.79 seconds
**New Coverage**: 3.81 seconds

http://localhost:5000/cmip6/point/61.5/-147
**Old Coverage**: 5 minutes - 500 HTTP return code
**New Coverage**: 8.89 seconds 

For testing, you can swap the coverage names in the code below back to the original coverage and back to the new coverage to get the timing for both in the /cmip6/point/ endpoint.

