### PR TITLE
Fixes time index function for newer version of Pandas for time frequency.

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -233,7 +233,7 @@ def generate_gipl1km_time_index():
     date_index = pd.date_range(
         start=pd.Timestamp(year_start.split("T")[0]),
         end=pd.Timestamp(year_stop.split("T")[0]),
-        freq="AS",
+        freq="YS",
     )
     return date_index
 


### PR DESCRIPTION
This PR fixes the error we are seeing with newer versions of Pandas that are not reverse compatible with the frequency string of "AS".

At some point, Pandas started to use "YS" for "Year Start" rather than "AS" for "Annual Start" for the frequency field of the Pandas date_range function and this was preventing the API Permafrost endpoints from working. 

For testing, you should be able to switch between main and this branch on a new version of Pandas in your local environment and see that the /ncr/permafrost/point/ and /permafrost/point/ endpoints both fail in main, but work in this newest branch. I've confirmed that "YS" is available in older versions of Pandas as well, so this works even if you don't update to a newer version of Pandas on your local environment.