### PR TITLE
Add streamlined, hydroviz webapp specific endpoint to conus_hydrology

### DIFF
--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -1005,7 +1005,8 @@ def run_get_conus_hydrology_gauge_info():
 @routes.route("/conus_hydrology/hydroviz/<stream_id>/<model>")
 def fetch_all_hydroviz_route(stream_id, model):
     """
-    Function to fetch all data for the hydrology visualization for a given stream ID and model. Maurer historical baseline data is included in every return.
+    Function to fetch all data for the hydrology visualization for a given stream ID and model.
+    Maurer historical baseline data is included in every return.
     Args:
         stream_id (str): Stream ID for the hydrology data
         model (str): Model for projected data, only affects stats for tables.
@@ -1042,9 +1043,17 @@ def fetch_all_hydroviz_route(stream_id, model):
     if model not in projected_models:
         return render_template("400/bad_request.html"), 400
 
+    stats_response = run_get_conus_hydrology_stats_data(stream_id)
+    modeled_response = run_get_conus_hydrology_modeled_climatology(stream_id)
+
+    # If either response is an error page, return it.
+    for response in [stats_response, modeled_response]:
+        if isinstance(response, tuple):
+            return response
+
     try:
-        stats = run_get_conus_hydrology_stats_data(stream_id).get_json()
-        modeled = run_get_conus_hydrology_modeled_climatology(stream_id).get_json()
+        stats = stats_response.get_json()
+        modeled = modeled_response.get_json()
 
         # The hydrograph and monthly mean flow charts use this scenario and era.
         scenario = "rcp85"


### PR DESCRIPTION
Xref: https://github.com/ua-snap/hydroviz/issues/86
Xref: https://github.com/ua-snap/hydroviz/issues/98
Xref: https://github.com/ua-snap/hydroviz/pull/110

This PR adds a custom hydroviz-webapp-specific endpoint to the CONUS hydrology family of endpoints. This is intentionally undocumented since it is specific to the hydroviz webapp, similar to the Arctic-EDS endpoint we use for the Arctic-EDS webapp. This PR replaces the misfire that was PR #702, which allowed us to filter by model but ultimately provided no benefit when I remembered that the hydrograph and monthly flow charts are populated using data across all models.

This PR also moves most of the data manipulation code out of the webapp and into the Data API, so things like finding the min/mean/max for each DOY across all models, or grouping data by month, don't need to be performed in the user's web browser. And all of the raw data needed to perform those calculations are also not sent to the web browser, reducing the Data API response size from 10mb down to about ~20kb, per selected stream segment.

Note that the model parameter is provided as a component of the URL path like this:

```
/conus_hydrology/hydroviz/<stream_id>/<model>
```

I did it this way and not via a `?models=` parameter because the model parameter is not quite being used like a filter here, and the `hydrograph`, `monthly_flow`, `summary` properties of the response object provide data across all models regardless of what model is provided. The `model` variable only affects the `stats` property.

To test, try the endpoint URL using a variety of streams and models and make sure the output is sane. That's about it!