### PR TITLE
Fixes permafrost endpoints in API

### DIFF
--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -68,6 +68,21 @@ titles = {
     "obupfx": "Obu et al. (2018) Permafrost Extent",
 }
 
+# Map variable names from Rasdaman variable name to
+# expected variable names in CSV output and data returns.
+variable_name_map = {
+    "magt05m_degC": "magt0.5m",
+    "magt1m_degC": "magt1m",
+    "magt2m_degC": "magt2m",
+    "magt3m_degC": "magt3m",
+    "magt4m_degC": "magt4m",
+    "magt5m_degC": "magt5m",
+    "magtsurface_degC": "magtsurface",
+    "permafrostbase_m": "permafrostbase",
+    "permafrosttop_m": "permafrosttop",
+    "talikthickness_m": "talikthickness",
+}
+
 
 # packaging functions unique to each query
 def package_obu_magt(obu_magt_resp):
@@ -86,7 +101,7 @@ def package_obu_magt(obu_magt_resp):
 
     nullified_data = nullify_nodata(temp, "permafrost")
     if nullified_data is not None:
-        di = {"year": year, "depth": depth, "temp": temp}
+        di = {"time": year, "depth": depth, "temp": temp}
         return di
 
     return None
@@ -128,7 +143,7 @@ def make_ncr_gipl1km_wcps_request_str(x, y, years, model, scenario, summary_oper
         (
             f"ProcessCoverages&query=for $c in ({gipl_1km_coverage_id}) "
             f"  return encode ("
-            f"    {summary_operation}($c[model({model}),scenario({scenario}),year({years}),X({x}),Y({y})])"
+            f"    {summary_operation}($c[model({model}),scenario({scenario}),time({years}),X({x}),Y({y})])"
             f', "application/json")'
         )
     )
@@ -162,13 +177,14 @@ def package_ncr_gipl1km_wcps_data(gipl1km_wcps_resp):
                 gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"] = dict()
                 # Step through the variable names and their corresponding values
                 for k, v in zip(variable_names, resp.split()):
+                    csv_name = variable_name_map.get(k, k)
                     if v == "null" or v is None:
                         gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
-                            k
+                            csv_name
                         ] = None
                     else:
                         gipl1km_wcps_point_pkg[model][scenario][f"gipl1km{stat_type}"][
-                            k
+                            csv_name
                         ] = round(float(v), 1)
     return gipl1km_wcps_point_pkg
 
@@ -188,7 +204,7 @@ def make_gipl1km_wcps_request_str(x, y, years, summary_operation):
         (
             f"ProcessCoverages&query=for $c in ({gipl_1km_coverage_id}) "
             f"  return encode ("
-            f"    {summary_operation}($c[year({years}),X({x}),Y({y})] )"
+            f"    {summary_operation}($c[time({years}),X({x}),Y({y})] )"
             f', "application/json")'
         )
     )
@@ -213,10 +229,13 @@ def package_gipl1km_wcps_data(gipl1km_wcps_resp):
             gipl1km_dim_encodings["variable"].values(),
             summary_op_resp.split(),
         ):
+            csv_name = variable_name_map.get(k, k)
             if v == "null" or v is None:
-                gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][k] = None
+                gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][csv_name] = None
             else:
-                gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][k] = round(float(v), 1)
+                gipl1km_wcps_point_pkg[f"gipl1km{stat_type}"][csv_name] = round(
+                    float(v), 1
+                )
 
     return gipl1km_wcps_point_pkg
 
@@ -276,9 +295,11 @@ def package_gipl1km_point_data(gipl1km_point_resp, time_slice=None):
                         values.append(None)
                     else:
                         values.append(float(v))
-                # Add the variable values to the packaged data
+
                 gipl1km_point_pkg[model_name][year][scenario_name] = {
-                    var: (round(val, 1) if val is not None else None)
+                    variable_name_map.get(var, var): (
+                        round(val, 1) if val is not None else None
+                    )
                     for var, val in zip(variable_names, values)
                 }
 
@@ -469,7 +490,7 @@ async def fetch_gipl_1km_point_data(x, y, start_year, end_year, summarize, ncr):
         timestring = (
             f'"{start_year}-01-01T00:00:00.000Z":"{end_year}-01-01T00:00:00.000Z"'
         )
-        time_subset = ("year", timestring)
+        time_subset = ("time", timestring)
         gipl_request_str = generate_wcs_getcov_str(
             x, y, gipl_1km_coverage_id, time_slice=time_subset
         )
@@ -680,9 +701,7 @@ def permafrost_eds_request(lat, lon):
 
     # If there are no error responses, include the summary and preview data in the response
     permafrostData["summary"] = summary
-    # permafrostData["permafrost"]["preview"] = [r.data.decode("utf-8") for r in preview]
-
-    preview_string = [r.data.decode("utf-8") for r in preview]
+    preview_string = [r.get_data(as_text=True) for r in preview]
 
     preview_past = preview_string[0].split("\n")[4:10]
     preview_future = preview_string[1].split("\n")[-6:]

--- a/routes/permafrost.py
+++ b/routes/permafrost.py
@@ -101,7 +101,7 @@ def package_obu_magt(obu_magt_resp):
 
     nullified_data = nullify_nodata(temp, "permafrost")
     if nullified_data is not None:
-        di = {"time": year, "depth": depth, "temp": temp}
+        di = {"year": year, "depth": depth, "temp": temp}
         return di
 
     return None

--- a/tests/eds_point.json
+++ b/tests/eds_point.json
@@ -1,0 +1,20908 @@
+{
+    "elevation": {
+        "max": 577,
+        "mean": 510,
+        "min": 443,
+        "res": "1 kilometer",
+        "title": "ASTER Global Digital Elevation Model",
+        "units": "meters difference from sea level"
+    },
+    "freezing_index": {
+        "preview": "model,scenario,year,dd\r\ndaymet,modeled_baseline,1980,4178\r\ndaymet,modeled_baseline,1981,3262\r\ndaymet,modeled_baseline,1982,4622\r\ndaymet,modeled_baseline,1983,3897\r\ndaymet,modeled_baseline,1984,4400\r\ninmcm4,rcp85,2095,1869\r\ninmcm4,rcp85,2096,2113\r\ninmcm4,rcp85,2097,1810\r\ninmcm4,rcp85,2098,2330\r\ninmcm4,rcp85,2099,2895\r\n",
+        "summary": {
+            "2010-2039": {
+                "ddmax": 6610,
+                "ddmean": 3769,
+                "ddmin": 1320
+            },
+            "2040-2069": {
+                "ddmax": 5869,
+                "ddmean": 3130,
+                "ddmin": 985
+            },
+            "2070-2099": {
+                "ddmax": 5248,
+                "ddmean": 2629,
+                "ddmin": 389
+            },
+            "modeled_baseline": {
+                "ddmax": 5740,
+                "ddmean": 4404,
+                "ddmin": 3001
+            }
+        }
+    },
+    "heating_degree_days": {
+        "preview": "model,scenario,year,dd\r\ndaymet,modeled_baseline,1980,14155\r\ndaymet,modeled_baseline,1981,13058\r\ndaymet,modeled_baseline,1982,14502\r\ndaymet,modeled_baseline,1983,13766\r\ndaymet,modeled_baseline,1984,14088\r\ninmcm4,rcp85,2095,9709\r\ninmcm4,rcp85,2096,10413\r\ninmcm4,rcp85,2097,9299\r\ninmcm4,rcp85,2098,11119\r\ninmcm4,rcp85,2099,11275\r\n",
+        "summary": {
+            "2010-2039": {
+                "ddmax": 16759,
+                "ddmean": 13052,
+                "ddmin": 9008
+            },
+            "2040-2069": {
+                "ddmax": 15597,
+                "ddmean": 11989,
+                "ddmin": 7833
+            },
+            "2070-2099": {
+                "ddmax": 14702,
+                "ddmean": 11055,
+                "ddmin": 6573
+            },
+            "modeled_baseline": {
+                "ddmax": 15427,
+                "ddmean": 14076,
+                "ddmin": 12433
+            }
+        }
+    },
+    "hydrology": {
+        "preview": "model,scenario,month,era,evap,glacier_melt,iwe,pcp,runoff,sm1,sm2,sm3,snow_melt,swe,tmax,tmin\r\nACCESS1-3,rcp45,apr,1950-1959,8,0,0,37,22,8,342,0,64,282,2.9,-8.7\r\nACCESS1-3,rcp45,apr,1960-1969,7,0,0,16,48,9,346,0,117,396,4.1,-7.3\r\nACCESS1-3,rcp45,apr,1970-1979,7,0,0,29,34,9,335,0,100,284,6.2,-7.2\r\nACCESS1-3,rcp45,apr,1980-1989,8,0,0,24,67,9,351,0,148,328,4.1,-6.4\r\nACCESS1-3,rcp45,apr,1990-1999,8,0,0,13,35,9,325,0,70,284,-0.8,-10.4\r\ninmcm4,rcp85,sep,2050-2059,12,0,0,50,11,8,317,24,7,1,10.6,2.7\r\ninmcm4,rcp85,sep,2060-2069,13,0,0,64,15,8,312,17,8,3,11.5,3.9\r\ninmcm4,rcp85,sep,2070-2079,14,0,0,137,39,8,340,45,13,2,11.8,3.9\r\ninmcm4,rcp85,sep,2080-2089,13,0,0,93,23,8,322,21,6,2,11.5,4.6\r\ninmcm4,rcp85,sep,2090-2099,14,0,0,85,22,8,335,32,6,2,12.8,4.3\r\n",
+        "summary": {
+            "ACCESS1-3": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 85.33,
+                                "mean": 19.69,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 83,
+                                "mean": 19.14,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 89,
+                                "mean": 21.5,
+                                "min": -2.33
+                            },
+                            "mid_century": {
+                                "max": 89.67,
+                                "mean": 21.42,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 114.33,
+                                "mean": 27.3,
+                                "min": 0.33
+                            },
+                            "historical": {
+                                "max": 134.5,
+                                "mean": 23.72,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 177,
+                                "mean": 35.83,
+                                "min": 0.33
+                            },
+                            "mid_century": {
+                                "max": 111.33,
+                                "mean": 26.42,
+                                "min": 0.33
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 10
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 14
+                            },
+                            "mid_century": {
+                                "total": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 21
+                            },
+                            "historical": {
+                                "total": 20
+                            },
+                            "late_century": {
+                                "total": 28
+                            },
+                            "mid_century": {
+                                "total": 34
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 26
+                            },
+                            "mid_century": {
+                                "total": 28
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 189
+                            },
+                            "historical": {
+                                "total": 177
+                            },
+                            "late_century": {
+                                "total": 309
+                            },
+                            "mid_century": {
+                                "total": 230
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 207
+                            },
+                            "historical": {
+                                "total": 201
+                            },
+                            "late_century": {
+                                "total": 224
+                            },
+                            "mid_century": {
+                                "total": 223
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 116
+                            },
+                            "historical": {
+                                "total": 87
+                            },
+                            "late_century": {
+                                "total": 89
+                            },
+                            "mid_century": {
+                                "total": 52
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 5
+                            },
+                            "mid_century": {
+                                "total": 1
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 5.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7.33,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 5,
+                                "mean": 4,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 93,
+                                "mean": 69.33,
+                                "min": 55
+                            },
+                            "historical": {
+                                "max": 67,
+                                "mean": 42.17,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 184,
+                                "mean": 125.33,
+                                "min": 84
+                            },
+                            "mid_century": {
+                                "max": 156,
+                                "mean": 111.33,
+                                "min": 74
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 58,
+                                "mean": 53.33,
+                                "min": 48
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 50.67,
+                                "min": 47
+                            },
+                            "late_century": {
+                                "max": 62,
+                                "mean": 59.67,
+                                "min": 58
+                            },
+                            "mid_century": {
+                                "max": 58,
+                                "mean": 56.33,
+                                "min": 54
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 30,
+                                "mean": 21.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 31,
+                                "mean": 17.67,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 19.67,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 31,
+                                "mean": 20.33,
+                                "min": 15
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 3,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 90,
+                                "mean": 85.33,
+                                "min": 81
+                            },
+                            "historical": {
+                                "max": 87,
+                                "mean": 83,
+                                "min": 81
+                            },
+                            "late_century": {
+                                "max": 94,
+                                "mean": 89,
+                                "min": 84
+                            },
+                            "mid_century": {
+                                "max": 95,
+                                "mean": 89.67,
+                                "min": 87
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 33,
+                                "mean": 23,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 20,
+                                "mean": 16.83,
+                                "min": 11
+                            },
+                            "late_century": {
+                                "max": 32,
+                                "mean": 21.33,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 15,
+                                "mean": 13.67,
+                                "min": 13
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 70,
+                                "mean": 68.33,
+                                "min": 65
+                            },
+                            "historical": {
+                                "max": 73,
+                                "mean": 67.33,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 76,
+                                "mean": 75.67,
+                                "min": 75
+                            },
+                            "mid_century": {
+                                "max": 83,
+                                "mean": 77,
+                                "min": 70
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 97,
+                                "mean": 71.67,
+                                "min": 59
+                            },
+                            "historical": {
+                                "max": 115,
+                                "mean": 52.83,
+                                "min": 19
+                            },
+                            "late_century": {
+                                "max": 60,
+                                "mean": 47.67,
+                                "min": 35
+                            },
+                            "mid_century": {
+                                "max": 20,
+                                "mean": 18.33,
+                                "min": 15
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 10,
+                                "mean": 6.33,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 13,
+                                "mean": 8.67,
+                                "min": 6
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 19,
+                                "mean": 17.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 18,
+                                "mean": 16.5,
+                                "min": 15
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 21,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 22,
+                                "min": 17
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 144,
+                                "mean": 114.33,
+                                "min": 67
+                            },
+                            "historical": {
+                                "max": 170,
+                                "mean": 134.5,
+                                "min": 119
+                            },
+                            "late_century": {
+                                "max": 261,
+                                "mean": 177,
+                                "min": 104
+                            },
+                            "mid_century": {
+                                "max": 169,
+                                "mean": 109.67,
+                                "min": 80
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 3.67,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 11,
+                                "mean": 7,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 4.83,
+                                "min": 3
+                            },
+                            "late_century": {
+                                "max": 12,
+                                "mean": 9,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 9,
+                                "mean": 8.33,
+                                "min": 8
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 12.33,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.83,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 19,
+                                "mean": 15.33,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 14.33,
+                                "min": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 15,
+                                "mean": 14,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 21,
+                                "mean": 14.5,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 20,
+                                "mean": 17.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 21.67,
+                                "min": 16
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 86.67,
+                                "mean": 19.94,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 83.17,
+                                "mean": 19.11,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 96,
+                                "mean": 23.11,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": 92.33,
+                                "mean": 22.22,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 166.33,
+                                "mean": 30.14,
+                                "min": 0.33
+                            },
+                            "historical": {
+                                "max": 133.83,
+                                "mean": 23.19,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 185.67,
+                                "mean": 44.03,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 128.67,
+                                "mean": 33.72,
+                                "min": 0.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 10
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 18
+                            },
+                            "mid_century": {
+                                "total": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 20
+                            },
+                            "late_century": {
+                                "total": 65
+                            },
+                            "mid_century": {
+                                "total": 31
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 28
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 29
+                            },
+                            "mid_century": {
+                                "total": 30
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 266
+                            },
+                            "historical": {
+                                "total": 175
+                            },
+                            "late_century": {
+                                "total": 367
+                            },
+                            "mid_century": {
+                                "total": 265
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 207
+                            },
+                            "historical": {
+                                "total": 201
+                            },
+                            "late_century": {
+                                "total": 239
+                            },
+                            "mid_century": {
+                                "total": 230
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 71
+                            },
+                            "historical": {
+                                "total": 83
+                            },
+                            "late_century": {
+                                "total": 66
+                            },
+                            "mid_century": {
+                                "total": 105
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -8
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 30
+                            },
+                            "mid_century": {
+                                "total": 3
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7.33,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2.67,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 5.33,
+                                "min": 4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 114,
+                                "mean": 93.67,
+                                "min": 66
+                            },
+                            "historical": {
+                                "max": 67,
+                                "mean": 40.67,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 217,
+                                "mean": 185.67,
+                                "min": 137
+                            },
+                            "mid_century": {
+                                "max": 192,
+                                "mean": 128.67,
+                                "min": 80
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 54,
+                                "mean": 50.67,
+                                "min": 47
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 49.83,
+                                "min": 44
+                            },
+                            "late_century": {
+                                "max": 67,
+                                "mean": 62.33,
+                                "min": 60
+                            },
+                            "mid_century": {
+                                "max": 63,
+                                "mean": 60.33,
+                                "min": 57
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 17,
+                                "mean": 15.67,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 31,
+                                "mean": 18.5,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 25,
+                                "mean": 21.67,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 19,
+                                "min": 13
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 5,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 19,
+                                "mean": 12,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1.67,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 12.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 91,
+                                "mean": 86.67,
+                                "min": 80
+                            },
+                            "historical": {
+                                "max": 87,
+                                "mean": 83.17,
+                                "min": 81
+                            },
+                            "late_century": {
+                                "max": 98,
+                                "mean": 96,
+                                "min": 94
+                            },
+                            "mid_century": {
+                                "max": 94,
+                                "mean": 92.33,
+                                "min": 91
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 44,
+                                "mean": 25.67,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 20,
+                                "mean": 16.67,
+                                "min": 11
+                            },
+                            "late_century": {
+                                "max": 25,
+                                "mean": 21.33,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 46,
+                                "mean": 27.67,
+                                "min": 16
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 73,
+                                "mean": 69.33,
+                                "min": 65
+                            },
+                            "historical": {
+                                "max": 73,
+                                "mean": 68.17,
+                                "min": 64
+                            },
+                            "late_century": {
+                                "max": 84,
+                                "mean": 80.67,
+                                "min": 77
+                            },
+                            "mid_century": {
+                                "max": 83,
+                                "mean": 77,
+                                "min": 70
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 44,
+                                "mean": 29.67,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 85,
+                                "mean": 47.83,
+                                "min": 19
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 23,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 130,
+                                "mean": 58.67,
+                                "min": 21
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 5.67,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 94,
+                                "mean": 68.33,
+                                "min": 40
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 12,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 19.67,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 18,
+                                "mean": 16.17,
+                                "min": 15
+                            },
+                            "late_century": {
+                                "max": 29,
+                                "mean": 27.33,
+                                "min": 25
+                            },
+                            "mid_century": {
+                                "max": 25,
+                                "mean": 24,
+                                "min": 22
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 182,
+                                "mean": 166.33,
+                                "min": 156
+                            },
+                            "historical": {
+                                "max": 170,
+                                "mean": 133.83,
+                                "min": 119
+                            },
+                            "late_century": {
+                                "max": 143,
+                                "mean": 113.33,
+                                "min": 79
+                            },
+                            "mid_century": {
+                                "max": 133,
+                                "mean": 124.67,
+                                "min": 116
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 11,
+                                "mean": 6.67,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 2,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 2.67,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 21,
+                                "mean": 10.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 4.33,
+                                "min": 3
+                            },
+                            "late_century": {
+                                "max": 44,
+                                "mean": 34,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 19,
+                                "mean": 15.33,
+                                "min": 10
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 12.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.83,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 18,
+                                "mean": 17,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 15,
+                                "min": 14
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 15,
+                                "mean": 13,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 21,
+                                "mean": 15.33,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 27,
+                                "mean": 24.67,
+                                "min": 23
+                            },
+                            "mid_century": {
+                                "max": 17,
+                                "mean": 13.67,
+                                "min": 9
+                            }
+                        }
+                    }
+                }
+            },
+            "CCSM4": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 87.33,
+                                "mean": 19.97,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 81,
+                                "mean": 18.42,
+                                "min": -1.5
+                            },
+                            "late_century": {
+                                "max": 88.33,
+                                "mean": 21.5,
+                                "min": -2.33
+                            },
+                            "mid_century": {
+                                "max": 88.67,
+                                "mean": 20.97,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 170,
+                                "mean": 28.89,
+                                "min": 0.33
+                            },
+                            "historical": {
+                                "max": 128.33,
+                                "mean": 22.92,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 145.67,
+                                "mean": 27.19,
+                                "min": 0.33
+                            },
+                            "mid_century": {
+                                "max": 149.67,
+                                "mean": 26.44,
+                                "min": 0.33
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 10
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 11
+                            },
+                            "mid_century": {
+                                "total": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 21
+                            },
+                            "late_century": {
+                                "total": 35
+                            },
+                            "mid_century": {
+                                "total": 32
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 22
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 26
+                            },
+                            "mid_century": {
+                                "total": 25
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 215
+                            },
+                            "historical": {
+                                "total": 158
+                            },
+                            "late_century": {
+                                "total": 225
+                            },
+                            "mid_century": {
+                                "total": 190
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 213
+                            },
+                            "historical": {
+                                "total": 194
+                            },
+                            "late_century": {
+                                "total": 227
+                            },
+                            "mid_century": {
+                                "total": 222
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 102
+                            },
+                            "historical": {
+                                "total": 96
+                            },
+                            "late_century": {
+                                "total": 62
+                            },
+                            "mid_century": {
+                                "total": 93
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -6
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 5
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 4
+                            },
+                            "mid_century": {
+                                "total": 2
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 6.33,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7.67,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 5.67,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 64,
+                                "mean": 44.33,
+                                "min": 22
+                            },
+                            "historical": {
+                                "max": 37,
+                                "mean": 29.5,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 100,
+                                "mean": 78.33,
+                                "min": 62
+                            },
+                            "mid_century": {
+                                "max": 39,
+                                "mean": 38.67,
+                                "min": 38
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 55,
+                                "mean": 54.33,
+                                "min": 53
+                            },
+                            "historical": {
+                                "max": 53,
+                                "mean": 48.83,
+                                "min": 42
+                            },
+                            "late_century": {
+                                "max": 58,
+                                "mean": 54.33,
+                                "min": 51
+                            },
+                            "mid_century": {
+                                "max": 58,
+                                "mean": 53.33,
+                                "min": 48
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 18.67,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 28,
+                                "mean": 18.5,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 16.67,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 22.67,
+                                "min": 20
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 2,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 3.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 93,
+                                "mean": 87.33,
+                                "min": 84
+                            },
+                            "historical": {
+                                "max": 95,
+                                "mean": 81,
+                                "min": 75
+                            },
+                            "late_century": {
+                                "max": 90,
+                                "mean": 88.33,
+                                "min": 86
+                            },
+                            "mid_century": {
+                                "max": 92,
+                                "mean": 88.67,
+                                "min": 83
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 17,
+                                "mean": 13.67,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 41,
+                                "mean": 27.83,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 43,
+                                "mean": 26.67,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 31,
+                                "mean": 24.33,
+                                "min": 15
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 74,
+                                "mean": 71.67,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 74,
+                                "mean": 64,
+                                "min": 59
+                            },
+                            "late_century": {
+                                "max": 89,
+                                "mean": 84.33,
+                                "min": 81
+                            },
+                            "mid_century": {
+                                "max": 84,
+                                "mean": 79.67,
+                                "min": 75
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 96,
+                                "mean": 70,
+                                "min": 40
+                            },
+                            "historical": {
+                                "max": 85,
+                                "mean": 49.33,
+                                "min": 27
+                            },
+                            "late_century": {
+                                "max": 29,
+                                "mean": 19,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 94,
+                                "mean": 46,
+                                "min": 17
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 2,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 16,
+                                "mean": 15.33,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 16,
+                                "mean": 14.5,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 19.67,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 20,
+                                "mean": 18,
+                                "min": 15
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 197,
+                                "mean": 170,
+                                "min": 121
+                            },
+                            "historical": {
+                                "max": 201,
+                                "mean": 128.33,
+                                "min": 82
+                            },
+                            "late_century": {
+                                "max": 266,
+                                "mean": 145.67,
+                                "min": 75
+                            },
+                            "mid_century": {
+                                "max": 205,
+                                "mean": 149.67,
+                                "min": 96
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.83,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 7,
+                                "mean": 4.17,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 13,
+                                "mean": 8.67,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 12.67,
+                                "min": 7
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 12.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 10,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 15,
+                                "mean": 13.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 13.33,
+                                "min": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 18.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 24,
+                                "mean": 15.67,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 34,
+                                "mean": 26,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 18.67,
+                                "min": 16
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 86.67,
+                                "mean": 20.75,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 80.5,
+                                "mean": 18.4,
+                                "min": -1.5
+                            },
+                            "late_century": {
+                                "max": 96.33,
+                                "mean": 24.08,
+                                "min": -3.33
+                            },
+                            "mid_century": {
+                                "max": 94.67,
+                                "mean": 22.03,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 131.67,
+                                "mean": 23.92,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 116.83,
+                                "mean": 22.1,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 128.33,
+                                "mean": 29.16,
+                                "min": 2.33
+                            },
+                            "mid_century": {
+                                "max": 111,
+                                "mean": 28.2,
+                                "min": 0.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 9
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 15
+                            },
+                            "mid_century": {
+                                "total": 10
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 28
+                            },
+                            "historical": {
+                                "total": 22
+                            },
+                            "late_century": {
+                                "total": 44
+                            },
+                            "mid_century": {
+                                "total": 42
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 26
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 35
+                            },
+                            "mid_century": {
+                                "total": 30
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 186
+                            },
+                            "historical": {
+                                "total": 156
+                            },
+                            "late_century": {
+                                "total": 222
+                            },
+                            "mid_century": {
+                                "total": 219
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 218
+                            },
+                            "historical": {
+                                "total": 193
+                            },
+                            "late_century": {
+                                "total": 247
+                            },
+                            "mid_century": {
+                                "total": 232
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 72
+                            },
+                            "historical": {
+                                "total": 87
+                            },
+                            "late_century": {
+                                "total": 70
+                            },
+                            "mid_century": {
+                                "total": 73
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -4
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -8
+                            },
+                            "mid_century": {
+                                "total": -7
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 14
+                            },
+                            "mid_century": {
+                                "total": 4
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 6.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7.67,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 5,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 6,
+                                "min": 6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 60,
+                                "mean": 53.67,
+                                "min": 45
+                            },
+                            "historical": {
+                                "max": 86,
+                                "mean": 38.83,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 173,
+                                "mean": 128.33,
+                                "min": 97
+                            },
+                            "mid_century": {
+                                "max": 125,
+                                "mean": 105,
+                                "min": 71
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 59,
+                                "mean": 54.67,
+                                "min": 51
+                            },
+                            "historical": {
+                                "max": 52,
+                                "mean": 47.67,
+                                "min": 42
+                            },
+                            "late_century": {
+                                "max": 59,
+                                "mean": 58,
+                                "min": 57
+                            },
+                            "mid_century": {
+                                "max": 56,
+                                "mean": 54.33,
+                                "min": 53
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 25,
+                                "mean": 22.67,
+                                "min": 19
+                            },
+                            "historical": {
+                                "max": 24,
+                                "mean": 17.83,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 29,
+                                "mean": 24.33,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 35,
+                                "mean": 30,
+                                "min": 26
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.33,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 12,
+                                "mean": 6.67,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 1.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 5,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 92,
+                                "mean": 86.67,
+                                "min": 82
+                            },
+                            "historical": {
+                                "max": 92,
+                                "mean": 80.5,
+                                "min": 75
+                            },
+                            "late_century": {
+                                "max": 101,
+                                "mean": 96.33,
+                                "min": 92
+                            },
+                            "mid_century": {
+                                "max": 96,
+                                "mean": 94.67,
+                                "min": 94
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 23,
+                                "mean": 18.67,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 40,
+                                "mean": 23.33,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 42,
+                                "mean": 24.33,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 25,
+                                "mean": 19,
+                                "min": 12
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 79,
+                                "mean": 76.33,
+                                "min": 73
+                            },
+                            "historical": {
+                                "max": 79,
+                                "mean": 64.83,
+                                "min": 59
+                            },
+                            "late_century": {
+                                "max": 97,
+                                "mean": 93,
+                                "min": 90
+                            },
+                            "mid_century": {
+                                "max": 88,
+                                "mean": 82.67,
+                                "min": 78
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 40,
+                                "mean": 31,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 85,
+                                "mean": 45.5,
+                                "min": 18
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 21,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 31,
+                                "mean": 24.33,
+                                "min": 20
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 11,
+                                "mean": 10.33,
+                                "min": 10
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 3,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 21,
+                                "mean": 18.67,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 19,
+                                "mean": 15,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 31,
+                                "mean": 28.67,
+                                "min": 27
+                            },
+                            "mid_century": {
+                                "max": 24,
+                                "mean": 23,
+                                "min": 22
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 149,
+                                "mean": 131.67,
+                                "min": 122
+                            },
+                            "historical": {
+                                "max": 159,
+                                "mean": 116.83,
+                                "min": 82
+                            },
+                            "late_century": {
+                                "max": 123,
+                                "mean": 83.33,
+                                "min": 49
+                            },
+                            "mid_century": {
+                                "max": 125,
+                                "mean": 111,
+                                "min": 90
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 6,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 2.67,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.83,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 7.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 7,
+                                "mean": 4,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 16.33,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 14.67,
+                                "min": 10
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 12,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 10,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 16.33,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 18,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 31,
+                                "mean": 16.83,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 22,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 31,
+                                "mean": 25,
+                                "min": 21
+                            }
+                        }
+                    }
+                }
+            },
+            "CSIRO-Mk3-6-0": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 87.33,
+                                "mean": 19.83,
+                                "min": -1.67
+                            },
+                            "historical": {
+                                "max": 83.17,
+                                "mean": 18.92,
+                                "min": -1.5
+                            },
+                            "late_century": {
+                                "max": 89.33,
+                                "mean": 21.03,
+                                "min": -2.33
+                            },
+                            "mid_century": {
+                                "max": 92.67,
+                                "mean": 21,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 108.33,
+                                "mean": 21.8,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 96.33,
+                                "mean": 20.68,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 128.33,
+                                "mean": 24.83,
+                                "min": 0.33
+                            },
+                            "mid_century": {
+                                "max": 110.67,
+                                "mean": 22.94,
+                                "min": 0.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 8
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 14
+                            },
+                            "mid_century": {
+                                "total": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 16
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 37
+                            },
+                            "mid_century": {
+                                "total": 27
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 26
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 25
+                            },
+                            "mid_century": {
+                                "total": 26
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 150
+                            },
+                            "historical": {
+                                "total": 133
+                            },
+                            "late_century": {
+                                "total": 186
+                            },
+                            "mid_century": {
+                                "total": 189
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 208
+                            },
+                            "historical": {
+                                "total": 199
+                            },
+                            "late_century": {
+                                "total": 220
+                            },
+                            "mid_century": {
+                                "total": 222
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 94
+                            },
+                            "historical": {
+                                "total": 91
+                            },
+                            "late_century": {
+                                "total": 72
+                            },
+                            "mid_century": {
+                                "total": 56
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -4
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 4
+                            },
+                            "mid_century": {
+                                "total": 3
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 6.33,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 7.83,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 5.33,
+                                "min": 5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 57,
+                                "mean": 39.67,
+                                "min": 25
+                            },
+                            "historical": {
+                                "max": 75,
+                                "mean": 35.67,
+                                "min": 15
+                            },
+                            "late_century": {
+                                "max": 73,
+                                "mean": 53.67,
+                                "min": 31
+                            },
+                            "mid_century": {
+                                "max": 92,
+                                "mean": 76,
+                                "min": 61
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 54,
+                                "mean": 50,
+                                "min": 47
+                            },
+                            "historical": {
+                                "max": 50,
+                                "mean": 48.5,
+                                "min": 46
+                            },
+                            "late_century": {
+                                "max": 62,
+                                "mean": 54.33,
+                                "min": 49
+                            },
+                            "mid_century": {
+                                "max": 57,
+                                "mean": 53.33,
+                                "min": 48
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 16.33,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 22,
+                                "mean": 17.17,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 27,
+                                "mean": 17.33,
+                                "min": 11
+                            },
+                            "mid_century": {
+                                "max": 24,
+                                "mean": 20.33,
+                                "min": 17
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 1.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 2.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 93,
+                                "mean": 87.33,
+                                "min": 83
+                            },
+                            "historical": {
+                                "max": 87,
+                                "mean": 83.17,
+                                "min": 80
+                            },
+                            "late_century": {
+                                "max": 92,
+                                "mean": 89.33,
+                                "min": 88
+                            },
+                            "mid_century": {
+                                "max": 95,
+                                "mean": 92.67,
+                                "min": 91
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 38,
+                                "mean": 30.67,
+                                "min": 19
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 24.67,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 50,
+                                "mean": 34,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 19.67,
+                                "min": 11
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 74,
+                                "mean": 70.67,
+                                "min": 66
+                            },
+                            "historical": {
+                                "max": 71,
+                                "mean": 67.33,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 78,
+                                "mean": 76,
+                                "min": 72
+                            },
+                            "mid_century": {
+                                "max": 77,
+                                "mean": 75.67,
+                                "min": 73
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 86,
+                                "mean": 47.33,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 75,
+                                "mean": 48.67,
+                                "min": 18
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 20.67,
+                                "min": 11
+                            },
+                            "mid_century": {
+                                "max": 24,
+                                "mean": 16.33,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 1.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 3.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 2,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 18.67,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 16,
+                                "mean": 15,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 20,
+                                "mean": 18.67,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 21,
+                                "mean": 19.67,
+                                "min": 18
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 118,
+                                "mean": 108.33,
+                                "min": 99
+                            },
+                            "historical": {
+                                "max": 134,
+                                "mean": 96.33,
+                                "min": 58
+                            },
+                            "late_century": {
+                                "max": 162,
+                                "mean": 128.33,
+                                "min": 98
+                            },
+                            "mid_century": {
+                                "max": 155,
+                                "mean": 110.67,
+                                "min": 61
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 10,
+                                "mean": 3.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 4,
+                                "min": 3
+                            },
+                            "historical": {
+                                "max": 13,
+                                "mean": 5.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 5.67,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 4
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 11,
+                                "mean": 10.33,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.17,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 16,
+                                "mean": 14.67,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 12.33,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 28,
+                                "mean": 18.5,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 34,
+                                "mean": 30.33,
+                                "min": 26
+                            },
+                            "mid_century": {
+                                "max": 24,
+                                "mean": 18.33,
+                                "min": 11
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 81.67,
+                                "mean": 19.69,
+                                "min": -1.67
+                            },
+                            "historical": {
+                                "max": 83.83,
+                                "mean": 19.06,
+                                "min": -1.33
+                            },
+                            "late_century": {
+                                "max": 93.67,
+                                "mean": 22.06,
+                                "min": -3.33
+                            },
+                            "mid_century": {
+                                "max": 90,
+                                "mean": 21.11,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 94.67,
+                                "mean": 19.94,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 104.83,
+                                "mean": 21.01,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 134.33,
+                                "mean": 34.97,
+                                "min": 1.67
+                            },
+                            "mid_century": {
+                                "max": 152.67,
+                                "mean": 29.19,
+                                "min": 1.33
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 11
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 15
+                            },
+                            "mid_century": {
+                                "total": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 21
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 37
+                            },
+                            "mid_century": {
+                                "total": 33
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 26
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 26
+                            },
+                            "mid_century": {
+                                "total": 24
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 133
+                            },
+                            "historical": {
+                                "total": 138
+                            },
+                            "late_century": {
+                                "total": 282
+                            },
+                            "mid_century": {
+                                "total": 243
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 203
+                            },
+                            "historical": {
+                                "total": 201
+                            },
+                            "late_century": {
+                                "total": 233
+                            },
+                            "mid_century": {
+                                "total": 224
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 85
+                            },
+                            "historical": {
+                                "total": 88
+                            },
+                            "late_century": {
+                                "total": 81
+                            },
+                            "mid_century": {
+                                "total": 66
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -4
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -9
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 0
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 20
+                            },
+                            "mid_century": {
+                                "total": 8
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 8,
+                                "min": 8
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 7.5,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 3,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 4.67,
+                                "min": 3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 37,
+                                "mean": 34.33,
+                                "min": 30
+                            },
+                            "historical": {
+                                "max": 75,
+                                "mean": 33,
+                                "min": 15
+                            },
+                            "late_century": {
+                                "max": 164,
+                                "mean": 134.33,
+                                "min": 104
+                            },
+                            "mid_century": {
+                                "max": 129,
+                                "mean": 84.33,
+                                "min": 47
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 51,
+                                "mean": 50.33,
+                                "min": 50
+                            },
+                            "historical": {
+                                "max": 50,
+                                "mean": 49,
+                                "min": 48
+                            },
+                            "late_century": {
+                                "max": 60,
+                                "mean": 58,
+                                "min": 54
+                            },
+                            "mid_century": {
+                                "max": 60,
+                                "mean": 56.33,
+                                "min": 53
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 28,
+                                "mean": 22.33,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 22,
+                                "mean": 17.67,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 26,
+                                "mean": 22.33,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 16,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -2,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 2,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.33,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -2,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 13,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 10,
+                                "mean": 5,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 13,
+                                "mean": 4.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 86,
+                                "mean": 81.67,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 87,
+                                "mean": 83.83,
+                                "min": 80
+                            },
+                            "late_century": {
+                                "max": 95,
+                                "mean": 93.67,
+                                "min": 92
+                            },
+                            "mid_century": {
+                                "max": 92,
+                                "mean": 90,
+                                "min": 87
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 25,
+                                "mean": 23.33,
+                                "min": 22
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 24.83,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 39,
+                                "mean": 35.67,
+                                "min": 31
+                            },
+                            "mid_century": {
+                                "max": 33,
+                                "mean": 17.33,
+                                "min": 7
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 74,
+                                "mean": 71.33,
+                                "min": 69
+                            },
+                            "historical": {
+                                "max": 71,
+                                "mean": 67.83,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 84,
+                                "mean": 81,
+                                "min": 78
+                            },
+                            "mid_century": {
+                                "max": 79,
+                                "mean": 77.33,
+                                "min": 75
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 42,
+                                "mean": 39.33,
+                                "min": 35
+                            },
+                            "historical": {
+                                "max": 75,
+                                "mean": 46,
+                                "min": 18
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 23,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 61,
+                                "mean": 33,
+                                "min": 16
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 4,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 36,
+                                "mean": 22.33,
+                                "min": 8
+                            },
+                            "mid_century": {
+                                "max": 15,
+                                "mean": 6,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 17,
+                                "mean": 16.67,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 16,
+                                "mean": 15,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 23,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 21,
+                                "mean": 19.33,
+                                "min": 17
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 125,
+                                "mean": 94.67,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 134,
+                                "mean": 104.83,
+                                "min": 58
+                            },
+                            "late_century": {
+                                "max": 226,
+                                "mean": 125.67,
+                                "min": 33
+                            },
+                            "mid_century": {
+                                "max": 183,
+                                "mean": 152.67,
+                                "min": 99
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 2.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 8.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 13,
+                                "mean": 5.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 18,
+                                "mean": 11,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 9,
+                                "mean": 7.67,
+                                "min": 6
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.33,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 16,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 15,
+                                "mean": 14,
+                                "min": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 12.67,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 28,
+                                "mean": 19.33,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 26,
+                                "mean": 23.67,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 25,
+                                "mean": 23,
+                                "min": 20
+                            }
+                        }
+                    }
+                }
+            },
+            "CanESM2": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 90.67,
+                                "mean": 21.2,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 82.17,
+                                "mean": 18.92,
+                                "min": -1.67
+                            },
+                            "late_century": {
+                                "max": 95.67,
+                                "mean": 22.28,
+                                "min": -2.67
+                            },
+                            "mid_century": {
+                                "max": 95,
+                                "mean": 22.06,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 96.67,
+                                "mean": 19.53,
+                                "min": 0.67
+                            },
+                            "historical": {
+                                "max": 87.5,
+                                "mean": 19.96,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 119.33,
+                                "mean": 28.75,
+                                "min": 2.67
+                            },
+                            "mid_century": {
+                                "max": 81,
+                                "mean": 22.56,
+                                "min": 0.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 11
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 13
+                            },
+                            "mid_century": {
+                                "total": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 29
+                            },
+                            "historical": {
+                                "total": 22
+                            },
+                            "late_century": {
+                                "total": 42
+                            },
+                            "mid_century": {
+                                "total": 34
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 27
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 27
+                            },
+                            "mid_century": {
+                                "total": 27
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 149
+                            },
+                            "historical": {
+                                "total": 138
+                            },
+                            "late_century": {
+                                "total": 239
+                            },
+                            "mid_century": {
+                                "total": 164
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 223
+                            },
+                            "historical": {
+                                "total": 200
+                            },
+                            "late_century": {
+                                "total": 234
+                            },
+                            "mid_century": {
+                                "total": 232
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 51
+                            },
+                            "historical": {
+                                "total": 78
+                            },
+                            "late_century": {
+                                "total": 55
+                            },
+                            "mid_century": {
+                                "total": 67
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -6
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -7
+                            },
+                            "mid_century": {
+                                "total": -7
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 5
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 10
+                            },
+                            "mid_century": {
+                                "total": 6
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 5.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 6.83,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 4,
+                                "min": 3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 65,
+                                "mean": 49.33,
+                                "min": 24
+                            },
+                            "historical": {
+                                "max": 79,
+                                "mean": 49.33,
+                                "min": 23
+                            },
+                            "late_century": {
+                                "max": 150,
+                                "mean": 112.67,
+                                "min": 73
+                            },
+                            "mid_century": {
+                                "max": 94,
+                                "mean": 81,
+                                "min": 65
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 58,
+                                "mean": 56,
+                                "min": 55
+                            },
+                            "historical": {
+                                "max": 58,
+                                "mean": 50,
+                                "min": 45
+                            },
+                            "late_century": {
+                                "max": 62,
+                                "mean": 60.67,
+                                "min": 60
+                            },
+                            "mid_century": {
+                                "max": 59,
+                                "mean": 58.33,
+                                "min": 57
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 28,
+                                "mean": 21.33,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 30,
+                                "mean": 22.17,
+                                "min": 16
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 18.67,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 39,
+                                "mean": 28.67,
+                                "min": 21
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 2.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 2.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 4,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 3.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 2.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 92,
+                                "mean": 90.67,
+                                "min": 88
+                            },
+                            "historical": {
+                                "max": 90,
+                                "mean": 82.17,
+                                "min": 73
+                            },
+                            "late_century": {
+                                "max": 99,
+                                "mean": 95.67,
+                                "min": 93
+                            },
+                            "mid_century": {
+                                "max": 95,
+                                "mean": 95,
+                                "min": 95
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 10.33,
+                                "min": 9
+                            },
+                            "historical": {
+                                "max": 34,
+                                "mean": 20.5,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 7.67,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 14,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 78,
+                                "mean": 76.33,
+                                "min": 73
+                            },
+                            "historical": {
+                                "max": 78,
+                                "mean": 68,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 84,
+                                "mean": 78,
+                                "min": 73
+                            },
+                            "mid_century": {
+                                "max": 80,
+                                "mean": 78.33,
+                                "min": 77
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 31,
+                                "mean": 19.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 60,
+                                "mean": 35.17,
+                                "min": 21
+                            },
+                            "late_century": {
+                                "max": 38,
+                                "mean": 28.33,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 33,
+                                "mean": 24,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 3.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 1.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 6.67,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 2,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 24,
+                                "mean": 20,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 15.33,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 26,
+                                "mean": 23.33,
+                                "min": 21
+                            },
+                            "mid_century": {
+                                "max": 23,
+                                "mean": 22,
+                                "min": 20
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 130,
+                                "mean": 96.67,
+                                "min": 55
+                            },
+                            "historical": {
+                                "max": 116,
+                                "mean": 87.5,
+                                "min": 33
+                            },
+                            "late_century": {
+                                "max": 166,
+                                "mean": 119.33,
+                                "min": 44
+                            },
+                            "mid_century": {
+                                "max": 123,
+                                "mean": 81,
+                                "min": 41
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 5.33,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 3.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -1,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 10,
+                                "mean": 6.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 4.33,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 5.33,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 10.33,
+                                "min": 6
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 13.33,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.33,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 15.67,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 14.67,
+                                "min": 14
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 25,
+                                "mean": 21.67,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 25,
+                                "mean": 16.5,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 39,
+                                "mean": 31,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 27,
+                                "mean": 20.67,
+                                "min": 13
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 86.67,
+                                "mean": 20.89,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 82.33,
+                                "mean": 18.87,
+                                "min": -1.67
+                            },
+                            "late_century": {
+                                "max": 98,
+                                "mean": 24.36,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": 93.33,
+                                "mean": 22.61,
+                                "min": -3.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 105.33,
+                                "mean": 21.81,
+                                "min": 0.33
+                            },
+                            "historical": {
+                                "max": 90.17,
+                                "mean": 20.12,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 115.67,
+                                "mean": 31.36,
+                                "min": 6.67
+                            },
+                            "mid_century": {
+                                "max": 114.67,
+                                "mean": 28.33,
+                                "min": 3.33
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 12
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 16
+                            },
+                            "mid_century": {
+                                "total": 14
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 27
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 56
+                            },
+                            "mid_century": {
+                                "total": 42
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 26
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 33
+                            },
+                            "mid_century": {
+                                "total": 27
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 159
+                            },
+                            "historical": {
+                                "total": 139
+                            },
+                            "late_century": {
+                                "total": 200
+                            },
+                            "mid_century": {
+                                "total": 212
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 218
+                            },
+                            "historical": {
+                                "total": 200
+                            },
+                            "late_century": {
+                                "total": 254
+                            },
+                            "mid_century": {
+                                "total": 237
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 72
+                            },
+                            "historical": {
+                                "total": 79
+                            },
+                            "late_century": {
+                                "total": 51
+                            },
+                            "mid_century": {
+                                "total": 75
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -6
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -10
+                            },
+                            "mid_century": {
+                                "total": -7
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 4
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 69
+                            },
+                            "mid_century": {
+                                "total": 12
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 5.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 7,
+                                "mean": 6.67,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 2,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 3.33,
+                                "min": 2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 54,
+                                "mean": 49.67,
+                                "min": 45
+                            },
+                            "historical": {
+                                "max": 66,
+                                "mean": 47.17,
+                                "min": 23
+                            },
+                            "late_century": {
+                                "max": 142,
+                                "mean": 115.67,
+                                "min": 77
+                            },
+                            "mid_century": {
+                                "max": 116,
+                                "mean": 86.33,
+                                "min": 67
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 59,
+                                "mean": 54.33,
+                                "min": 49
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 49.33,
+                                "min": 45
+                            },
+                            "late_century": {
+                                "max": 66,
+                                "mean": 64.67,
+                                "min": 64
+                            },
+                            "mid_century": {
+                                "max": 66,
+                                "mean": 62.33,
+                                "min": 57
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 29,
+                                "mean": 25.33,
+                                "min": 19
+                            },
+                            "historical": {
+                                "max": 30,
+                                "mean": 21.5,
+                                "min": 16
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 18.33,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 39,
+                                "mean": 26.67,
+                                "min": 17
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -4,
+                                "mean": -4,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -3,
+                                "mean": -3.33,
+                                "min": -4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 17,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 9,
+                                "mean": 5.33,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 20,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 3.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.33,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 55,
+                                "mean": 32.33,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 3.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 89,
+                                "mean": 86.67,
+                                "min": 84
+                            },
+                            "historical": {
+                                "max": 90,
+                                "mean": 82.33,
+                                "min": 74
+                            },
+                            "late_century": {
+                                "max": 98,
+                                "mean": 98,
+                                "min": 98
+                            },
+                            "mid_century": {
+                                "max": 98,
+                                "mean": 93.33,
+                                "min": 91
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 17,
+                                "mean": 13.67,
+                                "min": 8
+                            },
+                            "historical": {
+                                "max": 34,
+                                "mean": 20.83,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 20,
+                                "mean": 16.67,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 16.67,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 82,
+                                "mean": 77.33,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 78,
+                                "mean": 68,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 92,
+                                "mean": 91,
+                                "min": 90
+                            },
+                            "mid_century": {
+                                "max": 87,
+                                "mean": 81.67,
+                                "min": 79
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 71,
+                                "mean": 33.33,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 60,
+                                "mean": 36.5,
+                                "min": 21
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 15.67,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 63,
+                                "mean": 31.33,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 3.67,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 1.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 52,
+                                "mean": 27.67,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 17,
+                                "mean": 10.67,
+                                "min": 4
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 19.33,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 15.33,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 34,
+                                "mean": 30.67,
+                                "min": 28
+                            },
+                            "mid_century": {
+                                "max": 27,
+                                "mean": 23.67,
+                                "min": 21
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 131,
+                                "mean": 105.33,
+                                "min": 89
+                            },
+                            "historical": {
+                                "max": 116,
+                                "mean": 90.17,
+                                "min": 33
+                            },
+                            "late_century": {
+                                "max": 109,
+                                "mean": 56.67,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 177,
+                                "mean": 114.67,
+                                "min": 73
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 3,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 11,
+                                "mean": 6.67,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 5.67,
+                                "min": 3
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -1,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 5,
+                                "min": 3
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 4.5,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 64,
+                                "mean": 29,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 15,
+                                "mean": 10,
+                                "min": 5
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 16,
+                                "mean": 15,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 13,
+                                "mean": 10.5,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 18,
+                                "mean": 17,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 17,
+                                "mean": 16,
+                                "min": 15
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 19,
+                                "min": 15
+                            },
+                            "historical": {
+                                "max": 25,
+                                "mean": 16.83,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 20.67,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 31,
+                                "mean": 26,
+                                "min": 21
+                            }
+                        }
+                    }
+                }
+            },
+            "GFDL-ESM2M": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 86,
+                                "mean": 19.25,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 83.5,
+                                "mean": 18.88,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 85.67,
+                                "mean": 19.89,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": 88.67,
+                                "mean": 20.28,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 173,
+                                "mean": 31,
+                                "min": 0.67
+                            },
+                            "historical": {
+                                "max": 119.5,
+                                "mean": 21.68,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 178,
+                                "mean": 30.19,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 185,
+                                "mean": 30.06,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 7
+                            },
+                            "historical": {
+                                "total": 7
+                            },
+                            "late_century": {
+                                "total": 9
+                            },
+                            "mid_century": {
+                                "total": 8
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 39
+                            },
+                            "historical": {
+                                "total": 22
+                            },
+                            "late_century": {
+                                "total": 44
+                            },
+                            "mid_century": {
+                                "total": 34
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 24
+                            },
+                            "mid_century": {
+                                "total": 24
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 222
+                            },
+                            "historical": {
+                                "total": 162
+                            },
+                            "late_century": {
+                                "total": 236
+                            },
+                            "mid_century": {
+                                "total": 239
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 206
+                            },
+                            "historical": {
+                                "total": 199
+                            },
+                            "late_century": {
+                                "total": 212
+                            },
+                            "mid_century": {
+                                "total": 215
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 107
+                            },
+                            "historical": {
+                                "total": 77
+                            },
+                            "late_century": {
+                                "total": 82
+                            },
+                            "mid_century": {
+                                "total": 86
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -6
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 5
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 0
+                            },
+                            "mid_century": {
+                                "total": 3
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 7,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 8,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 8,
+                                "min": 8
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 48,
+                                "mean": 46.33,
+                                "min": 43
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 41.5,
+                                "min": 29
+                            },
+                            "late_century": {
+                                "max": 79,
+                                "mean": 56.33,
+                                "min": 33
+                            },
+                            "mid_century": {
+                                "max": 77,
+                                "mean": 50,
+                                "min": 35
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 55,
+                                "mean": 53,
+                                "min": 50
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 48.17,
+                                "min": 43
+                            },
+                            "late_century": {
+                                "max": 57,
+                                "mean": 55.67,
+                                "min": 54
+                            },
+                            "mid_century": {
+                                "max": 55,
+                                "mean": 52.67,
+                                "min": 49
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 32,
+                                "mean": 24.67,
+                                "min": 20
+                            },
+                            "historical": {
+                                "max": 41,
+                                "mean": 20.17,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 18,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 21,
+                                "mean": 19.33,
+                                "min": 16
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 1.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 89,
+                                "mean": 86,
+                                "min": 84
+                            },
+                            "historical": {
+                                "max": 88,
+                                "mean": 83.5,
+                                "min": 80
+                            },
+                            "late_century": {
+                                "max": 89,
+                                "mean": 85.67,
+                                "min": 81
+                            },
+                            "mid_century": {
+                                "max": 90,
+                                "mean": 88.67,
+                                "min": 88
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 35,
+                                "mean": 27.67,
+                                "min": 23
+                            },
+                            "historical": {
+                                "max": 26,
+                                "mean": 17.5,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 21,
+                                "mean": 15.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 23.67,
+                                "min": 15
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 72,
+                                "mean": 67.33,
+                                "min": 64
+                            },
+                            "historical": {
+                                "max": 71,
+                                "mean": 67,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 76,
+                                "mean": 70.67,
+                                "min": 65
+                            },
+                            "mid_century": {
+                                "max": 77,
+                                "mean": 74,
+                                "min": 70
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 85,
+                                "mean": 54.33,
+                                "min": 32
+                            },
+                            "historical": {
+                                "max": 50,
+                                "mean": 39,
+                                "min": 17
+                            },
+                            "late_century": {
+                                "max": 84,
+                                "mean": 49,
+                                "min": 26
+                            },
+                            "mid_century": {
+                                "max": 80,
+                                "mean": 42.67,
+                                "min": 12
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 2.33,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 11,
+                                "mean": 3.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 16,
+                                "mean": 15.67,
+                                "min": 15
+                            },
+                            "historical": {
+                                "max": 19,
+                                "mean": 16.33,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 16,
+                                "mean": 15.67,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 16.67,
+                                "min": 16
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 201,
+                                "mean": 173,
+                                "min": 131
+                            },
+                            "historical": {
+                                "max": 192,
+                                "mean": 119.5,
+                                "min": 92
+                            },
+                            "late_century": {
+                                "max": 273,
+                                "mean": 178,
+                                "min": 101
+                            },
+                            "mid_century": {
+                                "max": 203,
+                                "mean": 185,
+                                "min": 169
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 6.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -1,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 24,
+                                "mean": 15.67,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 2.83,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 11.67,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 5.67,
+                                "min": 5
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 11,
+                                "mean": 10.33,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 9.67,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 13,
+                                "mean": 12,
+                                "min": 10
+                            },
+                            "mid_century": {
+                                "max": 13,
+                                "mean": 11.33,
+                                "min": 10
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 27,
+                                "mean": 22,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 28,
+                                "mean": 18.83,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 25.67,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 41,
+                                "mean": 26.67,
+                                "min": 7
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 82,
+                                "mean": 18.92,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 82.67,
+                                "mean": 18.74,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 90,
+                                "mean": 20.97,
+                                "min": -2.33
+                            },
+                            "mid_century": {
+                                "max": 86.67,
+                                "mean": 20.11,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 159.67,
+                                "mean": 28.5,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 113.5,
+                                "mean": 21.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 179.67,
+                                "mean": 31.72,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 194.33,
+                                "mean": 37.97,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 8
+                            },
+                            "historical": {
+                                "total": 7
+                            },
+                            "late_century": {
+                                "total": 11
+                            },
+                            "mid_century": {
+                                "total": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 37
+                            },
+                            "historical": {
+                                "total": 20
+                            },
+                            "late_century": {
+                                "total": 39
+                            },
+                            "mid_century": {
+                                "total": 35
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 23
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 27
+                            },
+                            "mid_century": {
+                                "total": 25
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 189
+                            },
+                            "historical": {
+                                "total": 154
+                            },
+                            "late_century": {
+                                "total": 260
+                            },
+                            "mid_century": {
+                                "total": 275
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 201
+                            },
+                            "historical": {
+                                "total": 197
+                            },
+                            "late_century": {
+                                "total": 220
+                            },
+                            "mid_century": {
+                                "total": 212
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 115
+                            },
+                            "historical": {
+                                "total": 80
+                            },
+                            "late_century": {
+                                "total": 75
+                            },
+                            "mid_century": {
+                                "total": 137
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 0
+                            },
+                            "late_century": {
+                                "total": 7
+                            },
+                            "mid_century": {
+                                "total": 8
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 6.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 8.33,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 6.33,
+                                "min": 4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 36,
+                                "mean": 28.33,
+                                "min": 22
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 39.5,
+                                "min": 29
+                            },
+                            "late_century": {
+                                "max": 81,
+                                "mean": 72.33,
+                                "min": 62
+                            },
+                            "mid_century": {
+                                "max": 84,
+                                "mean": 79.67,
+                                "min": 75
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 54,
+                                "mean": 53,
+                                "min": 51
+                            },
+                            "historical": {
+                                "max": 52,
+                                "mean": 47.67,
+                                "min": 43
+                            },
+                            "late_century": {
+                                "max": 55,
+                                "mean": 52.33,
+                                "min": 50
+                            },
+                            "mid_century": {
+                                "max": 55,
+                                "mean": 53,
+                                "min": 49
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 21,
+                                "mean": 16.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 41,
+                                "mean": 21.17,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 24,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 15.33,
+                                "min": 11
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 6,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 84,
+                                "mean": 82,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 88,
+                                "mean": 82.67,
+                                "min": 77
+                            },
+                            "late_century": {
+                                "max": 95,
+                                "mean": 90,
+                                "min": 86
+                            },
+                            "mid_century": {
+                                "max": 92,
+                                "mean": 86.67,
+                                "min": 82
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 26,
+                                "mean": 22.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 17,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 22.67,
+                                "min": 10
+                            },
+                            "mid_century": {
+                                "max": 53,
+                                "mean": 49,
+                                "min": 44
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 69,
+                                "mean": 66.33,
+                                "min": 64
+                            },
+                            "historical": {
+                                "max": 71,
+                                "mean": 66.5,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 81,
+                                "mean": 77.67,
+                                "min": 76
+                            },
+                            "mid_century": {
+                                "max": 76,
+                                "mean": 72,
+                                "min": 70
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 122,
+                                "mean": 76.33,
+                                "min": 24
+                            },
+                            "historical": {
+                                "max": 61,
+                                "mean": 42,
+                                "min": 17
+                            },
+                            "late_century": {
+                                "max": 45,
+                                "mean": 28.33,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 105,
+                                "mean": 72.67,
+                                "min": 23
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 11,
+                                "mean": 8,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 16,
+                                "mean": 15.33,
+                                "min": 15
+                            },
+                            "historical": {
+                                "max": 19,
+                                "mean": 15.83,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 19.33,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 19,
+                                "mean": 18,
+                                "min": 17
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 192,
+                                "mean": 159.67,
+                                "min": 138
+                            },
+                            "historical": {
+                                "max": 156,
+                                "mean": 113.5,
+                                "min": 92
+                            },
+                            "late_century": {
+                                "max": 330,
+                                "mean": 179.67,
+                                "min": 85
+                            },
+                            "mid_century": {
+                                "max": 236,
+                                "mean": 194.33,
+                                "min": 141
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 4.33,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 2.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": -0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 6.33,
+                                "min": 3
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 2.83,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 15,
+                                "mean": 9.67,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 13,
+                                "mean": 9.33,
+                                "min": 6
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 11,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 9.83,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 15,
+                                "mean": 13.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 44,
+                                "mean": 29.67,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 28,
+                                "mean": 17.17,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 29,
+                                "mean": 25,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 29,
+                                "mean": 23.33,
+                                "min": 18
+                            }
+                        }
+                    }
+                }
+            },
+            "HadGEM2-ES": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 85,
+                                "mean": 20.25,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 83.83,
+                                "mean": 19.26,
+                                "min": -1.5
+                            },
+                            "late_century": {
+                                "max": 89,
+                                "mean": 21.42,
+                                "min": -2.67
+                            },
+                            "mid_century": {
+                                "max": 87,
+                                "mean": 20.72,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 112.67,
+                                "mean": 24.53,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 91,
+                                "mean": 19.33,
+                                "min": 0.17
+                            },
+                            "late_century": {
+                                "max": 138,
+                                "mean": 31.75,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 155.67,
+                                "mean": 30.89,
+                                "min": 0.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 9
+                            },
+                            "historical": {
+                                "total": 9
+                            },
+                            "late_century": {
+                                "total": 13
+                            },
+                            "mid_century": {
+                                "total": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 31
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 33
+                            },
+                            "mid_century": {
+                                "total": 32
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 28
+                            },
+                            "historical": {
+                                "total": 26
+                            },
+                            "late_century": {
+                                "total": 28
+                            },
+                            "mid_century": {
+                                "total": 28
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 181
+                            },
+                            "historical": {
+                                "total": 130
+                            },
+                            "late_century": {
+                                "total": 265
+                            },
+                            "mid_century": {
+                                "total": 241
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 212
+                            },
+                            "historical": {
+                                "total": 200
+                            },
+                            "late_century": {
+                                "total": 222
+                            },
+                            "mid_century": {
+                                "total": 216
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 80
+                            },
+                            "historical": {
+                                "total": 72
+                            },
+                            "late_century": {
+                                "total": 77
+                            },
+                            "mid_century": {
+                                "total": 92
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -6
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -7
+                            },
+                            "mid_century": {
+                                "total": -7
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 3
+                            },
+                            "historical": {
+                                "total": 4
+                            },
+                            "late_century": {
+                                "total": 6
+                            },
+                            "mid_century": {
+                                "total": 5
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 6.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 8.33,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 5,
+                                "mean": 4,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 77,
+                                "mean": 65.33,
+                                "min": 48
+                            },
+                            "historical": {
+                                "max": 68,
+                                "mean": 38.5,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 154,
+                                "mean": 138,
+                                "min": 122
+                            },
+                            "mid_century": {
+                                "max": 95,
+                                "mean": 78.33,
+                                "min": 57
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 56,
+                                "mean": 54,
+                                "min": 53
+                            },
+                            "historical": {
+                                "max": 53,
+                                "mean": 49,
+                                "min": 44
+                            },
+                            "late_century": {
+                                "max": 59,
+                                "mean": 57.67,
+                                "min": 56
+                            },
+                            "mid_century": {
+                                "max": 57,
+                                "mean": 55,
+                                "min": 52
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 35,
+                                "mean": 24,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 32,
+                                "mean": 20.5,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 20,
+                                "mean": 19,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 35,
+                                "mean": 26.33,
+                                "min": 18
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 21,
+                                "mean": 3.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 2,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 2,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 2.67,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 2.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 2.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 89,
+                                "mean": 85,
+                                "min": 83
+                            },
+                            "historical": {
+                                "max": 88,
+                                "mean": 83.83,
+                                "min": 81
+                            },
+                            "late_century": {
+                                "max": 93,
+                                "mean": 89,
+                                "min": 84
+                            },
+                            "mid_century": {
+                                "max": 89,
+                                "mean": 87,
+                                "min": 85
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 43,
+                                "mean": 30.33,
+                                "min": 19
+                            },
+                            "historical": {
+                                "max": 34,
+                                "mean": 17.67,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 50,
+                                "mean": 31.33,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 35,
+                                "mean": 28.33,
+                                "min": 24
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 76,
+                                "mean": 72.67,
+                                "min": 66
+                            },
+                            "historical": {
+                                "max": 74,
+                                "mean": 67.33,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 83,
+                                "mean": 75.33,
+                                "min": 70
+                            },
+                            "mid_century": {
+                                "max": 79,
+                                "mean": 73.67,
+                                "min": 70
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 38,
+                                "mean": 25.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 58,
+                                "mean": 34,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 46,
+                                "mean": 27,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 61,
+                                "mean": 37.67,
+                                "min": 23
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 2.67,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 20,
+                                "mean": 11.67,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 10,
+                                "mean": 7,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 21,
+                                "mean": 19.67,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 20,
+                                "mean": 16.17,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 25,
+                                "mean": 23.33,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 24,
+                                "mean": 21.67,
+                                "min": 19
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 159,
+                                "mean": 112.67,
+                                "min": 86
+                            },
+                            "historical": {
+                                "max": 134,
+                                "mean": 91,
+                                "min": 61
+                            },
+                            "late_century": {
+                                "max": 194,
+                                "mean": 115.67,
+                                "min": 67
+                            },
+                            "mid_century": {
+                                "max": 171,
+                                "mean": 155.67,
+                                "min": 137
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 5.67,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 3,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 28,
+                                "mean": 11.33,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 5.83,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 12,
+                                "mean": 9.67,
+                                "min": 8
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 12.33,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 13,
+                                "mean": 11.33,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 16,
+                                "mean": 15.33,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 13.67,
+                                "min": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 23,
+                                "mean": 17.67,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 25,
+                                "mean": 19.33,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 21,
+                                "mean": 20,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 19.67,
+                                "min": 14
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 89.33,
+                                "mean": 20.42,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 82.83,
+                                "mean": 19.07,
+                                "min": -1.5
+                            },
+                            "late_century": {
+                                "max": 96.67,
+                                "mean": 23.28,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": 89.33,
+                                "mean": 21.47,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 123.33,
+                                "mean": 21.19,
+                                "min": 0.33
+                            },
+                            "historical": {
+                                "max": 95.83,
+                                "mean": 19.81,
+                                "min": 0.33
+                            },
+                            "late_century": {
+                                "max": 160.33,
+                                "mean": 44.67,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 137.67,
+                                "mean": 35.67,
+                                "min": 2.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 10
+                            },
+                            "historical": {
+                                "total": 9
+                            },
+                            "late_century": {
+                                "total": 15
+                            },
+                            "mid_century": {
+                                "total": 14
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 23
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 67
+                            },
+                            "mid_century": {
+                                "total": 46
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 25
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 30
+                            },
+                            "mid_century": {
+                                "total": 28
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 179
+                            },
+                            "historical": {
+                                "total": 133
+                            },
+                            "late_century": {
+                                "total": 342
+                            },
+                            "mid_century": {
+                                "total": 265
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 215
+                            },
+                            "historical": {
+                                "total": 198
+                            },
+                            "late_century": {
+                                "total": 245
+                            },
+                            "mid_century": {
+                                "total": 223
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 51
+                            },
+                            "historical": {
+                                "total": 76
+                            },
+                            "late_century": {
+                                "total": 66
+                            },
+                            "mid_century": {
+                                "total": 93
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -11
+                            },
+                            "mid_century": {
+                                "total": -7
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 2
+                            },
+                            "historical": {
+                                "total": 4
+                            },
+                            "late_century": {
+                                "total": 61
+                            },
+                            "mid_century": {
+                                "total": 23
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 8.17,
+                                "min": 7
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 3,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 3.67,
+                                "min": 2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 72,
+                                "mean": 53,
+                                "min": 38
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 36.17,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 207,
+                                "mean": 160.33,
+                                "min": 128
+                            },
+                            "mid_century": {
+                                "max": 170,
+                                "mean": 137.67,
+                                "min": 120
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 54,
+                                "mean": 52.33,
+                                "min": 51
+                            },
+                            "historical": {
+                                "max": 52,
+                                "mean": 48.83,
+                                "min": 44
+                            },
+                            "late_century": {
+                                "max": 66,
+                                "mean": 62.33,
+                                "min": 59
+                            },
+                            "mid_century": {
+                                "max": 58,
+                                "mean": 57.67,
+                                "min": 57
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 16,
+                                "mean": 15,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 31,
+                                "mean": 20.33,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 20.67,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 29,
+                                "mean": 24,
+                                "min": 16
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.33,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 21,
+                                "mean": 3.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 7,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 2.67,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.67,
+                                "min": -5
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 69,
+                                "mean": 34.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 8.67,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -4,
+                                "mean": -4,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 19.67,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 33,
+                                "mean": 12,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 93,
+                                "mean": 89.33,
+                                "min": 87
+                            },
+                            "historical": {
+                                "max": 88,
+                                "mean": 82.83,
+                                "min": 75
+                            },
+                            "late_century": {
+                                "max": 99,
+                                "mean": 96.67,
+                                "min": 93
+                            },
+                            "mid_century": {
+                                "max": 91,
+                                "mean": 89.33,
+                                "min": 86
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 17.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 61,
+                                "mean": 24.67,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 21.33,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 61,
+                                "mean": 38.67,
+                                "min": 8
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 75,
+                                "mean": 73.33,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 72,
+                                "mean": 66.83,
+                                "min": 62
+                            },
+                            "late_century": {
+                                "max": 90,
+                                "mean": 85.67,
+                                "min": 82
+                            },
+                            "mid_century": {
+                                "max": 78,
+                                "mean": 76,
+                                "min": 73
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 23,
+                                "mean": 18.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 41,
+                                "mean": 31.17,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 34,
+                                "mean": 24.33,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 45,
+                                "mean": 30.67,
+                                "min": 16
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.67,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 77,
+                                "mean": 69,
+                                "min": 64
+                            },
+                            "mid_century": {
+                                "max": 42,
+                                "mean": 22.33,
+                                "min": 11
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 21,
+                                "mean": 18,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 18,
+                                "mean": 15.83,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 33,
+                                "mean": 28.33,
+                                "min": 25
+                            },
+                            "mid_century": {
+                                "max": 29,
+                                "mean": 24.67,
+                                "min": 21
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 182,
+                                "mean": 123.33,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 134,
+                                "mean": 95.83,
+                                "min": 61
+                            },
+                            "late_century": {
+                                "max": 180,
+                                "mean": 112.67,
+                                "min": 33
+                            },
+                            "mid_century": {
+                                "max": 143,
+                                "mean": 105,
+                                "min": 50
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -3,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 34,
+                                "mean": 23,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 11,
+                                "mean": 5,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 19,
+                                "mean": 7.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 6.17,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 21,
+                                "mean": 16.67,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 19,
+                                "mean": 12.67,
+                                "min": 5
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 13,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 13,
+                                "mean": 11.17,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 19,
+                                "mean": 17.67,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 15.33,
+                                "min": 14
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 25,
+                                "mean": 17.5,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 29,
+                                "mean": 27,
+                                "min": 25
+                            },
+                            "mid_century": {
+                                "max": 32,
+                                "mean": 28.67,
+                                "min": 25
+                            }
+                        }
+                    }
+                }
+            },
+            "MIROC5": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 83.67,
+                                "mean": 20.06,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 80.67,
+                                "mean": 18.83,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 85.67,
+                                "mean": 20.78,
+                                "min": -2.33
+                            },
+                            "mid_century": {
+                                "max": 84,
+                                "mean": 20.2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 205,
+                                "mean": 34.81,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 126.33,
+                                "mean": 21.72,
+                                "min": 0.17
+                            },
+                            "late_century": {
+                                "max": 136.33,
+                                "mean": 26.58,
+                                "min": 0.67
+                            },
+                            "mid_century": {
+                                "max": 126.67,
+                                "mean": 30.5,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 11
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 13
+                            },
+                            "mid_century": {
+                                "total": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 48
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 32
+                            },
+                            "mid_century": {
+                                "total": 35
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 24
+                            },
+                            "mid_century": {
+                                "total": 25
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 279
+                            },
+                            "historical": {
+                                "total": 163
+                            },
+                            "late_century": {
+                                "total": 215
+                            },
+                            "mid_century": {
+                                "total": 239
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 211
+                            },
+                            "historical": {
+                                "total": 198
+                            },
+                            "late_century": {
+                                "total": 217
+                            },
+                            "mid_century": {
+                                "total": 211
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 80
+                            },
+                            "historical": {
+                                "total": 72
+                            },
+                            "late_century": {
+                                "total": 70
+                            },
+                            "mid_century": {
+                                "total": 89
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 11
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 3
+                            },
+                            "mid_century": {
+                                "total": 2
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 7.83,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 4.33,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 9,
+                                "mean": 6.67,
+                                "min": 5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 74,
+                                "mean": 70.33,
+                                "min": 64
+                            },
+                            "historical": {
+                                "max": 58,
+                                "mean": 36,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 106,
+                                "mean": 73.67,
+                                "min": 50
+                            },
+                            "mid_century": {
+                                "max": 130,
+                                "mean": 104.67,
+                                "min": 73
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 55,
+                                "mean": 52,
+                                "min": 49
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 50.5,
+                                "min": 43
+                            },
+                            "late_century": {
+                                "max": 59,
+                                "mean": 55.33,
+                                "min": 50
+                            },
+                            "mid_century": {
+                                "max": 56,
+                                "mean": 54,
+                                "min": 52
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 25,
+                                "mean": 21.67,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 27,
+                                "mean": 16.17,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 21,
+                                "mean": 19.67,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 27,
+                                "mean": 21.67,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 26,
+                                "mean": 8.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 89,
+                                "mean": 83.67,
+                                "min": 81
+                            },
+                            "historical": {
+                                "max": 89,
+                                "mean": 80.67,
+                                "min": 73
+                            },
+                            "late_century": {
+                                "max": 92,
+                                "mean": 85.67,
+                                "min": 80
+                            },
+                            "mid_century": {
+                                "max": 87,
+                                "mean": 84,
+                                "min": 80
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 24,
+                                "mean": 18.67,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 35,
+                                "mean": 17,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 73,
+                                "mean": 31.67,
+                                "min": 8
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 16.33,
+                                "min": 8
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 79,
+                                "mean": 75.33,
+                                "min": 72
+                            },
+                            "historical": {
+                                "max": 75,
+                                "mean": 67,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 78,
+                                "mean": 76.33,
+                                "min": 74
+                            },
+                            "mid_century": {
+                                "max": 78,
+                                "mean": 72.67,
+                                "min": 69
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 60,
+                                "mean": 39.67,
+                                "min": 20
+                            },
+                            "historical": {
+                                "max": 67,
+                                "mean": 38.5,
+                                "min": 26
+                            },
+                            "late_century": {
+                                "max": 25,
+                                "mean": 18.67,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 72,
+                                "mean": 51.33,
+                                "min": 21
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 3.67,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 4.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 12,
+                                "mean": 8,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 19,
+                                "mean": 16,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 14.83,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 21,
+                                "mean": 19.33,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 17.33,
+                                "min": 16
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 424,
+                                "mean": 205,
+                                "min": 62
+                            },
+                            "historical": {
+                                "max": 175,
+                                "mean": 126.33,
+                                "min": 89
+                            },
+                            "late_century": {
+                                "max": 162,
+                                "mean": 136.33,
+                                "min": 117
+                            },
+                            "mid_century": {
+                                "max": 191,
+                                "mean": 126.67,
+                                "min": 82
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 2.67,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 40,
+                                "mean": 23,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 24,
+                                "mean": 8.83,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 12,
+                                "min": 8
+                            },
+                            "mid_century": {
+                                "max": 11,
+                                "mean": 10.33,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 13,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.83,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 15.33,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 12.67,
+                                "min": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 26,
+                                "mean": 22.67,
+                                "min": 21
+                            },
+                            "historical": {
+                                "max": 25,
+                                "mean": 15.33,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 17.33,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 30,
+                                "mean": 22.33,
+                                "min": 13
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 84.33,
+                                "mean": 20.5,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 81,
+                                "mean": 18.76,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 97.33,
+                                "mean": 23.25,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": 81.67,
+                                "mean": 20.75,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 132,
+                                "mean": 26.56,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 130.33,
+                                "mean": 21.99,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 141.33,
+                                "mean": 26.31,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 130,
+                                "mean": 26.55,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 11
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 16
+                            },
+                            "mid_century": {
+                                "total": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 27
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 43
+                            },
+                            "mid_century": {
+                                "total": 48
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 26
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 30
+                            },
+                            "mid_century": {
+                                "total": 24
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 204
+                            },
+                            "historical": {
+                                "total": 168
+                            },
+                            "late_century": {
+                                "total": 214
+                            },
+                            "mid_century": {
+                                "total": 207
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 213
+                            },
+                            "historical": {
+                                "total": 198
+                            },
+                            "late_century": {
+                                "total": 240
+                            },
+                            "mid_century": {
+                                "total": 217
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 81
+                            },
+                            "historical": {
+                                "total": 72
+                            },
+                            "late_century": {
+                                "total": 49
+                            },
+                            "mid_century": {
+                                "total": 59
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -4
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -7
+                            },
+                            "mid_century": {
+                                "total": -5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 6
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 10
+                            },
+                            "mid_century": {
+                                "total": 5
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 5.67,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7.67,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 3.67,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 92,
+                                "mean": 69,
+                                "min": 39
+                            },
+                            "historical": {
+                                "max": 58,
+                                "mean": 37.33,
+                                "min": 22
+                            },
+                            "late_century": {
+                                "max": 193,
+                                "mean": 141.33,
+                                "min": 115
+                            },
+                            "mid_century": {
+                                "max": 106,
+                                "mean": 66,
+                                "min": 38
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 58,
+                                "mean": 54.67,
+                                "min": 52
+                            },
+                            "historical": {
+                                "max": 57,
+                                "mean": 50.67,
+                                "min": 43
+                            },
+                            "late_century": {
+                                "max": 63,
+                                "mean": 58.67,
+                                "min": 54
+                            },
+                            "mid_century": {
+                                "max": 58,
+                                "mean": 57.33,
+                                "min": 57
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 28,
+                                "mean": 24.33,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 27,
+                                "mean": 15.67,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 19,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 15.67,
+                                "min": 13
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 6,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -3,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 18,
+                                "mean": 6.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 3.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 10,
+                                "mean": 4.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 90,
+                                "mean": 84.33,
+                                "min": 81
+                            },
+                            "historical": {
+                                "max": 91,
+                                "mean": 81,
+                                "min": 73
+                            },
+                            "late_century": {
+                                "max": 102,
+                                "mean": 97.33,
+                                "min": 93
+                            },
+                            "mid_century": {
+                                "max": 84,
+                                "mean": 81.67,
+                                "min": 77
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 31,
+                                "mean": 21.33,
+                                "min": 9
+                            },
+                            "historical": {
+                                "max": 35,
+                                "mean": 17,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 15.67,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 23,
+                                "mean": 19.33,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 76,
+                                "mean": 74,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 68,
+                                "mean": 65.83,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 89,
+                                "mean": 84.33,
+                                "min": 82
+                            },
+                            "mid_century": {
+                                "max": 80,
+                                "mean": 77.67,
+                                "min": 74
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 50,
+                                "mean": 35,
+                                "min": 24
+                            },
+                            "historical": {
+                                "max": 67,
+                                "mean": 39,
+                                "min": 26
+                            },
+                            "late_century": {
+                                "max": 18,
+                                "mean": 14,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 38,
+                                "mean": 24.33,
+                                "min": 10
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 3.33,
+                                "min": 2
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 19,
+                                "mean": 13.33,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 10.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 19.33,
+                                "min": 19
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 14.67,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 27,
+                                "mean": 26.33,
+                                "min": 25
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 18.33,
+                                "min": 16
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 176,
+                                "mean": 132,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 175,
+                                "mean": 130.33,
+                                "min": 92
+                            },
+                            "late_century": {
+                                "max": 73,
+                                "mean": 59,
+                                "min": 36
+                            },
+                            "mid_century": {
+                                "max": 188,
+                                "mean": 130,
+                                "min": 74
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 3,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 6,
+                                "mean": 3.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.83,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 7,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 24,
+                                "mean": 8.67,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 37,
+                                "mean": 20,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 56,
+                                "mean": 31.33,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 13.33,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.83,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 18,
+                                "mean": 16.67,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 17,
+                                "mean": 15,
+                                "min": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 24,
+                                "mean": 19.67,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 25,
+                                "mean": 14.33,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 20,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 13.33,
+                                "min": 11
+                            }
+                        }
+                    }
+                }
+            },
+            "MPI-ESM-MR": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 81.67,
+                                "mean": 19,
+                                "min": -1.67
+                            },
+                            "historical": {
+                                "max": 83,
+                                "mean": 19,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 82.33,
+                                "mean": 20.3,
+                                "min": -2.67
+                            },
+                            "mid_century": {
+                                "max": 79.33,
+                                "mean": 19.86,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 158.67,
+                                "mean": 32.03,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 114.67,
+                                "mean": 22.28,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 161,
+                                "mean": 33.14,
+                                "min": 3.33
+                            },
+                            "mid_century": {
+                                "max": 118,
+                                "mean": 27.44,
+                                "min": 0.67
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 10
+                            },
+                            "historical": {
+                                "total": 7
+                            },
+                            "late_century": {
+                                "total": 11
+                            },
+                            "mid_century": {
+                                "total": 9
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 23
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 41
+                            },
+                            "mid_century": {
+                                "total": 34
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 25
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 25
+                            },
+                            "mid_century": {
+                                "total": 26
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 233
+                            },
+                            "historical": {
+                                "total": 155
+                            },
+                            "late_century": {
+                                "total": 265
+                            },
+                            "mid_century": {
+                                "total": 237
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 197
+                            },
+                            "historical": {
+                                "total": 202
+                            },
+                            "late_century": {
+                                "total": 215
+                            },
+                            "mid_century": {
+                                "total": 209
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 128
+                            },
+                            "historical": {
+                                "total": 87
+                            },
+                            "late_century": {
+                                "total": 77
+                            },
+                            "mid_century": {
+                                "total": 55
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -4
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -7
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 2
+                            },
+                            "late_century": {
+                                "total": 15
+                            },
+                            "mid_century": {
+                                "total": 3
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 5
+                            },
+                            "late_century": {
+                                "max": 5,
+                                "mean": 3.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 4,
+                                "min": 2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 106,
+                                "mean": 72,
+                                "min": 48
+                            },
+                            "historical": {
+                                "max": 68,
+                                "mean": 39.83,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 104,
+                                "mean": 97,
+                                "min": 88
+                            },
+                            "mid_century": {
+                                "max": 149,
+                                "mean": 118,
+                                "min": 89
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 51,
+                                "mean": 49,
+                                "min": 48
+                            },
+                            "historical": {
+                                "max": 57,
+                                "mean": 51.83,
+                                "min": 48
+                            },
+                            "late_century": {
+                                "max": 53,
+                                "mean": 52.33,
+                                "min": 51
+                            },
+                            "mid_century": {
+                                "max": 57,
+                                "mean": 54,
+                                "min": 51
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 32,
+                                "mean": 24,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 36,
+                                "mean": 20.17,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 46,
+                                "mean": 32.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 16,
+                                "min": 11
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 7,
+                                "mean": 2,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 6,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 1.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 5,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 9,
+                                "mean": 3.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 88,
+                                "mean": 81.67,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 91,
+                                "mean": 83,
+                                "min": 77
+                            },
+                            "late_century": {
+                                "max": 87,
+                                "mean": 82.33,
+                                "min": 78
+                            },
+                            "mid_century": {
+                                "max": 84,
+                                "mean": 79.33,
+                                "min": 75
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 51,
+                                "mean": 25.33,
+                                "min": 9
+                            },
+                            "historical": {
+                                "max": 27,
+                                "mean": 16.5,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 39,
+                                "mean": 23.67,
+                                "min": 15
+                            },
+                            "mid_century": {
+                                "max": 25,
+                                "mean": 18.67,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 72,
+                                "mean": 66.33,
+                                "min": 62
+                            },
+                            "historical": {
+                                "max": 80,
+                                "mean": 66.67,
+                                "min": 61
+                            },
+                            "late_century": {
+                                "max": 84,
+                                "mean": 80.33,
+                                "min": 76
+                            },
+                            "mid_century": {
+                                "max": 78,
+                                "mean": 76,
+                                "min": 72
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 162,
+                                "mean": 78.67,
+                                "min": 26
+                            },
+                            "historical": {
+                                "max": 72,
+                                "mean": 50.5,
+                                "min": 21
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 20.67,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 29,
+                                "mean": 20.33,
+                                "min": 13
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 7,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 12,
+                                "mean": 5,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 19,
+                                "mean": 17,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 15.5,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 26,
+                                "mean": 20.67,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 24,
+                                "mean": 21.67,
+                                "min": 19
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 203,
+                                "mean": 158.67,
+                                "min": 128
+                            },
+                            "historical": {
+                                "max": 207,
+                                "mean": 114.67,
+                                "min": 58
+                            },
+                            "late_century": {
+                                "max": 213,
+                                "mean": 161,
+                                "min": 134
+                            },
+                            "mid_century": {
+                                "max": 209,
+                                "mean": 114.33,
+                                "min": 42
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 5,
+                                "mean": 3.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 6.33,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 18,
+                                "mean": 7.17,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 25,
+                                "mean": 19,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 13.33,
+                                "min": 6
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 12.33,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.17,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 12,
+                                "mean": 11.67,
+                                "min": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 19,
+                                "mean": 16,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 22,
+                                "mean": 15.33,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 19,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 19,
+                                "min": 14
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 81.33,
+                                "mean": 19.39,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 82.33,
+                                "mean": 18.8,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 88.33,
+                                "mean": 21.56,
+                                "min": -4.33
+                            },
+                            "mid_century": {
+                                "max": 83.33,
+                                "mean": 20.69,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 159.67,
+                                "mean": 29.17,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 126.33,
+                                "mean": 23.79,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 161,
+                                "mean": 38.14,
+                                "min": 8
+                            },
+                            "mid_century": {
+                                "max": 121,
+                                "mean": 30.17,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 9
+                            },
+                            "historical": {
+                                "total": 7
+                            },
+                            "late_century": {
+                                "total": 12
+                            },
+                            "mid_century": {
+                                "total": 12
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 36
+                            },
+                            "historical": {
+                                "total": 20
+                            },
+                            "late_century": {
+                                "total": 66
+                            },
+                            "mid_century": {
+                                "total": 34
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 27
+                            },
+                            "mid_century": {
+                                "total": 27
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 232
+                            },
+                            "historical": {
+                                "total": 170
+                            },
+                            "late_century": {
+                                "total": 267
+                            },
+                            "mid_century": {
+                                "total": 261
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 205
+                            },
+                            "historical": {
+                                "total": 199
+                            },
+                            "late_century": {
+                                "total": 231
+                            },
+                            "mid_century": {
+                                "total": 217
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 79
+                            },
+                            "historical": {
+                                "total": 93
+                            },
+                            "late_century": {
+                                "total": 57
+                            },
+                            "mid_century": {
+                                "total": 50
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -11
+                            },
+                            "mid_century": {
+                                "total": -8
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 4
+                            },
+                            "historical": {
+                                "total": 2
+                            },
+                            "late_century": {
+                                "total": 67
+                            },
+                            "mid_century": {
+                                "total": 17
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7.17,
+                                "min": 5
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 1.67,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 3.67,
+                                "min": 3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 84,
+                                "mean": 68.33,
+                                "min": 52
+                            },
+                            "historical": {
+                                "max": 76,
+                                "mean": 43.33,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 209,
+                                "mean": 161,
+                                "min": 109
+                            },
+                            "mid_century": {
+                                "max": 144,
+                                "mean": 113.33,
+                                "min": 81
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 53,
+                                "mean": 52.33,
+                                "min": 52
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 50.83,
+                                "min": 48
+                            },
+                            "late_century": {
+                                "max": 63,
+                                "mean": 59.67,
+                                "min": 57
+                            },
+                            "mid_century": {
+                                "max": 56,
+                                "mean": 55,
+                                "min": 54
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 26,
+                                "mean": 23,
+                                "min": 18
+                            },
+                            "historical": {
+                                "max": 36,
+                                "mean": 20.17,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 30,
+                                "mean": 26,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 19.33,
+                                "min": 18
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -2,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.67,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 2.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 7,
+                                "mean": 2,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 31,
+                                "mean": 13.33,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 8.67,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -3.33,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 42,
+                                "mean": 28.33,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 7.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -4,
+                                "mean": -4.33,
+                                "min": -5
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 38,
+                                "mean": 25.67,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 84,
+                                "mean": 81.33,
+                                "min": 78
+                            },
+                            "historical": {
+                                "max": 91,
+                                "mean": 82.33,
+                                "min": 77
+                            },
+                            "late_century": {
+                                "max": 91,
+                                "mean": 88.33,
+                                "min": 84
+                            },
+                            "mid_century": {
+                                "max": 86,
+                                "mean": 83.33,
+                                "min": 78
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 15.67,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 38,
+                                "mean": 20.17,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 22,
+                                "mean": 15,
+                                "min": 8
+                            },
+                            "mid_century": {
+                                "max": 15,
+                                "mean": 11.33,
+                                "min": 9
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 73,
+                                "mean": 71,
+                                "min": 68
+                            },
+                            "historical": {
+                                "max": 78,
+                                "mean": 66.33,
+                                "min": 61
+                            },
+                            "late_century": {
+                                "max": 85,
+                                "mean": 83.33,
+                                "min": 80
+                            },
+                            "mid_century": {
+                                "max": 80,
+                                "mean": 78.67,
+                                "min": 78
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 81,
+                                "mean": 40,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 72,
+                                "mean": 52.5,
+                                "min": 30
+                            },
+                            "late_century": {
+                                "max": 18,
+                                "mean": 16.33,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 19.33,
+                                "min": 17
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": -1,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 4,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 86,
+                                "mean": 54,
+                                "min": 24
+                            },
+                            "mid_century": {
+                                "max": 37,
+                                "mean": 26.33,
+                                "min": 12
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 17.67,
+                                "min": 15
+                            },
+                            "historical": {
+                                "max": 16,
+                                "mean": 15.33,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 26,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 23,
+                                "min": 20
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 203,
+                                "mean": 159.67,
+                                "min": 89
+                            },
+                            "historical": {
+                                "max": 207,
+                                "mean": 126.33,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 102,
+                                "mean": 52.33,
+                                "min": 21
+                            },
+                            "mid_century": {
+                                "max": 164,
+                                "mean": 121,
+                                "min": 91
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 15,
+                                "mean": 8,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 1.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 18.33,
+                                "min": 17
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 4.67,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 32,
+                                "mean": 29.33,
+                                "min": 25
+                            },
+                            "mid_century": {
+                                "max": 23,
+                                "mean": 16.67,
+                                "min": 10
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 11.33,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 10,
+                                "min": 9
+                            },
+                            "late_century": {
+                                "max": 15,
+                                "mean": 14.33,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 13.67,
+                                "min": 13
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 25,
+                                "mean": 17.33,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 22,
+                                "mean": 15,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 36,
+                                "mean": 28.33,
+                                "min": 24
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 16,
+                                "min": 14
+                            }
+                        }
+                    }
+                }
+            },
+            "MRI-CGCM3": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 85.67,
+                                "mean": 19.81,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": 82.17,
+                                "mean": 19.01,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 81.33,
+                                "mean": 19.28,
+                                "min": -2.33
+                            },
+                            "mid_century": {
+                                "max": 86.33,
+                                "mean": 19.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 161.33,
+                                "mean": 28.25,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 119.5,
+                                "mean": 22.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 184.67,
+                                "mean": 31.86,
+                                "min": 0.33
+                            },
+                            "mid_century": {
+                                "max": 151.67,
+                                "mean": 28.36,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 9
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 10
+                            },
+                            "mid_century": {
+                                "total": 9
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 21
+                            },
+                            "historical": {
+                                "total": 22
+                            },
+                            "late_century": {
+                                "total": 33
+                            },
+                            "mid_century": {
+                                "total": 34
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 25
+                            },
+                            "historical": {
+                                "total": 24
+                            },
+                            "late_century": {
+                                "total": 22
+                            },
+                            "mid_century": {
+                                "total": 24
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 220
+                            },
+                            "historical": {
+                                "total": 150
+                            },
+                            "late_century": {
+                                "total": 266
+                            },
+                            "mid_century": {
+                                "total": 208
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 209
+                            },
+                            "historical": {
+                                "total": 200
+                            },
+                            "late_century": {
+                                "total": 205
+                            },
+                            "mid_century": {
+                                "total": 205
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 95
+                            },
+                            "historical": {
+                                "total": 93
+                            },
+                            "late_century": {
+                                "total": 77
+                            },
+                            "mid_century": {
+                                "total": 92
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -5
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 3
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 7
+                            },
+                            "mid_century": {
+                                "total": 6
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 7.67,
+                                "min": 7
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 8,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 6.33,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 6,
+                                "min": 4
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 73,
+                                "mean": 57.67,
+                                "min": 43
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 30,
+                                "min": 17
+                            },
+                            "late_century": {
+                                "max": 91,
+                                "mean": 75.67,
+                                "min": 51
+                            },
+                            "mid_century": {
+                                "max": 63,
+                                "mean": 54.67,
+                                "min": 44
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 53,
+                                "mean": 52,
+                                "min": 51
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 50.83,
+                                "min": 49
+                            },
+                            "late_century": {
+                                "max": 61,
+                                "mean": 54.67,
+                                "min": 51
+                            },
+                            "mid_century": {
+                                "max": 56,
+                                "mean": 49.33,
+                                "min": 45
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 31,
+                                "mean": 27.67,
+                                "min": 25
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 17.83,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 28,
+                                "mean": 21.67,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 18,
+                                "min": 12
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -2,
+                                "min": -3
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -3,
+                                "mean": -3,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 5,
+                                "mean": 2,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 4,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 5.67,
+                                "min": 3
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 2.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 89,
+                                "mean": 85.67,
+                                "min": 83
+                            },
+                            "historical": {
+                                "max": 87,
+                                "mean": 82.17,
+                                "min": 79
+                            },
+                            "late_century": {
+                                "max": 85,
+                                "mean": 81.33,
+                                "min": 78
+                            },
+                            "mid_century": {
+                                "max": 89,
+                                "mean": 86.33,
+                                "min": 82
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 24,
+                                "mean": 20,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 17,
+                                "min": 11
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 19,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 20,
+                                "min": 15
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 73,
+                                "mean": 71,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 73,
+                                "mean": 67.5,
+                                "min": 61
+                            },
+                            "late_century": {
+                                "max": 71,
+                                "mean": 69,
+                                "min": 68
+                            },
+                            "mid_century": {
+                                "max": 72,
+                                "mean": 69.67,
+                                "min": 65
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 82,
+                                "mean": 47,
+                                "min": 20
+                            },
+                            "historical": {
+                                "max": 102,
+                                "mean": 58.5,
+                                "min": 16
+                            },
+                            "late_century": {
+                                "max": 49,
+                                "mean": 36.33,
+                                "min": 27
+                            },
+                            "mid_century": {
+                                "max": 91,
+                                "mean": 54.33,
+                                "min": 35
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 8,
+                                "mean": 5.67,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 4,
+                                "mean": 1.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 18,
+                                "mean": 16.33,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 14.83,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 16,
+                                "mean": 14.67,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 18,
+                                "mean": 17,
+                                "min": 16
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 217,
+                                "mean": 161.33,
+                                "min": 61
+                            },
+                            "historical": {
+                                "max": 182,
+                                "mean": 119.5,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 207,
+                                "mean": 184.67,
+                                "min": 150
+                            },
+                            "mid_century": {
+                                "max": 184,
+                                "mean": 151.67,
+                                "min": 105
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 5,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 3.33,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 4
+                            },
+                            "historical": {
+                                "max": 4,
+                                "mean": 3.17,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 11.33,
+                                "min": 7
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 7.33,
+                                "min": 7
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 11,
+                                "mean": 11,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 10.67,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 13,
+                                "mean": 12.33,
+                                "min": 11
+                            },
+                            "mid_century": {
+                                "max": 12,
+                                "mean": 11.67,
+                                "min": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 16,
+                                "mean": 13.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 18,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 24,
+                                "mean": 19,
+                                "min": 16
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 23.33,
+                                "min": 18
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 80.67,
+                                "mean": 18.67,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 82.83,
+                                "mean": 19.12,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 85,
+                                "mean": 19.72,
+                                "min": -3.67
+                            },
+                            "mid_century": {
+                                "max": 82.67,
+                                "mean": 19,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 204.67,
+                                "mean": 34.47,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 116,
+                                "mean": 21.92,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 181,
+                                "mean": 36.39,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 175.67,
+                                "mean": 34,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 9
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 11
+                            },
+                            "mid_century": {
+                                "total": 9
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 37
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 37
+                            },
+                            "mid_century": {
+                                "total": 45
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 21
+                            },
+                            "historical": {
+                                "total": 25
+                            },
+                            "late_century": {
+                                "total": 22
+                            },
+                            "mid_century": {
+                                "total": 23
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 249
+                            },
+                            "historical": {
+                                "total": 153
+                            },
+                            "late_century": {
+                                "total": 289
+                            },
+                            "mid_century": {
+                                "total": 255
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 200
+                            },
+                            "historical": {
+                                "total": 201
+                            },
+                            "late_century": {
+                                "total": 212
+                            },
+                            "mid_century": {
+                                "total": 202
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 123
+                            },
+                            "historical": {
+                                "total": 86
+                            },
+                            "late_century": {
+                                "total": 91
+                            },
+                            "mid_century": {
+                                "total": 106
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -6
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -8
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 4
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 20
+                            },
+                            "mid_century": {
+                                "total": 2
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 6.67,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 10,
+                                "mean": 8.33,
+                                "min": 6
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 5,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 5.67,
+                                "min": 5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 44,
+                                "mean": 43.33,
+                                "min": 42
+                            },
+                            "historical": {
+                                "max": 56,
+                                "mean": 36.33,
+                                "min": 20
+                            },
+                            "late_century": {
+                                "max": 116,
+                                "mean": 101.67,
+                                "min": 86
+                            },
+                            "mid_century": {
+                                "max": 106,
+                                "mean": 77.33,
+                                "min": 38
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 55,
+                                "mean": 52.33,
+                                "min": 51
+                            },
+                            "historical": {
+                                "max": 54,
+                                "mean": 50,
+                                "min": 46
+                            },
+                            "late_century": {
+                                "max": 58,
+                                "mean": 55.67,
+                                "min": 53
+                            },
+                            "mid_century": {
+                                "max": 53,
+                                "mean": 52,
+                                "min": 50
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 27,
+                                "mean": 19.33,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 18.67,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 31,
+                                "mean": 27.67,
+                                "min": 23
+                            },
+                            "mid_century": {
+                                "max": 30,
+                                "mean": 25.33,
+                                "min": 19
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.67,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 3.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 19,
+                                "mean": 15.33,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1.67,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 3,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 88,
+                                "mean": 80.67,
+                                "min": 76
+                            },
+                            "historical": {
+                                "max": 87,
+                                "mean": 82.83,
+                                "min": 79
+                            },
+                            "late_century": {
+                                "max": 86,
+                                "mean": 85,
+                                "min": 84
+                            },
+                            "mid_century": {
+                                "max": 88,
+                                "mean": 82.67,
+                                "min": 78
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 19,
+                                "mean": 17.33,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 28,
+                                "mean": 19,
+                                "min": 11
+                            },
+                            "late_century": {
+                                "max": 31,
+                                "mean": 27,
+                                "min": 21
+                            },
+                            "mid_century": {
+                                "max": 49,
+                                "mean": 32,
+                                "min": 15
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 73,
+                                "mean": 67,
+                                "min": 63
+                            },
+                            "historical": {
+                                "max": 73,
+                                "mean": 67.83,
+                                "min": 61
+                            },
+                            "late_century": {
+                                "max": 72,
+                                "mean": 71,
+                                "min": 70
+                            },
+                            "mid_century": {
+                                "max": 75,
+                                "mean": 67.33,
+                                "min": 62
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 94,
+                                "mean": 86.67,
+                                "min": 77
+                            },
+                            "historical": {
+                                "max": 102,
+                                "mean": 48.33,
+                                "min": 16
+                            },
+                            "late_century": {
+                                "max": 39,
+                                "mean": 36.33,
+                                "min": 35
+                            },
+                            "mid_century": {
+                                "max": 93,
+                                "mean": 48.67,
+                                "min": 23
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 4,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 6,
+                                "min": 5
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 2,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 13.33,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 15.5,
+                                "min": 14
+                            },
+                            "late_century": {
+                                "max": 17,
+                                "mean": 16,
+                                "min": 14
+                            },
+                            "mid_century": {
+                                "max": 19,
+                                "mean": 16.33,
+                                "min": 15
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 268,
+                                "mean": 204.67,
+                                "min": 169
+                            },
+                            "historical": {
+                                "max": 182,
+                                "mean": 116,
+                                "min": 63
+                            },
+                            "late_century": {
+                                "max": 201,
+                                "mean": 181,
+                                "min": 166
+                            },
+                            "mid_century": {
+                                "max": 215,
+                                "mean": 175.67,
+                                "min": 153
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 16,
+                                "mean": 8,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 6.67,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": -0.33,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 38,
+                                "mean": 17.33,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 6,
+                                "mean": 3.67,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 13,
+                                "mean": 11.67,
+                                "min": 10
+                            },
+                            "mid_century": {
+                                "max": 10,
+                                "mean": 8.33,
+                                "min": 7
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 13,
+                                "mean": 11.33,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 11,
+                                "mean": 10.67,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 13,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 14,
+                                "mean": 11.67,
+                                "min": 10
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 19.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 30,
+                                "mean": 19.33,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 21,
+                                "mean": 17,
+                                "min": 12
+                            },
+                            "mid_century": {
+                                "max": 37,
+                                "mean": 29.67,
+                                "min": 23
+                            }
+                        }
+                    }
+                }
+            },
+            "inmcm4": {
+                "rcp45": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 81.67,
+                                "mean": 18.89,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 83.67,
+                                "mean": 18.69,
+                                "min": -1.67
+                            },
+                            "late_century": {
+                                "max": 78.67,
+                                "mean": 19.42,
+                                "min": -2.67
+                            },
+                            "mid_century": {
+                                "max": 81,
+                                "mean": 18.89,
+                                "min": -2.33
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 124.67,
+                                "mean": 24.25,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 102.17,
+                                "mean": 20.67,
+                                "min": 0.17
+                            },
+                            "late_century": {
+                                "max": 113.67,
+                                "mean": 27.17,
+                                "min": 0.67
+                            },
+                            "mid_century": {
+                                "max": 94.67,
+                                "mean": 25.25,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 9
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 8
+                            },
+                            "mid_century": {
+                                "total": 9
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 24
+                            },
+                            "historical": {
+                                "total": 20
+                            },
+                            "late_century": {
+                                "total": 34
+                            },
+                            "mid_century": {
+                                "total": 37
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 25
+                            },
+                            "historical": {
+                                "total": 22
+                            },
+                            "late_century": {
+                                "total": 26
+                            },
+                            "mid_century": {
+                                "total": 26
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 197
+                            },
+                            "historical": {
+                                "total": 148
+                            },
+                            "late_century": {
+                                "total": 214
+                            },
+                            "mid_century": {
+                                "total": 192
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 198
+                            },
+                            "historical": {
+                                "total": 197
+                            },
+                            "late_century": {
+                                "total": 204
+                            },
+                            "mid_century": {
+                                "total": 196
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 69
+                            },
+                            "historical": {
+                                "total": 78
+                            },
+                            "late_century": {
+                                "total": 74
+                            },
+                            "mid_century": {
+                                "total": 74
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -5
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -6
+                            },
+                            "mid_century": {
+                                "total": -5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 4
+                            },
+                            "mid_century": {
+                                "total": 0
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 6.33,
+                                "min": 5
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 5
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 3
+                            },
+                            "mid_century": {
+                                "max": 7,
+                                "mean": 5.33,
+                                "min": 3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 108,
+                                "mean": 70,
+                                "min": 32
+                            },
+                            "historical": {
+                                "max": 51,
+                                "mean": 44.5,
+                                "min": 36
+                            },
+                            "late_century": {
+                                "max": 120,
+                                "mean": 97,
+                                "min": 75
+                            },
+                            "mid_century": {
+                                "max": 110,
+                                "mean": 93.33,
+                                "min": 64
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 53,
+                                "mean": 50,
+                                "min": 47
+                            },
+                            "historical": {
+                                "max": 51,
+                                "mean": 47.33,
+                                "min": 42
+                            },
+                            "late_century": {
+                                "max": 57,
+                                "mean": 54.67,
+                                "min": 52
+                            },
+                            "mid_century": {
+                                "max": 49,
+                                "mean": 47.33,
+                                "min": 46
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 26,
+                                "mean": 19.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 16,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 23,
+                                "mean": 20,
+                                "min": 17
+                            },
+                            "mid_century": {
+                                "max": 30,
+                                "mean": 19.67,
+                                "min": 12
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 2,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.33,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 3,
+                                "mean": 1,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 86,
+                                "mean": 81.67,
+                                "min": 79
+                            },
+                            "historical": {
+                                "max": 88,
+                                "mean": 83.67,
+                                "min": 79
+                            },
+                            "late_century": {
+                                "max": 82,
+                                "mean": 78.67,
+                                "min": 74
+                            },
+                            "mid_century": {
+                                "max": 87,
+                                "mean": 81,
+                                "min": 77
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 23,
+                                "mean": 16.67,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 13.67,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 31,
+                                "mean": 24,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 21.33,
+                                "min": 14
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 68,
+                                "mean": 66.67,
+                                "min": 64
+                            },
+                            "historical": {
+                                "max": 68,
+                                "mean": 66.17,
+                                "min": 64
+                            },
+                            "late_century": {
+                                "max": 73,
+                                "mean": 71,
+                                "min": 68
+                            },
+                            "mid_century": {
+                                "max": 73,
+                                "mean": 68,
+                                "min": 64
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 58,
+                                "mean": 32.67,
+                                "min": 13
+                            },
+                            "historical": {
+                                "max": 91,
+                                "mean": 48.33,
+                                "min": 21
+                            },
+                            "late_century": {
+                                "max": 32,
+                                "mean": 30.33,
+                                "min": 28
+                            },
+                            "mid_century": {
+                                "max": 39,
+                                "mean": 33,
+                                "min": 23
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 2,
+                                "mean": 1.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 2,
+                                "mean": 1,
+                                "min": 0
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 7,
+                                "mean": 2.67,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 6,
+                                "mean": 1.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 6,
+                                "mean": 3.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 5,
+                                "mean": 4.33,
+                                "min": 3
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 20,
+                                "mean": 17,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 14.5,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 20,
+                                "mean": 19.33,
+                                "min": 18
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 20,
+                                "min": 18
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 202,
+                                "mean": 124.67,
+                                "min": 56
+                            },
+                            "historical": {
+                                "max": 137,
+                                "mean": 102.17,
+                                "min": 72
+                            },
+                            "late_century": {
+                                "max": 127,
+                                "mean": 113.67,
+                                "min": 106
+                            },
+                            "mid_century": {
+                                "max": 102,
+                                "mean": 94.67,
+                                "min": 89
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 6,
+                                "mean": 2.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 10,
+                                "mean": 6,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 26,
+                                "mean": 10.33,
+                                "min": 1
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.83,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 0,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 3,
+                                "min": 3
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 5,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 10,
+                                "mean": 7.33,
+                                "min": 6
+                            },
+                            "mid_century": {
+                                "max": 11,
+                                "mean": 7.33,
+                                "min": 3
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 12,
+                                "mean": 11.67,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.83,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 12,
+                                "mean": 11.33,
+                                "min": 10
+                            },
+                            "mid_century": {
+                                "max": 11,
+                                "mean": 11,
+                                "min": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 23,
+                                "mean": 18.33,
+                                "min": 12
+                            },
+                            "historical": {
+                                "max": 26,
+                                "mean": 14.83,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 29,
+                                "mean": 20.33,
+                                "min": 10
+                            },
+                            "mid_century": {
+                                "max": 23,
+                                "mean": 19,
+                                "min": 16
+                            }
+                        }
+                    }
+                },
+                "rcp85": {
+                    "Annual": {
+                        "evap": {
+                            "early_century": {
+                                "max": 78.67,
+                                "mean": 19.19,
+                                "min": -2.33
+                            },
+                            "historical": {
+                                "max": 84.67,
+                                "mean": 18.82,
+                                "min": -1.83
+                            },
+                            "late_century": {
+                                "max": 77,
+                                "mean": 18.83,
+                                "min": -3.33
+                            },
+                            "mid_century": {
+                                "max": 79.67,
+                                "mean": 19.22,
+                                "min": -2.67
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 112.33,
+                                "mean": 22.61,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 104.5,
+                                "mean": 20.81,
+                                "min": 0.17
+                            },
+                            "late_century": {
+                                "max": 161.33,
+                                "mean": 34.42,
+                                "min": 1.33
+                            },
+                            "mid_century": {
+                                "max": 142.33,
+                                "mean": 33.19,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "Fall": {
+                        "evap": {
+                            "early_century": {
+                                "total": 8
+                            },
+                            "historical": {
+                                "total": 8
+                            },
+                            "late_century": {
+                                "total": 11
+                            },
+                            "mid_century": {
+                                "total": 9
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 28
+                            },
+                            "historical": {
+                                "total": 19
+                            },
+                            "late_century": {
+                                "total": 47
+                            },
+                            "mid_century": {
+                                "total": 38
+                            }
+                        }
+                    },
+                    "Spring": {
+                        "evap": {
+                            "early_century": {
+                                "total": 26
+                            },
+                            "historical": {
+                                "total": 23
+                            },
+                            "late_century": {
+                                "total": 26
+                            },
+                            "mid_century": {
+                                "total": 27
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 171
+                            },
+                            "historical": {
+                                "total": 150
+                            },
+                            "late_century": {
+                                "total": 262
+                            },
+                            "mid_century": {
+                                "total": 228
+                            }
+                        }
+                    },
+                    "Summer": {
+                        "evap": {
+                            "early_century": {
+                                "total": 200
+                            },
+                            "historical": {
+                                "total": 198
+                            },
+                            "late_century": {
+                                "total": 197
+                            },
+                            "mid_century": {
+                                "total": 201
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 72
+                            },
+                            "historical": {
+                                "total": 79
+                            },
+                            "late_century": {
+                                "total": 96
+                            },
+                            "mid_century": {
+                                "total": 122
+                            }
+                        }
+                    },
+                    "Winter": {
+                        "evap": {
+                            "early_century": {
+                                "total": -4
+                            },
+                            "historical": {
+                                "total": -4
+                            },
+                            "late_century": {
+                                "total": -8
+                            },
+                            "mid_century": {
+                                "total": -6
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "total": 1
+                            },
+                            "historical": {
+                                "total": 1
+                            },
+                            "late_century": {
+                                "total": 8
+                            },
+                            "mid_century": {
+                                "total": 11
+                            }
+                        }
+                    },
+                    "apr": {
+                        "evap": {
+                            "early_century": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 6
+                            },
+                            "historical": {
+                                "max": 8,
+                                "mean": 7,
+                                "min": 5
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 3,
+                                "min": 2
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 6.67,
+                                "min": 5
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 61,
+                                "mean": 57,
+                                "min": 53
+                            },
+                            "historical": {
+                                "max": 51,
+                                "mean": 44.17,
+                                "min": 36
+                            },
+                            "late_century": {
+                                "max": 179,
+                                "mean": 161.33,
+                                "min": 135
+                            },
+                            "mid_century": {
+                                "max": 97,
+                                "mean": 76.67,
+                                "min": 65
+                            }
+                        }
+                    },
+                    "aug": {
+                        "evap": {
+                            "early_century": {
+                                "max": 52,
+                                "mean": 51.33,
+                                "min": 50
+                            },
+                            "historical": {
+                                "max": 51,
+                                "mean": 47.5,
+                                "min": 42
+                            },
+                            "late_century": {
+                                "max": 53,
+                                "mean": 52.67,
+                                "min": 52
+                            },
+                            "mid_century": {
+                                "max": 55,
+                                "mean": 52,
+                                "min": 50
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 23,
+                                "mean": 17.33,
+                                "min": 14
+                            },
+                            "historical": {
+                                "max": 23,
+                                "mean": 16.33,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 31,
+                                "mean": 26.33,
+                                "min": 20
+                            },
+                            "mid_century": {
+                                "max": 28,
+                                "mean": 23.33,
+                                "min": 17
+                            }
+                        }
+                    },
+                    "dec": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.5,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3.33,
+                                "min": -4
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 3,
+                                "mean": 0.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 7,
+                                "mean": 4.33,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 22,
+                                "mean": 7.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "feb": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -2,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 5,
+                                "mean": 2.67,
+                                "min": 1
+                            },
+                            "mid_century": {
+                                "max": 8,
+                                "mean": 3.67,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jan": {
+                        "evap": {
+                            "early_century": {
+                                "max": -1,
+                                "mean": -1,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.17,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -1,
+                                "mean": -1.67,
+                                "min": -2
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": 0
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.17,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 4,
+                                "mean": 1.33,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "jul": {
+                        "evap": {
+                            "early_century": {
+                                "max": 84,
+                                "mean": 78.67,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 88,
+                                "mean": 84.67,
+                                "min": 79
+                            },
+                            "late_century": {
+                                "max": 80,
+                                "mean": 77,
+                                "min": 72
+                            },
+                            "mid_century": {
+                                "max": 81,
+                                "mean": 79.67,
+                                "min": 77
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 14,
+                                "mean": 11.33,
+                                "min": 10
+                            },
+                            "historical": {
+                                "max": 29,
+                                "mean": 16.67,
+                                "min": 8
+                            },
+                            "late_century": {
+                                "max": 43,
+                                "mean": 32,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 57,
+                                "mean": 44,
+                                "min": 21
+                            }
+                        }
+                    },
+                    "jun": {
+                        "evap": {
+                            "early_century": {
+                                "max": 71,
+                                "mean": 70.33,
+                                "min": 70
+                            },
+                            "historical": {
+                                "max": 69,
+                                "mean": 66.33,
+                                "min": 64
+                            },
+                            "late_century": {
+                                "max": 72,
+                                "mean": 67.67,
+                                "min": 65
+                            },
+                            "mid_century": {
+                                "max": 73,
+                                "mean": 69.33,
+                                "min": 64
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 56,
+                                "mean": 43,
+                                "min": 34
+                            },
+                            "historical": {
+                                "max": 91,
+                                "mean": 46.33,
+                                "min": 13
+                            },
+                            "late_century": {
+                                "max": 46,
+                                "mean": 38,
+                                "min": 32
+                            },
+                            "mid_century": {
+                                "max": 99,
+                                "mean": 54.33,
+                                "min": 28
+                            }
+                        }
+                    },
+                    "mar": {
+                        "evap": {
+                            "early_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 1,
+                                "mean": 0.83,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 1,
+                                "mean": 0.33,
+                                "min": -1
+                            },
+                            "mid_century": {
+                                "max": 1,
+                                "mean": 1,
+                                "min": 1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 2,
+                                "mean": 1.67,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 6,
+                                "mean": 1.5,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 44,
+                                "mean": 31,
+                                "min": 19
+                            },
+                            "mid_century": {
+                                "max": 12,
+                                "mean": 8.67,
+                                "min": 2
+                            }
+                        }
+                    },
+                    "may": {
+                        "evap": {
+                            "early_century": {
+                                "max": 22,
+                                "mean": 18.33,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 17,
+                                "mean": 14.83,
+                                "min": 12
+                            },
+                            "late_century": {
+                                "max": 25,
+                                "mean": 23,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 23,
+                                "mean": 19.33,
+                                "min": 16
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 182,
+                                "mean": 112.33,
+                                "min": 65
+                            },
+                            "historical": {
+                                "max": 151,
+                                "mean": 104.5,
+                                "min": 72
+                            },
+                            "late_century": {
+                                "max": 128,
+                                "mean": 69.33,
+                                "min": 29
+                            },
+                            "mid_century": {
+                                "max": 172,
+                                "mean": 142.33,
+                                "min": 97
+                            }
+                        }
+                    },
+                    "nov": {
+                        "evap": {
+                            "early_century": {
+                                "max": -2,
+                                "mean": -2.33,
+                                "min": -3
+                            },
+                            "historical": {
+                                "max": -1,
+                                "mean": -1.83,
+                                "min": -2
+                            },
+                            "late_century": {
+                                "max": -3,
+                                "mean": -3,
+                                "min": -3
+                            },
+                            "mid_century": {
+                                "max": -2,
+                                "mean": -2.67,
+                                "min": -3
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 3,
+                                "mean": 2.33,
+                                "min": 1
+                            },
+                            "historical": {
+                                "max": 2,
+                                "mean": 0.67,
+                                "min": 0
+                            },
+                            "late_century": {
+                                "max": 11,
+                                "mean": 6.67,
+                                "min": 4
+                            },
+                            "mid_century": {
+                                "max": 13,
+                                "mean": 4.33,
+                                "min": 0
+                            }
+                        }
+                    },
+                    "oct": {
+                        "evap": {
+                            "early_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "historical": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            },
+                            "late_century": {
+                                "max": 0,
+                                "mean": 0,
+                                "min": 0
+                            },
+                            "mid_century": {
+                                "max": 0,
+                                "mean": -0.67,
+                                "min": -1
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 9,
+                                "mean": 5.67,
+                                "min": 3
+                            },
+                            "historical": {
+                                "max": 9,
+                                "mean": 5,
+                                "min": 2
+                            },
+                            "late_century": {
+                                "max": 16,
+                                "mean": 12,
+                                "min": 9
+                            },
+                            "mid_century": {
+                                "max": 36,
+                                "mean": 19.33,
+                                "min": 10
+                            }
+                        }
+                    },
+                    "sep": {
+                        "evap": {
+                            "early_century": {
+                                "max": 11,
+                                "mean": 11,
+                                "min": 11
+                            },
+                            "historical": {
+                                "max": 12,
+                                "mean": 10.83,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 14,
+                                "mean": 13.67,
+                                "min": 13
+                            },
+                            "mid_century": {
+                                "max": 13,
+                                "mean": 12,
+                                "min": 11
+                            }
+                        },
+                        "runoff": {
+                            "early_century": {
+                                "max": 27,
+                                "mean": 20,
+                                "min": 16
+                            },
+                            "historical": {
+                                "max": 18,
+                                "mean": 13.5,
+                                "min": 10
+                            },
+                            "late_century": {
+                                "max": 39,
+                                "mean": 28,
+                                "min": 22
+                            },
+                            "mid_century": {
+                                "max": 16,
+                                "mean": 14,
+                                "min": 11
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "permafrost": {
+        "preview": "model,year,scenario,magt0.5m,magt1m,magt2m,magt3m,magt4m,magt5m,magtsurface,permafrostbase,permafrosttop,talikthickness\r\n5ModelAvg,2021,RCP 4.5,-0.5,-0.8,-1.4,-1.9,-2.1,-2.1,0.1,85.3,3.3,0.0\r\n5ModelAvg,2021,RCP 8.5,0.5,0.5,0.3,-0.0,-0.2,-0.2,1.1,84.7,3.5,0.0\r\n5ModelAvg,2022,RCP 4.5,0.6,0.1,-0.6,-1.3,-1.5,-1.5,1.8,85.5,3.4,0.0\r\n5ModelAvg,2022,RCP 8.5,0.1,-0.3,-0.9,-1.4,-1.5,-1.4,1.6,84.6,3.4,0.0\r\n5ModelAvg,2023,RCP 4.5,1.6,1.2,0.6,-0.0,-0.3,-0.4,2.7,85.4,3.5,0.0\r\nNCAR-CCSM4,2098,RCP 8.5,-0.3,-0.3,-0.4,-0.5,-0.6,-0.7,0.3,85.0,3.4,0.0\r\nNCAR-CCSM4,2099,RCP 4.5,1.3,-0.3,-0.4,-0.5,-0.6,-0.7,0.3,85.0,3.4,0.0\r\nNCAR-CCSM4,2099,RCP 8.5,1.3,0.9,0.2,-0.5,-0.7,-0.7,2.6,83.5,3.5,0.0\r\nNCAR-CCSM4,2100,RCP 4.5,2.1,1.8,1.1,0.4,0.2,0.1,3.7,76.8,5.6,2.2\r\nNCAR-CCSM4,2100,RCP 8.5,2.4,2.2,1.8,1.6,1.8,1.9,3.6,76.8,22.3,19.1\r\n",
+        "summary": {
+            "2021-2039": {
+                "gipl1kmmax": {
+                    "magt0.5m": 6.6,
+                    "magt1m": 6.4,
+                    "magt2m": 5.9,
+                    "magt3m": 5.4,
+                    "magt4m": 5.2,
+                    "magt5m": 4.9,
+                    "magtsurface": 7.2,
+                    "permafrostbase": 85.5,
+                    "permafrosttop": 35,
+                    "talikthickness": 34.9
+                },
+                "gipl1kmmean": {
+                    "magt0.5m": 1,
+                    "magt1m": 0.7,
+                    "magt2m": 0.1,
+                    "magt3m": -0.4,
+                    "magt4m": -0.6,
+                    "magt5m": -0.6,
+                    "magtsurface": 2,
+                    "permafrostbase": 82.8,
+                    "permafrosttop": 3.9,
+                    "talikthickness": 0.5
+                },
+                "gipl1kmmin": {
+                    "magt0.5m": -0.5,
+                    "magt1m": -0.8,
+                    "magt2m": -1.4,
+                    "magt3m": -1.9,
+                    "magt4m": -2.1,
+                    "magt5m": -2.1,
+                    "magtsurface": 0.1,
+                    "permafrostbase": 70.8,
+                    "permafrosttop": 3.3,
+                    "talikthickness": 0
+                }
+            },
+            "2040-2069": {
+                "gipl1kmmax": {
+                    "magt0.5m": 4.6,
+                    "magt1m": 4.5,
+                    "magt2m": 4.4,
+                    "magt3m": 4.3,
+                    "magt4m": 4.2,
+                    "magt5m": 4.2,
+                    "magtsurface": 6.2,
+                    "permafrostbase": 85.4,
+                    "permafrosttop": 36,
+                    "talikthickness": 33.9
+                },
+                "gipl1kmmean": {
+                    "magt0.5m": 1.9,
+                    "magt1m": 1.6,
+                    "magt2m": 0.9,
+                    "magt3m": 0.3,
+                    "magt4m": 0.1,
+                    "magt5m": 0,
+                    "magtsurface": 3.2,
+                    "permafrostbase": 78.7,
+                    "permafrosttop": 5,
+                    "talikthickness": 1.6
+                },
+                "gipl1kmmin": {
+                    "magt0.5m": -0.4,
+                    "magt1m": -0.5,
+                    "magt2m": -0.6,
+                    "magt3m": -1.1,
+                    "magt4m": -1.2,
+                    "magt5m": -1.1,
+                    "magtsurface": 0.3,
+                    "permafrostbase": 70.2,
+                    "permafrosttop": 3.4,
+                    "talikthickness": 0
+                }
+            },
+            "2070-2099": {
+                "gipl1kmmax": {
+                    "magt0.5m": 6.5,
+                    "magt1m": 6.2,
+                    "magt2m": 5.6,
+                    "magt3m": 5,
+                    "magt4m": 4.8,
+                    "magt5m": 4.6,
+                    "magtsurface": 7.9,
+                    "permafrostbase": 85.1,
+                    "permafrosttop": 29.9,
+                    "talikthickness": 29.5
+                },
+                "gipl1kmmean": {
+                    "magt0.5m": 3,
+                    "magt1m": 2.7,
+                    "magt2m": 2.2,
+                    "magt3m": 1.7,
+                    "magt4m": 1.5,
+                    "magt5m": 1.3,
+                    "magtsurface": 4.5,
+                    "permafrostbase": 77.7,
+                    "permafrosttop": 13.6,
+                    "talikthickness": 10.9
+                },
+                "gipl1kmmin": {
+                    "magt0.5m": -0.3,
+                    "magt1m": -0.4,
+                    "magt2m": -0.9,
+                    "magt3m": -1.2,
+                    "magt4m": -1.3,
+                    "magt5m": -1.3,
+                    "magtsurface": 0.3,
+                    "permafrostbase": 76.4,
+                    "permafrosttop": 3.4,
+                    "talikthickness": 0
+                }
+            }
+        }
+    },
+    "precip_frequency": {
+        "2": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 94.53,
+                        "pf_lower": 85.76,
+                        "pf_upper": 104.6
+                    },
+                    "2050-2079": {
+                        "pf": 120.07,
+                        "pf_lower": 111.73,
+                        "pf_upper": 129.68
+                    },
+                    "2080-2099": {
+                        "pf": 128.51,
+                        "pf_lower": 114.85,
+                        "pf_upper": 143.26
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 77.22,
+                        "pf_lower": 69.45,
+                        "pf_upper": 86.58
+                    },
+                    "2050-2079": {
+                        "pf": 95.08,
+                        "pf_lower": 82.98,
+                        "pf_upper": 109.53
+                    },
+                    "2080-2099": {
+                        "pf": 87.11,
+                        "pf_lower": 74.24,
+                        "pf_upper": 102.27
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 32.89,
+                        "pf_lower": 29.98,
+                        "pf_upper": 36.43
+                    },
+                    "2050-2079": {
+                        "pf": 40.52,
+                        "pf_lower": 37.41,
+                        "pf_upper": 44
+                    },
+                    "2080-2099": {
+                        "pf": 42.39,
+                        "pf_lower": 38.57,
+                        "pf_upper": 46.28
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 26.27,
+                        "pf_lower": 23.63,
+                        "pf_upper": 29.31
+                    },
+                    "2050-2079": {
+                        "pf": 32.15,
+                        "pf_lower": 28.96,
+                        "pf_upper": 35.2
+                    },
+                    "2080-2099": {
+                        "pf": 27.28,
+                        "pf_lower": 24.41,
+                        "pf_upper": 30.9
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 134.52,
+                        "pf_lower": 124.52,
+                        "pf_upper": 145.93
+                    },
+                    "2050-2079": {
+                        "pf": 168.66,
+                        "pf_lower": 156.72,
+                        "pf_upper": 182.35
+                    },
+                    "2080-2099": {
+                        "pf": 179.53,
+                        "pf_lower": 157.94,
+                        "pf_upper": 203.15
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 109.99,
+                        "pf_lower": 97.74,
+                        "pf_upper": 123.31
+                    },
+                    "2050-2079": {
+                        "pf": 135.41,
+                        "pf_lower": 117.79,
+                        "pf_upper": 154.12
+                    },
+                    "2080-2099": {
+                        "pf": 118.56,
+                        "pf_lower": 102.97,
+                        "pf_upper": 138.62
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 49.49,
+                        "pf_lower": 44.37,
+                        "pf_upper": 55.4
+                    },
+                    "2050-2079": {
+                        "pf": 55.79,
+                        "pf_lower": 50.86,
+                        "pf_upper": 61.35
+                    },
+                    "2080-2099": {
+                        "pf": 52.9,
+                        "pf_lower": 47.88,
+                        "pf_upper": 59.36
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 35.29,
+                        "pf_lower": 31.61,
+                        "pf_upper": 39.59
+                    },
+                    "2050-2079": {
+                        "pf": 44.3,
+                        "pf_lower": 39,
+                        "pf_upper": 49.83
+                    },
+                    "2080-2099": {
+                        "pf": 39.8,
+                        "pf_lower": 35.32,
+                        "pf_upper": 44.92
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 58.34,
+                        "pf_lower": 52.69,
+                        "pf_upper": 65.37
+                    },
+                    "2050-2079": {
+                        "pf": 69.1,
+                        "pf_lower": 63.26,
+                        "pf_upper": 75.88
+                    },
+                    "2080-2099": {
+                        "pf": 63.98,
+                        "pf_lower": 57.64,
+                        "pf_upper": 71.85
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 47.99,
+                        "pf_lower": 43.11,
+                        "pf_upper": 53.84
+                    },
+                    "2050-2079": {
+                        "pf": 57,
+                        "pf_lower": 49.84,
+                        "pf_upper": 64.97
+                    },
+                    "2080-2099": {
+                        "pf": 48.39,
+                        "pf_lower": 42.23,
+                        "pf_upper": 56.46
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 14.26,
+                        "pf_lower": 13.2,
+                        "pf_upper": 15.51
+                    },
+                    "2050-2079": {
+                        "pf": 17,
+                        "pf_lower": 16,
+                        "pf_upper": 18.24
+                    },
+                    "2080-2099": {
+                        "pf": 19.4,
+                        "pf_lower": 17.92,
+                        "pf_upper": 21.33
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 13,
+                        "pf_lower": 12.24,
+                        "pf_upper": 13.91
+                    },
+                    "2050-2079": {
+                        "pf": 13.51,
+                        "pf_lower": 12.71,
+                        "pf_upper": 14.38
+                    },
+                    "2080-2099": {
+                        "pf": 12.95,
+                        "pf_lower": 12.21,
+                        "pf_upper": 13.79
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 183.85,
+                        "pf_lower": 167.28,
+                        "pf_upper": 202.53
+                    },
+                    "2050-2079": {
+                        "pf": 236.6,
+                        "pf_lower": 219,
+                        "pf_upper": 254.38
+                    },
+                    "2080-2099": {
+                        "pf": 233.63,
+                        "pf_lower": 208.86,
+                        "pf_upper": 261.97
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 142.13,
+                        "pf_lower": 125.05,
+                        "pf_upper": 160.42
+                    },
+                    "2050-2079": {
+                        "pf": 173.61,
+                        "pf_lower": 152.89,
+                        "pf_upper": 195.95
+                    },
+                    "2080-2099": {
+                        "pf": 147.84,
+                        "pf_lower": 132.55,
+                        "pf_upper": 170.27
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 69.42,
+                        "pf_lower": 62.81,
+                        "pf_upper": 76.81
+                    },
+                    "2050-2079": {
+                        "pf": 77.27,
+                        "pf_lower": 70.99,
+                        "pf_upper": 84.82
+                    },
+                    "2080-2099": {
+                        "pf": 78.42,
+                        "pf_lower": 69.65,
+                        "pf_upper": 88.1
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 51.98,
+                        "pf_lower": 46.55,
+                        "pf_upper": 58.75
+                    },
+                    "2050-2079": {
+                        "pf": 66.48,
+                        "pf_lower": 57.23,
+                        "pf_upper": 76.44
+                    },
+                    "2080-2099": {
+                        "pf": 54.5,
+                        "pf_lower": 49.2,
+                        "pf_upper": 61.8
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 17.64,
+                        "pf_lower": 16.17,
+                        "pf_upper": 19.37
+                    },
+                    "2050-2079": {
+                        "pf": 21.83,
+                        "pf_lower": 20.45,
+                        "pf_upper": 23.52
+                    },
+                    "2080-2099": {
+                        "pf": 24.15,
+                        "pf_lower": 22.3,
+                        "pf_upper": 26.46
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 15.46,
+                        "pf_lower": 14.44,
+                        "pf_upper": 16.61
+                    },
+                    "2050-2079": {
+                        "pf": 16.43,
+                        "pf_lower": 15.33,
+                        "pf_upper": 17.59
+                    },
+                    "2080-2099": {
+                        "pf": 15.94,
+                        "pf_lower": 14.93,
+                        "pf_upper": 17.05
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 223.66,
+                        "pf_lower": 203.24,
+                        "pf_upper": 245.53
+                    },
+                    "2050-2079": {
+                        "pf": 272.15,
+                        "pf_lower": 254.73,
+                        "pf_upper": 290.55
+                    },
+                    "2080-2099": {
+                        "pf": 282.96,
+                        "pf_lower": 251.3,
+                        "pf_upper": 319.46
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 194.66,
+                        "pf_lower": 171.21,
+                        "pf_upper": 218.97
+                    },
+                    "2050-2079": {
+                        "pf": 220.27,
+                        "pf_lower": 194.34,
+                        "pf_upper": 247.53
+                    },
+                    "2080-2099": {
+                        "pf": 192.55,
+                        "pf_lower": 170.9,
+                        "pf_upper": 223.62
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 75.51,
+                        "pf_lower": 67.6,
+                        "pf_upper": 84.68
+                    },
+                    "2050-2079": {
+                        "pf": 87.79,
+                        "pf_lower": 82.38,
+                        "pf_upper": 94.03
+                    },
+                    "2080-2099": {
+                        "pf": 84.4,
+                        "pf_lower": 76.15,
+                        "pf_upper": 93.64
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 57.1,
+                        "pf_lower": 50.52,
+                        "pf_upper": 65.17
+                    },
+                    "2050-2079": {
+                        "pf": 67.79,
+                        "pf_lower": 58.47,
+                        "pf_upper": 78.81
+                    },
+                    "2080-2099": {
+                        "pf": 60.66,
+                        "pf_lower": 53.25,
+                        "pf_upper": 69.46
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 266.31,
+                        "pf_lower": 242.8,
+                        "pf_upper": 290.92
+                    },
+                    "2050-2079": {
+                        "pf": 335.35,
+                        "pf_lower": 310.43,
+                        "pf_upper": 360.77
+                    },
+                    "2080-2099": {
+                        "pf": 338.01,
+                        "pf_lower": 302.29,
+                        "pf_upper": 378.35
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 206.75,
+                        "pf_lower": 181.48,
+                        "pf_upper": 234.69
+                    },
+                    "2050-2079": {
+                        "pf": 250.47,
+                        "pf_lower": 222.48,
+                        "pf_upper": 279.08
+                    },
+                    "2080-2099": {
+                        "pf": 212.56,
+                        "pf_lower": 187.24,
+                        "pf_upper": 249.08
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 11.04,
+                        "pf_lower": 10.47,
+                        "pf_upper": 11.7
+                    },
+                    "2050-2079": {
+                        "pf": 13.47,
+                        "pf_lower": 12.86,
+                        "pf_upper": 14.26
+                    },
+                    "2080-2099": {
+                        "pf": 15.43,
+                        "pf_lower": 14.52,
+                        "pf_upper": 16.57
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 10.19,
+                        "pf_lower": 9.78,
+                        "pf_upper": 10.71
+                    },
+                    "2050-2079": {
+                        "pf": 10.53,
+                        "pf_lower": 10.06,
+                        "pf_upper": 11.08
+                    },
+                    "2080-2099": {
+                        "pf": 10.08,
+                        "pf_lower": 9.66,
+                        "pf_upper": 10.55
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 25.6,
+                        "pf_lower": 23.38,
+                        "pf_upper": 28.21
+                    },
+                    "2050-2079": {
+                        "pf": 30.07,
+                        "pf_lower": 28.11,
+                        "pf_upper": 32.44
+                    },
+                    "2080-2099": {
+                        "pf": 32.72,
+                        "pf_lower": 30.5,
+                        "pf_upper": 35.39
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 21.61,
+                        "pf_lower": 19.84,
+                        "pf_upper": 23.51
+                    },
+                    "2050-2079": {
+                        "pf": 22.72,
+                        "pf_lower": 21.1,
+                        "pf_upper": 24.41
+                    },
+                    "2080-2099": {
+                        "pf": 21.92,
+                        "pf_lower": 20.07,
+                        "pf_upper": 23.94
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 84.49,
+                        "pf_lower": 77.9,
+                        "pf_upper": 92.14
+                    },
+                    "2050-2079": {
+                        "pf": 106.57,
+                        "pf_lower": 98.18,
+                        "pf_upper": 116.35
+                    },
+                    "2080-2099": {
+                        "pf": 110.5,
+                        "pf_lower": 100.14,
+                        "pf_upper": 122.55
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 69.75,
+                        "pf_lower": 61.93,
+                        "pf_upper": 78.8
+                    },
+                    "2050-2079": {
+                        "pf": 84.41,
+                        "pf_lower": 73.9,
+                        "pf_upper": 96.79
+                    },
+                    "2080-2099": {
+                        "pf": 73.24,
+                        "pf_lower": 65.49,
+                        "pf_upper": 83.16
+                    }
+                }
+            }
+        },
+        "5": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 133.32,
+                        "pf_lower": 120.31,
+                        "pf_upper": 147.52
+                    },
+                    "2050-2079": {
+                        "pf": 161.09,
+                        "pf_lower": 148.7,
+                        "pf_upper": 174.63
+                    },
+                    "2080-2099": {
+                        "pf": 173.75,
+                        "pf_lower": 157.43,
+                        "pf_upper": 189.8
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 104.81,
+                        "pf_lower": 90.95,
+                        "pf_upper": 120.09
+                    },
+                    "2050-2079": {
+                        "pf": 135.79,
+                        "pf_lower": 114.66,
+                        "pf_upper": 158.88
+                    },
+                    "2080-2099": {
+                        "pf": 120.19,
+                        "pf_lower": 101.35,
+                        "pf_upper": 140.83
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 45.34,
+                        "pf_lower": 40.15,
+                        "pf_upper": 51.51
+                    },
+                    "2050-2079": {
+                        "pf": 52.09,
+                        "pf_lower": 47.8,
+                        "pf_upper": 56.62
+                    },
+                    "2080-2099": {
+                        "pf": 52.43,
+                        "pf_lower": 48.22,
+                        "pf_upper": 56.39
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 38.38,
+                        "pf_lower": 34.08,
+                        "pf_upper": 42.95
+                    },
+                    "2050-2079": {
+                        "pf": 43.52,
+                        "pf_lower": 40.47,
+                        "pf_upper": 46.08
+                    },
+                    "2080-2099": {
+                        "pf": 39,
+                        "pf_lower": 34.2,
+                        "pf_upper": 44.63
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 171.85,
+                        "pf_lower": 157.32,
+                        "pf_upper": 187.6
+                    },
+                    "2050-2079": {
+                        "pf": 214.17,
+                        "pf_lower": 196.6,
+                        "pf_upper": 233.31
+                    },
+                    "2080-2099": {
+                        "pf": 234.38,
+                        "pf_lower": 208.07,
+                        "pf_upper": 260.59
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 143.63,
+                        "pf_lower": 126.48,
+                        "pf_upper": 160.92
+                    },
+                    "2050-2079": {
+                        "pf": 180.6,
+                        "pf_lower": 157.87,
+                        "pf_upper": 204.36
+                    },
+                    "2080-2099": {
+                        "pf": 159.71,
+                        "pf_lower": 132.7,
+                        "pf_upper": 191.8
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 69.14,
+                        "pf_lower": 61.44,
+                        "pf_upper": 77.58
+                    },
+                    "2050-2079": {
+                        "pf": 74.29,
+                        "pf_lower": 67.36,
+                        "pf_upper": 81.67
+                    },
+                    "2080-2099": {
+                        "pf": 70.61,
+                        "pf_lower": 62.07,
+                        "pf_upper": 80.8
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 52.03,
+                        "pf_lower": 45.91,
+                        "pf_upper": 58.61
+                    },
+                    "2050-2079": {
+                        "pf": 64.25,
+                        "pf_lower": 57.71,
+                        "pf_upper": 70.52
+                    },
+                    "2080-2099": {
+                        "pf": 55.82,
+                        "pf_lower": 49.68,
+                        "pf_upper": 62.36
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 80.75,
+                        "pf_lower": 70.93,
+                        "pf_upper": 92.14
+                    },
+                    "2050-2079": {
+                        "pf": 91.27,
+                        "pf_lower": 82.14,
+                        "pf_upper": 101.53
+                    },
+                    "2080-2099": {
+                        "pf": 84.11,
+                        "pf_lower": 73.94,
+                        "pf_upper": 95.86
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 71.13,
+                        "pf_lower": 62.58,
+                        "pf_upper": 80.48
+                    },
+                    "2050-2079": {
+                        "pf": 86.5,
+                        "pf_lower": 75.86,
+                        "pf_upper": 97.48
+                    },
+                    "2080-2099": {
+                        "pf": 73.15,
+                        "pf_lower": 62.15,
+                        "pf_upper": 86.37
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 19.92,
+                        "pf_lower": 18.24,
+                        "pf_upper": 21.81
+                    },
+                    "2050-2079": {
+                        "pf": 22.96,
+                        "pf_lower": 21.14,
+                        "pf_upper": 25.12
+                    },
+                    "2080-2099": {
+                        "pf": 26.4,
+                        "pf_lower": 23.81,
+                        "pf_upper": 29.52
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 19,
+                        "pf_lower": 17.66,
+                        "pf_upper": 20.48
+                    },
+                    "2050-2079": {
+                        "pf": 19.09,
+                        "pf_lower": 17.99,
+                        "pf_upper": 20.2
+                    },
+                    "2080-2099": {
+                        "pf": 17.62,
+                        "pf_lower": 16.6,
+                        "pf_upper": 18.78
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 239.1,
+                        "pf_lower": 216.96,
+                        "pf_upper": 262.11
+                    },
+                    "2050-2079": {
+                        "pf": 291.82,
+                        "pf_lower": 274.11,
+                        "pf_upper": 308.15
+                    },
+                    "2080-2099": {
+                        "pf": 302.94,
+                        "pf_lower": 269.01,
+                        "pf_upper": 338.87
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 185.86,
+                        "pf_lower": 162.93,
+                        "pf_upper": 208.63
+                    },
+                    "2050-2079": {
+                        "pf": 226.86,
+                        "pf_lower": 198.84,
+                        "pf_upper": 254.74
+                    },
+                    "2080-2099": {
+                        "pf": 194.86,
+                        "pf_lower": 161.7,
+                        "pf_upper": 238.32
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 90.35,
+                        "pf_lower": 81.21,
+                        "pf_upper": 100.1
+                    },
+                    "2050-2079": {
+                        "pf": 100.11,
+                        "pf_lower": 89.46,
+                        "pf_upper": 112.45
+                    },
+                    "2080-2099": {
+                        "pf": 99.38,
+                        "pf_lower": 88.33,
+                        "pf_upper": 110.61
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 72.71,
+                        "pf_lower": 62.64,
+                        "pf_upper": 84.46
+                    },
+                    "2050-2079": {
+                        "pf": 93.94,
+                        "pf_lower": 81.45,
+                        "pf_upper": 106.33
+                    },
+                    "2080-2099": {
+                        "pf": 73.89,
+                        "pf_lower": 63.55,
+                        "pf_upper": 86.81
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 24.78,
+                        "pf_lower": 22.37,
+                        "pf_upper": 27.54
+                    },
+                    "2050-2079": {
+                        "pf": 29.03,
+                        "pf_lower": 26.58,
+                        "pf_upper": 31.93
+                    },
+                    "2080-2099": {
+                        "pf": 31.55,
+                        "pf_lower": 28.58,
+                        "pf_upper": 34.98
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 22.15,
+                        "pf_lower": 20.54,
+                        "pf_upper": 23.85
+                    },
+                    "2050-2079": {
+                        "pf": 22.99,
+                        "pf_lower": 21.57,
+                        "pf_upper": 24.37
+                    },
+                    "2080-2099": {
+                        "pf": 21.35,
+                        "pf_lower": 20.1,
+                        "pf_upper": 22.6
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 279.35,
+                        "pf_lower": 254.01,
+                        "pf_upper": 304.88
+                    },
+                    "2050-2079": {
+                        "pf": 323.46,
+                        "pf_lower": 302.77,
+                        "pf_upper": 343.94
+                    },
+                    "2080-2099": {
+                        "pf": 357.26,
+                        "pf_lower": 313.16,
+                        "pf_upper": 404.39
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 253.93,
+                        "pf_lower": 225.15,
+                        "pf_upper": 281.27
+                    },
+                    "2050-2079": {
+                        "pf": 287.51,
+                        "pf_lower": 254.45,
+                        "pf_upper": 319.39
+                    },
+                    "2080-2099": {
+                        "pf": 257.57,
+                        "pf_lower": 213.82,
+                        "pf_upper": 317.31
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 105.55,
+                        "pf_lower": 93.41,
+                        "pf_upper": 119.02
+                    },
+                    "2050-2079": {
+                        "pf": 110.19,
+                        "pf_lower": 101.9,
+                        "pf_upper": 119.45
+                    },
+                    "2080-2099": {
+                        "pf": 108.41,
+                        "pf_lower": 97.75,
+                        "pf_upper": 119.4
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 83.74,
+                        "pf_lower": 71.67,
+                        "pf_upper": 98.46
+                    },
+                    "2050-2079": {
+                        "pf": 102.76,
+                        "pf_lower": 86.69,
+                        "pf_upper": 120.21
+                    },
+                    "2080-2099": {
+                        "pf": 83.64,
+                        "pf_lower": 72.55,
+                        "pf_upper": 95.93
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 333.78,
+                        "pf_lower": 306.84,
+                        "pf_upper": 360.01
+                    },
+                    "2050-2079": {
+                        "pf": 408.55,
+                        "pf_lower": 382.4,
+                        "pf_upper": 433.01
+                    },
+                    "2080-2099": {
+                        "pf": 427.25,
+                        "pf_lower": 379.83,
+                        "pf_upper": 476.86
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 277.04,
+                        "pf_lower": 242.26,
+                        "pf_upper": 314.03
+                    },
+                    "2050-2079": {
+                        "pf": 322.35,
+                        "pf_lower": 290.45,
+                        "pf_upper": 353.35
+                    },
+                    "2080-2099": {
+                        "pf": 287.86,
+                        "pf_lower": 236.45,
+                        "pf_upper": 353.73
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 15.09,
+                        "pf_lower": 14.16,
+                        "pf_upper": 16.15
+                    },
+                    "2050-2079": {
+                        "pf": 18.42,
+                        "pf_lower": 17.22,
+                        "pf_upper": 19.91
+                    },
+                    "2080-2099": {
+                        "pf": 20.79,
+                        "pf_lower": 19.29,
+                        "pf_upper": 22.54
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 14.35,
+                        "pf_lower": 13.6,
+                        "pf_upper": 15.24
+                    },
+                    "2050-2079": {
+                        "pf": 14.84,
+                        "pf_lower": 14.07,
+                        "pf_upper": 15.69
+                    },
+                    "2080-2099": {
+                        "pf": 13.31,
+                        "pf_lower": 12.7,
+                        "pf_upper": 14
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 35.08,
+                        "pf_lower": 31.47,
+                        "pf_upper": 39.19
+                    },
+                    "2050-2079": {
+                        "pf": 38.38,
+                        "pf_lower": 35.27,
+                        "pf_upper": 41.86
+                    },
+                    "2080-2099": {
+                        "pf": 40.28,
+                        "pf_lower": 36.95,
+                        "pf_upper": 44
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 30.62,
+                        "pf_lower": 28.21,
+                        "pf_upper": 33.11
+                    },
+                    "2050-2079": {
+                        "pf": 30.78,
+                        "pf_lower": 28.93,
+                        "pf_upper": 32.65
+                    },
+                    "2080-2099": {
+                        "pf": 29.81,
+                        "pf_lower": 27.44,
+                        "pf_upper": 32.3
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 115.01,
+                        "pf_lower": 104.76,
+                        "pf_upper": 126.52
+                    },
+                    "2050-2079": {
+                        "pf": 145.4,
+                        "pf_lower": 132.31,
+                        "pf_upper": 160.11
+                    },
+                    "2080-2099": {
+                        "pf": 147.89,
+                        "pf_lower": 133.25,
+                        "pf_upper": 163.6
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 94.71,
+                        "pf_lower": 82.05,
+                        "pf_upper": 108.58
+                    },
+                    "2050-2079": {
+                        "pf": 118.31,
+                        "pf_lower": 100.69,
+                        "pf_upper": 137.9
+                    },
+                    "2080-2099": {
+                        "pf": 94.98,
+                        "pf_lower": 81.73,
+                        "pf_upper": 111.12
+                    }
+                }
+            }
+        },
+        "10": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 162.63,
+                        "pf_lower": 145.09,
+                        "pf_upper": 182.74
+                    },
+                    "2050-2079": {
+                        "pf": 191.76,
+                        "pf_lower": 175.04,
+                        "pf_upper": 210.96
+                    },
+                    "2080-2099": {
+                        "pf": 203.99,
+                        "pf_lower": 184.69,
+                        "pf_upper": 222.72
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 125.34,
+                        "pf_lower": 104.47,
+                        "pf_upper": 149.65
+                    },
+                    "2050-2079": {
+                        "pf": 165.99,
+                        "pf_lower": 134.68,
+                        "pf_upper": 202.05
+                    },
+                    "2080-2099": {
+                        "pf": 141.3,
+                        "pf_lower": 116.1,
+                        "pf_upper": 168.77
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 56.37,
+                        "pf_lower": 48.39,
+                        "pf_upper": 66.49
+                    },
+                    "2050-2079": {
+                        "pf": 60.61,
+                        "pf_lower": 55.08,
+                        "pf_upper": 66.65
+                    },
+                    "2080-2099": {
+                        "pf": 59.03,
+                        "pf_lower": 54.21,
+                        "pf_upper": 63.54
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 48.51,
+                        "pf_lower": 42.41,
+                        "pf_upper": 55.34
+                    },
+                    "2050-2079": {
+                        "pf": 50.75,
+                        "pf_lower": 47.65,
+                        "pf_upper": 53.36
+                    },
+                    "2080-2099": {
+                        "pf": 48.9,
+                        "pf_lower": 41.98,
+                        "pf_upper": 57
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 197.32,
+                        "pf_lower": 177.94,
+                        "pf_upper": 219.4
+                    },
+                    "2050-2079": {
+                        "pf": 245.47,
+                        "pf_lower": 221.84,
+                        "pf_upper": 272.41
+                    },
+                    "2080-2099": {
+                        "pf": 267.81,
+                        "pf_lower": 236.23,
+                        "pf_upper": 299.02
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 165.43,
+                        "pf_lower": 143.27,
+                        "pf_upper": 188.42
+                    },
+                    "2050-2079": {
+                        "pf": 208.65,
+                        "pf_lower": 180.27,
+                        "pf_upper": 239.01
+                    },
+                    "2080-2099": {
+                        "pf": 190.95,
+                        "pf_lower": 151.1,
+                        "pf_upper": 238.31
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 84.17,
+                        "pf_lower": 73.71,
+                        "pf_upper": 96.25
+                    },
+                    "2050-2079": {
+                        "pf": 87.83,
+                        "pf_lower": 78.79,
+                        "pf_upper": 97.8
+                    },
+                    "2080-2099": {
+                        "pf": 85.63,
+                        "pf_lower": 73.04,
+                        "pf_upper": 100.68
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 66.38,
+                        "pf_lower": 57.56,
+                        "pf_upper": 76.35
+                    },
+                    "2050-2079": {
+                        "pf": 78.69,
+                        "pf_lower": 70.87,
+                        "pf_upper": 86.33
+                    },
+                    "2080-2099": {
+                        "pf": 68.11,
+                        "pf_lower": 60.19,
+                        "pf_upper": 76.43
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 99.75,
+                        "pf_lower": 84.98,
+                        "pf_upper": 117.13
+                    },
+                    "2050-2079": {
+                        "pf": 108.76,
+                        "pf_lower": 95.9,
+                        "pf_upper": 124.1
+                    },
+                    "2080-2099": {
+                        "pf": 100.34,
+                        "pf_lower": 85.88,
+                        "pf_upper": 117.25
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 90.55,
+                        "pf_lower": 77.85,
+                        "pf_upper": 105.21
+                    },
+                    "2050-2079": {
+                        "pf": 108.93,
+                        "pf_lower": 94.65,
+                        "pf_upper": 124.21
+                    },
+                    "2080-2099": {
+                        "pf": 94.2,
+                        "pf_lower": 77.74,
+                        "pf_upper": 113.91
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 24.41,
+                        "pf_lower": 22.04,
+                        "pf_upper": 27.24
+                    },
+                    "2050-2079": {
+                        "pf": 28.21,
+                        "pf_lower": 25.38,
+                        "pf_upper": 31.78
+                    },
+                    "2080-2099": {
+                        "pf": 32.42,
+                        "pf_lower": 28.53,
+                        "pf_upper": 37.16
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 24.36,
+                        "pf_lower": 22.35,
+                        "pf_upper": 26.69
+                    },
+                    "2050-2079": {
+                        "pf": 23.43,
+                        "pf_lower": 22.03,
+                        "pf_upper": 24.88
+                    },
+                    "2080-2099": {
+                        "pf": 21.35,
+                        "pf_lower": 19.98,
+                        "pf_upper": 22.91
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 272.49,
+                        "pf_lower": 244.53,
+                        "pf_upper": 301.63
+                    },
+                    "2050-2079": {
+                        "pf": 319.49,
+                        "pf_lower": 300.6,
+                        "pf_upper": 336.77
+                    },
+                    "2080-2099": {
+                        "pf": 345.54,
+                        "pf_lower": 301.96,
+                        "pf_upper": 392.15
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 210.26,
+                        "pf_lower": 181.47,
+                        "pf_upper": 239.5
+                    },
+                    "2050-2079": {
+                        "pf": 256.8,
+                        "pf_lower": 221.36,
+                        "pf_upper": 292.9
+                    },
+                    "2080-2099": {
+                        "pf": 233.87,
+                        "pf_lower": 178.02,
+                        "pf_upper": 305.05
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 105.2,
+                        "pf_lower": 93.33,
+                        "pf_upper": 118.33
+                    },
+                    "2050-2079": {
+                        "pf": 119.08,
+                        "pf_lower": 103.36,
+                        "pf_upper": 138.46
+                    },
+                    "2080-2099": {
+                        "pf": 113.41,
+                        "pf_lower": 99.89,
+                        "pf_upper": 127.04
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 91.45,
+                        "pf_lower": 77.93,
+                        "pf_upper": 110.73
+                    },
+                    "2050-2079": {
+                        "pf": 110.79,
+                        "pf_lower": 95.07,
+                        "pf_upper": 126.77
+                    },
+                    "2080-2099": {
+                        "pf": 95.15,
+                        "pf_lower": 78.75,
+                        "pf_upper": 115.51
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 30.33,
+                        "pf_lower": 26.85,
+                        "pf_upper": 34.56
+                    },
+                    "2050-2079": {
+                        "pf": 35,
+                        "pf_lower": 31.26,
+                        "pf_upper": 39.72
+                    },
+                    "2080-2099": {
+                        "pf": 37.26,
+                        "pf_lower": 33.04,
+                        "pf_upper": 42.18
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 27.91,
+                        "pf_lower": 25.65,
+                        "pf_upper": 30.4
+                    },
+                    "2050-2079": {
+                        "pf": 28.06,
+                        "pf_lower": 26.32,
+                        "pf_upper": 29.8
+                    },
+                    "2080-2099": {
+                        "pf": 25.47,
+                        "pf_lower": 23.96,
+                        "pf_upper": 26.97
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 310.02,
+                        "pf_lower": 279.58,
+                        "pf_upper": 341.49
+                    },
+                    "2050-2079": {
+                        "pf": 350.1,
+                        "pf_lower": 325.95,
+                        "pf_upper": 374.33
+                    },
+                    "2080-2099": {
+                        "pf": 401.95,
+                        "pf_lower": 344.83,
+                        "pf_upper": 463.41
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 285.17,
+                        "pf_lower": 251.31,
+                        "pf_upper": 317.93
+                    },
+                    "2050-2079": {
+                        "pf": 324.07,
+                        "pf_lower": 284.17,
+                        "pf_upper": 363.2
+                    },
+                    "2080-2099": {
+                        "pf": 310.78,
+                        "pf_lower": 238.09,
+                        "pf_upper": 407.84
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 129.99,
+                        "pf_lower": 113.25,
+                        "pf_upper": 149.62
+                    },
+                    "2050-2079": {
+                        "pf": 129.02,
+                        "pf_lower": 117.35,
+                        "pf_upper": 143.02
+                    },
+                    "2080-2099": {
+                        "pf": 126.28,
+                        "pf_lower": 113.05,
+                        "pf_upper": 139.97
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 106.06,
+                        "pf_lower": 87.19,
+                        "pf_upper": 129.46
+                    },
+                    "2050-2079": {
+                        "pf": 130.4,
+                        "pf_lower": 106.78,
+                        "pf_upper": 157.41
+                    },
+                    "2080-2099": {
+                        "pf": 99.77,
+                        "pf_lower": 84.74,
+                        "pf_upper": 116.38
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 367.19,
+                        "pf_lower": 336.43,
+                        "pf_upper": 397.38
+                    },
+                    "2050-2079": {
+                        "pf": 442.09,
+                        "pf_lower": 413.74,
+                        "pf_upper": 468.54
+                    },
+                    "2080-2099": {
+                        "pf": 476.63,
+                        "pf_lower": 416.76,
+                        "pf_upper": 539.32
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 320.23,
+                        "pf_lower": 275.51,
+                        "pf_upper": 368.9
+                    },
+                    "2050-2079": {
+                        "pf": 360.32,
+                        "pf_lower": 324.22,
+                        "pf_upper": 395.57
+                    },
+                    "2080-2099": {
+                        "pf": 349.2,
+                        "pf_lower": 265.94,
+                        "pf_upper": 455.32
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 18.39,
+                        "pf_lower": 17.03,
+                        "pf_upper": 20.04
+                    },
+                    "2050-2079": {
+                        "pf": 23.07,
+                        "pf_lower": 21.08,
+                        "pf_upper": 25.62
+                    },
+                    "2080-2099": {
+                        "pf": 25.18,
+                        "pf_lower": 23.01,
+                        "pf_upper": 27.76
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 18,
+                        "pf_lower": 16.84,
+                        "pf_upper": 19.42
+                    },
+                    "2050-2079": {
+                        "pf": 18.37,
+                        "pf_lower": 17.24,
+                        "pf_upper": 19.63
+                    },
+                    "2080-2099": {
+                        "pf": 15.76,
+                        "pf_lower": 14.93,
+                        "pf_upper": 16.68
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 42.3,
+                        "pf_lower": 37.13,
+                        "pf_upper": 48.58
+                    },
+                    "2050-2079": {
+                        "pf": 44.59,
+                        "pf_lower": 40.15,
+                        "pf_upper": 49.6
+                    },
+                    "2080-2099": {
+                        "pf": 45.78,
+                        "pf_lower": 41.24,
+                        "pf_upper": 50.88
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 37.85,
+                        "pf_lower": 34.71,
+                        "pf_upper": 41.13
+                    },
+                    "2050-2079": {
+                        "pf": 36.78,
+                        "pf_lower": 34.62,
+                        "pf_upper": 38.92
+                    },
+                    "2080-2099": {
+                        "pf": 35.95,
+                        "pf_lower": 33.05,
+                        "pf_upper": 39.05
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 137.49,
+                        "pf_lower": 123.11,
+                        "pf_upper": 154.58
+                    },
+                    "2050-2079": {
+                        "pf": 174.11,
+                        "pf_lower": 155.73,
+                        "pf_upper": 195.89
+                    },
+                    "2080-2099": {
+                        "pf": 173.62,
+                        "pf_lower": 154.52,
+                        "pf_upper": 194.29
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 112.57,
+                        "pf_lower": 94.16,
+                        "pf_upper": 133.6
+                    },
+                    "2050-2079": {
+                        "pf": 143.41,
+                        "pf_lower": 117.16,
+                        "pf_upper": 173.86
+                    },
+                    "2080-2099": {
+                        "pf": 110.92,
+                        "pf_lower": 91.61,
+                        "pf_upper": 135.41
+                    }
+                }
+            }
+        },
+        "25": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 204.22,
+                        "pf_lower": 177.1,
+                        "pf_upper": 237.09
+                    },
+                    "2050-2079": {
+                        "pf": 235,
+                        "pf_lower": 209.12,
+                        "pf_upper": 266.43
+                    },
+                    "2080-2099": {
+                        "pf": 242.73,
+                        "pf_lower": 217.14,
+                        "pf_upper": 270.18
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 154.78,
+                        "pf_lower": 119.79,
+                        "pf_upper": 202.23
+                    },
+                    "2050-2079": {
+                        "pf": 208.78,
+                        "pf_lower": 156.94,
+                        "pf_upper": 277.97
+                    },
+                    "2080-2099": {
+                        "pf": 167.24,
+                        "pf_lower": 129.68,
+                        "pf_upper": 211.47
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 74.26,
+                        "pf_lower": 60.26,
+                        "pf_upper": 93.9
+                    },
+                    "2050-2079": {
+                        "pf": 72.24,
+                        "pf_lower": 64.07,
+                        "pf_upper": 81.67
+                    },
+                    "2080-2099": {
+                        "pf": 67.41,
+                        "pf_lower": 61.15,
+                        "pf_upper": 74.2
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 64.13,
+                        "pf_lower": 54.46,
+                        "pf_upper": 76.61
+                    },
+                    "2050-2079": {
+                        "pf": 59.72,
+                        "pf_lower": 56.02,
+                        "pf_upper": 63.21
+                    },
+                    "2080-2099": {
+                        "pf": 64.33,
+                        "pf_lower": 53.13,
+                        "pf_upper": 78.9
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 231.02,
+                        "pf_lower": 201.24,
+                        "pf_upper": 266.81
+                    },
+                    "2050-2079": {
+                        "pf": 287.35,
+                        "pf_lower": 251.01,
+                        "pf_upper": 331.35
+                    },
+                    "2080-2099": {
+                        "pf": 307.77,
+                        "pf_lower": 265.41,
+                        "pf_upper": 354.06
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 192.92,
+                        "pf_lower": 160.85,
+                        "pf_upper": 229.69
+                    },
+                    "2050-2079": {
+                        "pf": 242.71,
+                        "pf_lower": 203.21,
+                        "pf_upper": 286.8
+                    },
+                    "2080-2099": {
+                        "pf": 236.62,
+                        "pf_lower": 170.78,
+                        "pf_upper": 325.01
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 105.99,
+                        "pf_lower": 89.69,
+                        "pf_upper": 125.9
+                    },
+                    "2050-2079": {
+                        "pf": 106.75,
+                        "pf_lower": 93.19,
+                        "pf_upper": 122.64
+                    },
+                    "2080-2099": {
+                        "pf": 109.34,
+                        "pf_lower": 88.7,
+                        "pf_upper": 138.04
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 89.27,
+                        "pf_lower": 75.12,
+                        "pf_upper": 107.77
+                    },
+                    "2050-2079": {
+                        "pf": 98.69,
+                        "pf_lower": 88.05,
+                        "pf_upper": 109.8
+                    },
+                    "2080-2099": {
+                        "pf": 85.92,
+                        "pf_lower": 74.47,
+                        "pf_upper": 98.82
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 129.67,
+                        "pf_lower": 104.67,
+                        "pf_upper": 163.34
+                    },
+                    "2050-2079": {
+                        "pf": 134.49,
+                        "pf_lower": 113.62,
+                        "pf_upper": 161.33
+                    },
+                    "2080-2099": {
+                        "pf": 124.57,
+                        "pf_lower": 101.61,
+                        "pf_upper": 155.71
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 121.01,
+                        "pf_lower": 99.89,
+                        "pf_upper": 149.26
+                    },
+                    "2050-2079": {
+                        "pf": 140.99,
+                        "pf_lower": 119.54,
+                        "pf_upper": 166.71
+                    },
+                    "2080-2099": {
+                        "pf": 127.62,
+                        "pf_lower": 100.09,
+                        "pf_upper": 165.03
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 31.05,
+                        "pf_lower": 27.22,
+                        "pf_upper": 35.94
+                    },
+                    "2050-2079": {
+                        "pf": 36.8,
+                        "pf_lower": 31.75,
+                        "pf_upper": 43.92
+                    },
+                    "2080-2099": {
+                        "pf": 42.08,
+                        "pf_lower": 35.56,
+                        "pf_upper": 51.44
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 33.1,
+                        "pf_lower": 29.76,
+                        "pf_upper": 37.58
+                    },
+                    "2050-2079": {
+                        "pf": 29.66,
+                        "pf_lower": 27.63,
+                        "pf_upper": 31.98
+                    },
+                    "2080-2099": {
+                        "pf": 26.81,
+                        "pf_lower": 24.82,
+                        "pf_upper": 29.33
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 312.1,
+                        "pf_lower": 272.46,
+                        "pf_upper": 356.23
+                    },
+                    "2050-2079": {
+                        "pf": 347.76,
+                        "pf_lower": 324.07,
+                        "pf_upper": 371.25
+                    },
+                    "2080-2099": {
+                        "pf": 397.08,
+                        "pf_lower": 334.38,
+                        "pf_upper": 473.39
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 236.9,
+                        "pf_lower": 196.08,
+                        "pf_upper": 281.85
+                    },
+                    "2050-2079": {
+                        "pf": 289.81,
+                        "pf_lower": 239.52,
+                        "pf_upper": 345.51
+                    },
+                    "2080-2099": {
+                        "pf": 297.57,
+                        "pf_lower": 191.07,
+                        "pf_upper": 450.99
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 130.97,
+                        "pf_lower": 113.47,
+                        "pf_upper": 163.51
+                    },
+                    "2050-2079": {
+                        "pf": 147.91,
+                        "pf_lower": 121.49,
+                        "pf_upper": 183.24
+                    },
+                    "2080-2099": {
+                        "pf": 131.22,
+                        "pf_lower": 112.74,
+                        "pf_upper": 155.86
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 122.22,
+                        "pf_lower": 99.99,
+                        "pf_upper": 161.64
+                    },
+                    "2050-2079": {
+                        "pf": 142.4,
+                        "pf_lower": 120.09,
+                        "pf_upper": 167.07
+                    },
+                    "2080-2099": {
+                        "pf": 128.9,
+                        "pf_lower": 100.19,
+                        "pf_upper": 170.38
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 38.2,
+                        "pf_lower": 32.47,
+                        "pf_upper": 45.72
+                    },
+                    "2050-2079": {
+                        "pf": 44.03,
+                        "pf_lower": 37.44,
+                        "pf_upper": 53.22
+                    },
+                    "2080-2099": {
+                        "pf": 45.28,
+                        "pf_lower": 38.6,
+                        "pf_upper": 54.3
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 36.76,
+                        "pf_lower": 33.24,
+                        "pf_upper": 41.21
+                    },
+                    "2050-2079": {
+                        "pf": 35.15,
+                        "pf_lower": 32.71,
+                        "pf_upper": 37.84
+                    },
+                    "2080-2099": {
+                        "pf": 31.16,
+                        "pf_lower": 29.09,
+                        "pf_upper": 33.38
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 343.42,
+                        "pf_lower": 301.32,
+                        "pf_upper": 389.26
+                    },
+                    "2050-2079": {
+                        "pf": 377.91,
+                        "pf_lower": 345.38,
+                        "pf_upper": 412.26
+                    },
+                    "2080-2099": {
+                        "pf": 454.93,
+                        "pf_lower": 372.25,
+                        "pf_upper": 555.73
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 317.38,
+                        "pf_lower": 271.9,
+                        "pf_upper": 364.07
+                    },
+                    "2050-2079": {
+                        "pf": 362.98,
+                        "pf_lower": 308.17,
+                        "pf_upper": 421.11
+                    },
+                    "2080-2099": {
+                        "pf": 395.71,
+                        "pf_lower": 262.06,
+                        "pf_upper": 600.64
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 166.15,
+                        "pf_lower": 139.68,
+                        "pf_upper": 198.88
+                    },
+                    "2050-2079": {
+                        "pf": 157.62,
+                        "pf_lower": 138.47,
+                        "pf_upper": 183.42
+                    },
+                    "2080-2099": {
+                        "pf": 150.6,
+                        "pf_lower": 132.21,
+                        "pf_upper": 171.96
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 140.96,
+                        "pf_lower": 108.23,
+                        "pf_upper": 187.61
+                    },
+                    "2050-2079": {
+                        "pf": 171.13,
+                        "pf_lower": 132.44,
+                        "pf_upper": 222.44
+                    },
+                    "2080-2099": {
+                        "pf": 130.19,
+                        "pf_lower": 107.51,
+                        "pf_upper": 170.55
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 398.95,
+                        "pf_lower": 358.53,
+                        "pf_upper": 441.07
+                    },
+                    "2050-2079": {
+                        "pf": 471.61,
+                        "pf_lower": 436.05,
+                        "pf_upper": 507.15
+                    },
+                    "2080-2099": {
+                        "pf": 529.64,
+                        "pf_lower": 445.42,
+                        "pf_upper": 628.8
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 371.2,
+                        "pf_lower": 306.94,
+                        "pf_upper": 447.26
+                    },
+                    "2050-2079": {
+                        "pf": 399.16,
+                        "pf_lower": 352.44,
+                        "pf_upper": 448.47
+                    },
+                    "2080-2099": {
+                        "pf": 445.73,
+                        "pf_lower": 295.09,
+                        "pf_upper": 659.81
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 23.32,
+                        "pf_lower": 21.08,
+                        "pf_upper": 26.3
+                    },
+                    "2050-2079": {
+                        "pf": 31.04,
+                        "pf_lower": 27.27,
+                        "pf_upper": 36.41
+                    },
+                    "2080-2099": {
+                        "pf": 31.83,
+                        "pf_lower": 28.31,
+                        "pf_upper": 36.72
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 23.88,
+                        "pf_lower": 21.86,
+                        "pf_upper": 26.73
+                    },
+                    "2050-2079": {
+                        "pf": 23.77,
+                        "pf_lower": 21.87,
+                        "pf_upper": 26.27
+                    },
+                    "2080-2099": {
+                        "pf": 19.19,
+                        "pf_lower": 17.94,
+                        "pf_upper": 20.75
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 52.44,
+                        "pf_lower": 43.95,
+                        "pf_upper": 63.53
+                    },
+                    "2050-2079": {
+                        "pf": 53.1,
+                        "pf_lower": 46.05,
+                        "pf_upper": 62.17
+                    },
+                    "2080-2099": {
+                        "pf": 53.11,
+                        "pf_lower": 46.2,
+                        "pf_upper": 61.96
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 48.28,
+                        "pf_lower": 43.67,
+                        "pf_upper": 53.55
+                    },
+                    "2050-2079": {
+                        "pf": 44.9,
+                        "pf_lower": 42.04,
+                        "pf_upper": 47.85
+                    },
+                    "2080-2099": {
+                        "pf": 44.59,
+                        "pf_lower": 40.62,
+                        "pf_upper": 49.23
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 168.99,
+                        "pf_lower": 145.92,
+                        "pf_upper": 199.08
+                    },
+                    "2050-2079": {
+                        "pf": 214.35,
+                        "pf_lower": 184.84,
+                        "pf_upper": 251.57
+                    },
+                    "2080-2099": {
+                        "pf": 207.42,
+                        "pf_lower": 179.65,
+                        "pf_upper": 241.43
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 142.37,
+                        "pf_lower": 112.3,
+                        "pf_upper": 187.8
+                    },
+                    "2050-2079": {
+                        "pf": 178.69,
+                        "pf_lower": 134.79,
+                        "pf_upper": 236.74
+                    },
+                    "2080-2099": {
+                        "pf": 133.31,
+                        "pf_lower": 107.62,
+                        "pf_upper": 180.22
+                    }
+                }
+            }
+        },
+        "50": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 239,
+                        "pf_lower": 203,
+                        "pf_upper": 288.12
+                    },
+                    "2050-2079": {
+                        "pf": 271.06,
+                        "pf_lower": 236.59,
+                        "pf_upper": 318.24
+                    },
+                    "2080-2099": {
+                        "pf": 272.41,
+                        "pf_lower": 241.28,
+                        "pf_upper": 311.35
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 180.03,
+                        "pf_lower": 133.4,
+                        "pf_upper": 258.25
+                    },
+                    "2050-2079": {
+                        "pf": 244.89,
+                        "pf_lower": 171.67,
+                        "pf_upper": 357.89
+                    },
+                    "2080-2099": {
+                        "pf": 186.41,
+                        "pf_lower": 137.94,
+                        "pf_upper": 252.18
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 91.12,
+                        "pf_lower": 70.72,
+                        "pf_upper": 124.3
+                    },
+                    "2050-2079": {
+                        "pf": 81.51,
+                        "pf_lower": 70.93,
+                        "pf_upper": 95.17
+                    },
+                    "2080-2099": {
+                        "pf": 73.74,
+                        "pf_lower": 66.13,
+                        "pf_upper": 83.55
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 78.09,
+                        "pf_lower": 64.77,
+                        "pf_upper": 97.67
+                    },
+                    "2050-2079": {
+                        "pf": 66.39,
+                        "pf_lower": 62.12,
+                        "pf_upper": 70.93
+                    },
+                    "2080-2099": {
+                        "pf": 78.27,
+                        "pf_lower": 63.03,
+                        "pf_upper": 101.36
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 257.61,
+                        "pf_lower": 218.24,
+                        "pf_upper": 310.96
+                    },
+                    "2050-2079": {
+                        "pf": 320.83,
+                        "pf_lower": 272.68,
+                        "pf_upper": 386
+                    },
+                    "2080-2099": {
+                        "pf": 336.5,
+                        "pf_lower": 284.61,
+                        "pf_upper": 402.55
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 213.71,
+                        "pf_lower": 171.93,
+                        "pf_upper": 267.05
+                    },
+                    "2050-2079": {
+                        "pf": 267.55,
+                        "pf_lower": 217.35,
+                        "pf_upper": 358.25
+                    },
+                    "2080-2099": {
+                        "pf": 276.26,
+                        "pf_lower": 185.05,
+                        "pf_upper": 418.96
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 124.56,
+                        "pf_lower": 102.81,
+                        "pf_upper": 154.56
+                    },
+                    "2050-2079": {
+                        "pf": 122.3,
+                        "pf_lower": 104.69,
+                        "pf_upper": 145.45
+                    },
+                    "2080-2099": {
+                        "pf": 131.15,
+                        "pf_lower": 102.43,
+                        "pf_upper": 178.54
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 110.46,
+                        "pf_lower": 90.82,
+                        "pf_upper": 139.83
+                    },
+                    "2050-2079": {
+                        "pf": 115.02,
+                        "pf_lower": 101.8,
+                        "pf_upper": 130.47
+                    },
+                    "2080-2099": {
+                        "pf": 101.04,
+                        "pf_lower": 86.55,
+                        "pf_upper": 119.87
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 157.46,
+                        "pf_lower": 121.68,
+                        "pf_upper": 214.6
+                    },
+                    "2050-2079": {
+                        "pf": 156.94,
+                        "pf_lower": 128.05,
+                        "pf_upper": 199.81
+                    },
+                    "2080-2099": {
+                        "pf": 145.96,
+                        "pf_lower": 114.7,
+                        "pf_upper": 196.12
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 149.19,
+                        "pf_lower": 119.24,
+                        "pf_upper": 195.52
+                    },
+                    "2050-2079": {
+                        "pf": 168.13,
+                        "pf_lower": 139.52,
+                        "pf_upper": 207.16
+                    },
+                    "2080-2099": {
+                        "pf": 158.91,
+                        "pf_lower": 120.39,
+                        "pf_upper": 219.72
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 36.61,
+                        "pf_lower": 31.35,
+                        "pf_upper": 44.33
+                    },
+                    "2050-2079": {
+                        "pf": 44.78,
+                        "pf_lower": 37.33,
+                        "pf_upper": 57.18
+                    },
+                    "2080-2099": {
+                        "pf": 50.91,
+                        "pf_lower": 41.64,
+                        "pf_upper": 66.8
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 41.1,
+                        "pf_lower": 36.35,
+                        "pf_upper": 48.46
+                    },
+                    "2050-2079": {
+                        "pf": 34.68,
+                        "pf_lower": 32.03,
+                        "pf_upper": 38.06
+                    },
+                    "2080-2099": {
+                        "pf": 31.27,
+                        "pf_lower": 28.65,
+                        "pf_upper": 34.98
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 340.43,
+                        "pf_lower": 289.71,
+                        "pf_upper": 403.24
+                    },
+                    "2050-2079": {
+                        "pf": 365.76,
+                        "pf_lower": 337.86,
+                        "pf_upper": 397
+                    },
+                    "2080-2099": {
+                        "pf": 434.71,
+                        "pf_lower": 354.66,
+                        "pf_upper": 546.83
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 254.43,
+                        "pf_lower": 202.26,
+                        "pf_upper": 318.82
+                    },
+                    "2050-2079": {
+                        "pf": 311.74,
+                        "pf_lower": 247.16,
+                        "pf_upper": 391.62
+                    },
+                    "2080-2099": {
+                        "pf": 359.58,
+                        "pf_lower": 196.55,
+                        "pf_upper": 633.92
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 159.03,
+                        "pf_lower": 136.31,
+                        "pf_upper": 214.82
+                    },
+                    "2050-2079": {
+                        "pf": 173.64,
+                        "pf_lower": 136.18,
+                        "pf_upper": 231
+                    },
+                    "2080-2099": {
+                        "pf": 147.42,
+                        "pf_lower": 124.45,
+                        "pf_upper": 196.31
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 150.68,
+                        "pf_lower": 119.36,
+                        "pf_upper": 218.44
+                    },
+                    "2050-2079": {
+                        "pf": 169.82,
+                        "pf_lower": 141.18,
+                        "pf_upper": 207.36
+                    },
+                    "2080-2099": {
+                        "pf": 160.5,
+                        "pf_lower": 120.51,
+                        "pf_upper": 231.13
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 44.66,
+                        "pf_lower": 36.66,
+                        "pf_upper": 56.67
+                    },
+                    "2050-2079": {
+                        "pf": 51.91,
+                        "pf_lower": 42.3,
+                        "pf_upper": 67.51
+                    },
+                    "2080-2099": {
+                        "pf": 51.8,
+                        "pf_lower": 42.73,
+                        "pf_upper": 66.87
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 44.52,
+                        "pf_lower": 39.72,
+                        "pf_upper": 51.45
+                    },
+                    "2050-2079": {
+                        "pf": 40.83,
+                        "pf_lower": 37.71,
+                        "pf_upper": 44.67
+                    },
+                    "2080-2099": {
+                        "pf": 35.66,
+                        "pf_lower": 33.11,
+                        "pf_upper": 38.81
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 365.49,
+                        "pf_lower": 313.2,
+                        "pf_upper": 428.08
+                    },
+                    "2050-2079": {
+                        "pf": 395.74,
+                        "pf_lower": 355.69,
+                        "pf_upper": 442.66
+                    },
+                    "2080-2099": {
+                        "pf": 492.9,
+                        "pf_lower": 387.13,
+                        "pf_upper": 641.96
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 337.37,
+                        "pf_lower": 281.09,
+                        "pf_upper": 401.27
+                    },
+                    "2050-2079": {
+                        "pf": 387.96,
+                        "pf_lower": 318.8,
+                        "pf_upper": 468.48
+                    },
+                    "2080-2099": {
+                        "pf": 476.28,
+                        "pf_lower": 273.62,
+                        "pf_upper": 847.03
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 197.53,
+                        "pf_lower": 161.81,
+                        "pf_upper": 248.04
+                    },
+                    "2050-2079": {
+                        "pf": 183.29,
+                        "pf_lower": 156.44,
+                        "pf_upper": 231.23
+                    },
+                    "2080-2099": {
+                        "pf": 170.24,
+                        "pf_lower": 147.15,
+                        "pf_upper": 201.17
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 173.24,
+                        "pf_lower": 124.76,
+                        "pf_upper": 252.68
+                    },
+                    "2050-2079": {
+                        "pf": 206.66,
+                        "pf_lower": 152.16,
+                        "pf_upper": 290.23
+                    },
+                    "2080-2099": {
+                        "pf": 162.11,
+                        "pf_lower": 132.58,
+                        "pf_upper": 231.36
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 416.97,
+                        "pf_lower": 367.67,
+                        "pf_upper": 473.44
+                    },
+                    "2050-2079": {
+                        "pf": 487.1,
+                        "pf_lower": 444.56,
+                        "pf_upper": 534.58
+                    },
+                    "2080-2099": {
+                        "pf": 564.02,
+                        "pf_lower": 457.67,
+                        "pf_upper": 708.02
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 407.19,
+                        "pf_lower": 323.42,
+                        "pf_upper": 516.85
+                    },
+                    "2050-2079": {
+                        "pf": 423.09,
+                        "pf_lower": 366.49,
+                        "pf_upper": 489.24
+                    },
+                    "2080-2099": {
+                        "pf": 536.13,
+                        "pf_lower": 312.43,
+                        "pf_upper": 915.59
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 27.62,
+                        "pf_lower": 24.47,
+                        "pf_upper": 32.42
+                    },
+                    "2050-2079": {
+                        "pf": 39.03,
+                        "pf_lower": 33.22,
+                        "pf_upper": 48.83
+                    },
+                    "2080-2099": {
+                        "pf": 37.7,
+                        "pf_lower": 32.84,
+                        "pf_upper": 45.76
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 29.4,
+                        "pf_lower": 26.44,
+                        "pf_upper": 34.18
+                    },
+                    "2050-2079": {
+                        "pf": 28.58,
+                        "pf_lower": 25.9,
+                        "pf_upper": 32.7
+                    },
+                    "2080-2099": {
+                        "pf": 22,
+                        "pf_lower": 20.34,
+                        "pf_upper": 24.4
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 60.61,
+                        "pf_lower": 48.79,
+                        "pf_upper": 78.25
+                    },
+                    "2050-2079": {
+                        "pf": 59.81,
+                        "pf_lower": 50.07,
+                        "pf_upper": 73.94
+                    },
+                    "2080-2099": {
+                        "pf": 58.74,
+                        "pf_lower": 49.58,
+                        "pf_upper": 72.43
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 56.83,
+                        "pf_lower": 50.88,
+                        "pf_upper": 64.32
+                    },
+                    "2050-2079": {
+                        "pf": 51.16,
+                        "pf_lower": 47.68,
+                        "pf_upper": 55.14
+                    },
+                    "2080-2099": {
+                        "pf": 51.5,
+                        "pf_lower": 46.51,
+                        "pf_upper": 58.05
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 199.5,
+                        "pf_lower": 167.92,
+                        "pf_upper": 248.29
+                    },
+                    "2050-2079": {
+                        "pf": 247.88,
+                        "pf_lower": 207.61,
+                        "pf_upper": 306.36
+                    },
+                    "2080-2099": {
+                        "pf": 233.95,
+                        "pf_lower": 198.27,
+                        "pf_upper": 284.4
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 174.98,
+                        "pf_lower": 133.27,
+                        "pf_upper": 252.94
+                    },
+                    "2050-2079": {
+                        "pf": 208.2,
+                        "pf_lower": 152.32,
+                        "pf_upper": 301.66
+                    },
+                    "2080-2099": {
+                        "pf": 163.73,
+                        "pf_lower": 132.71,
+                        "pf_upper": 238.99
+                    }
+                }
+            }
+        },
+        "100": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 276.69,
+                        "pf_lower": 230.17,
+                        "pf_upper": 348.85
+                    },
+                    "2050-2079": {
+                        "pf": 309.99,
+                        "pf_lower": 265.38,
+                        "pf_upper": 379.34
+                    },
+                    "2080-2099": {
+                        "pf": 302.29,
+                        "pf_lower": 265.33,
+                        "pf_upper": 356.92
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 216.51,
+                        "pf_lower": 158.87,
+                        "pf_upper": 344.73
+                    },
+                    "2050-2079": {
+                        "pf": 284.63,
+                        "pf_lower": 185.36,
+                        "pf_upper": 462.27
+                    },
+                    "2080-2099": {
+                        "pf": 205.18,
+                        "pf_lower": 163.91,
+                        "pf_upper": 324.34
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 111.56,
+                        "pf_lower": 83.08,
+                        "pf_upper": 165.27
+                    },
+                    "2050-2079": {
+                        "pf": 91.21,
+                        "pf_lower": 77.83,
+                        "pf_upper": 110.74
+                    },
+                    "2080-2099": {
+                        "pf": 80.15,
+                        "pf_lower": 71.14,
+                        "pf_upper": 93.87
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 94.23,
+                        "pf_lower": 76.64,
+                        "pf_upper": 124.06
+                    },
+                    "2050-2079": {
+                        "pf": 73.07,
+                        "pf_lower": 68.3,
+                        "pf_upper": 78.85
+                    },
+                    "2080-2099": {
+                        "pf": 94.57,
+                        "pf_lower": 74.54,
+                        "pf_upper": 130.64
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 284.94,
+                        "pf_lower": 234.31,
+                        "pf_upper": 362.8
+                    },
+                    "2050-2079": {
+                        "pf": 355.72,
+                        "pf_lower": 293.66,
+                        "pf_upper": 450.6
+                    },
+                    "2080-2099": {
+                        "pf": 363.82,
+                        "pf_lower": 301.64,
+                        "pf_upper": 457.88
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 234.35,
+                        "pf_lower": 182.12,
+                        "pf_upper": 345.08
+                    },
+                    "2050-2079": {
+                        "pf": 291.5,
+                        "pf_lower": 229.87,
+                        "pf_upper": 462.73
+                    },
+                    "2080-2099": {
+                        "pf": 320.87,
+                        "pf_lower": 199.18,
+                        "pf_upper": 551.39
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 145.43,
+                        "pf_lower": 117.18,
+                        "pf_upper": 189.7
+                    },
+                    "2050-2079": {
+                        "pf": 139.28,
+                        "pf_lower": 116.88,
+                        "pf_upper": 172.41
+                    },
+                    "2080-2099": {
+                        "pf": 157.24,
+                        "pf_lower": 118.58,
+                        "pf_upper": 234.21
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 135.88,
+                        "pf_lower": 109.72,
+                        "pf_upper": 181.04
+                    },
+                    "2050-2079": {
+                        "pf": 132.72,
+                        "pf_lower": 116.81,
+                        "pf_upper": 153.46
+                    },
+                    "2080-2099": {
+                        "pf": 117.94,
+                        "pf_lower": 100.04,
+                        "pf_upper": 145.24
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 190.94,
+                        "pf_lower": 141.46,
+                        "pf_upper": 282.71
+                    },
+                    "2050-2079": {
+                        "pf": 182.59,
+                        "pf_lower": 144.21,
+                        "pf_upper": 247.83
+                    },
+                    "2080-2099": {
+                        "pf": 170.58,
+                        "pf_lower": 129.32,
+                        "pf_upper": 250.03
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 183.04,
+                        "pf_lower": 142.22,
+                        "pf_upper": 256.5
+                    },
+                    "2050-2079": {
+                        "pf": 198.34,
+                        "pf_lower": 161.67,
+                        "pf_upper": 254.05
+                    },
+                    "2080-2099": {
+                        "pf": 196.92,
+                        "pf_lower": 144.87,
+                        "pf_upper": 295.09
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 42.76,
+                        "pf_lower": 35.82,
+                        "pf_upper": 54.38
+                    },
+                    "2050-2079": {
+                        "pf": 54.5,
+                        "pf_lower": 43.96,
+                        "pf_upper": 75.04
+                    },
+                    "2080-2099": {
+                        "pf": 61.51,
+                        "pf_lower": 48.77,
+                        "pf_upper": 87.81
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 50.58,
+                        "pf_lower": 44.11,
+                        "pf_upper": 62.26
+                    },
+                    "2050-2079": {
+                        "pf": 40.01,
+                        "pf_lower": 36.7,
+                        "pf_upper": 44.72
+                    },
+                    "2080-2099": {
+                        "pf": 36.06,
+                        "pf_lower": 32.79,
+                        "pf_upper": 41.48
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 367.18,
+                        "pf_lower": 304.31,
+                        "pf_upper": 455.36
+                    },
+                    "2050-2079": {
+                        "pf": 381.16,
+                        "pf_lower": 349.3,
+                        "pf_upper": 451.05
+                    },
+                    "2080-2099": {
+                        "pf": 470.95,
+                        "pf_lower": 370.8,
+                        "pf_upper": 637.47
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 269.73,
+                        "pf_lower": 205.52,
+                        "pf_upper": 356.87
+                    },
+                    "2050-2079": {
+                        "pf": 331.05,
+                        "pf_lower": 251.43,
+                        "pf_upper": 463.2
+                    },
+                    "2080-2099": {
+                        "pf": 436.93,
+                        "pf_lower": 199.38,
+                        "pf_upper": 929.23
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 192.85,
+                        "pf_lower": 164.03,
+                        "pf_upper": 282.99
+                    },
+                    "2050-2079": {
+                        "pf": 203.74,
+                        "pf_lower": 152.88,
+                        "pf_upper": 293.46
+                    },
+                    "2080-2099": {
+                        "pf": 172.29,
+                        "pf_lower": 144.48,
+                        "pf_upper": 250.28
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 184.87,
+                        "pf_lower": 142.36,
+                        "pf_upper": 297.19
+                    },
+                    "2050-2079": {
+                        "pf": 200.32,
+                        "pf_lower": 164.98,
+                        "pf_upper": 254.31
+                    },
+                    "2080-2099": {
+                        "pf": 198.89,
+                        "pf_lower": 145.02,
+                        "pf_upper": 317.92
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 51.6,
+                        "pf_lower": 40.88,
+                        "pf_upper": 69.99
+                    },
+                    "2050-2079": {
+                        "pf": 60.88,
+                        "pf_lower": 47.41,
+                        "pf_upper": 86.06
+                    },
+                    "2080-2099": {
+                        "pf": 62.12,
+                        "pf_lower": 50.16,
+                        "pf_upper": 87.9
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 53.26,
+                        "pf_lower": 46.95,
+                        "pf_upper": 63.62
+                    },
+                    "2050-2079": {
+                        "pf": 46.74,
+                        "pf_lower": 42.91,
+                        "pf_upper": 51.96
+                    },
+                    "2080-2099": {
+                        "pf": 40.3,
+                        "pf_lower": 37.24,
+                        "pf_upper": 44.78
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 385.06,
+                        "pf_lower": 321.59,
+                        "pf_upper": 470.33
+                    },
+                    "2050-2079": {
+                        "pf": 411.1,
+                        "pf_lower": 363.32,
+                        "pf_upper": 473.97
+                    },
+                    "2080-2099": {
+                        "pf": 529.17,
+                        "pf_lower": 396.72,
+                        "pf_upper": 749.47
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 354.09,
+                        "pf_lower": 286.84,
+                        "pf_upper": 439.18
+                    },
+                    "2050-2079": {
+                        "pf": 409.55,
+                        "pf_lower": 326.25,
+                        "pf_upper": 518.44
+                    },
+                    "2080-2099": {
+                        "pf": 574.79,
+                        "pf_lower": 278.81,
+                        "pf_upper": 1207.43
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 233.21,
+                        "pf_lower": 186.45,
+                        "pf_upper": 308.56
+                    },
+                    "2050-2079": {
+                        "pf": 213.48,
+                        "pf_lower": 177.3,
+                        "pf_upper": 293.76
+                    },
+                    "2080-2099": {
+                        "pf": 191.35,
+                        "pf_lower": 163.07,
+                        "pf_upper": 250.53
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 212.25,
+                        "pf_lower": 144.05,
+                        "pf_upper": 344.04
+                    },
+                    "2050-2079": {
+                        "pf": 247.5,
+                        "pf_lower": 174.01,
+                        "pf_upper": 378
+                    },
+                    "2080-2099": {
+                        "pf": 200.88,
+                        "pf_lower": 163.59,
+                        "pf_upper": 318.24
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 431.44,
+                        "pf_lower": 373.42,
+                        "pf_upper": 506.2
+                    },
+                    "2050-2079": {
+                        "pf": 498.81,
+                        "pf_lower": 450.15,
+                        "pf_upper": 560.36
+                    },
+                    "2080-2099": {
+                        "pf": 595.08,
+                        "pf_lower": 463.81,
+                        "pf_upper": 802.64
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 441.87,
+                        "pf_lower": 335.95,
+                        "pf_upper": 598.47
+                    },
+                    "2050-2079": {
+                        "pf": 443.84,
+                        "pf_lower": 376.43,
+                        "pf_upper": 532.86
+                    },
+                    "2080-2099": {
+                        "pf": 646.69,
+                        "pf_lower": 325.87,
+                        "pf_upper": 1316.01
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 32.36,
+                        "pf_lower": 28.11,
+                        "pf_upper": 39.9
+                    },
+                    "2050-2079": {
+                        "pf": 49.08,
+                        "pf_lower": 40.48,
+                        "pf_upper": 66.64
+                    },
+                    "2080-2099": {
+                        "pf": 44.27,
+                        "pf_lower": 37.76,
+                        "pf_upper": 57.16
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 35.9,
+                        "pf_lower": 31.73,
+                        "pf_upper": 43.9
+                    },
+                    "2050-2079": {
+                        "pf": 34.04,
+                        "pf_lower": 30.34,
+                        "pf_upper": 40.87
+                    },
+                    "2080-2099": {
+                        "pf": 24.9,
+                        "pf_lower": 22.79,
+                        "pf_upper": 28.52
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 69.29,
+                        "pf_lower": 53.5,
+                        "pf_upper": 96.24
+                    },
+                    "2050-2079": {
+                        "pf": 66.81,
+                        "pf_lower": 53.83,
+                        "pf_upper": 88.38
+                    },
+                    "2080-2099": {
+                        "pf": 64.46,
+                        "pf_lower": 52.61,
+                        "pf_upper": 87.98
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 65.95,
+                        "pf_lower": 58.52,
+                        "pf_upper": 76.58
+                    },
+                    "2050-2079": {
+                        "pf": 57.51,
+                        "pf_lower": 53.4,
+                        "pf_upper": 62.9
+                    },
+                    "2080-2099": {
+                        "pf": 58.71,
+                        "pf_lower": 52.66,
+                        "pf_upper": 67.86
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 235.54,
+                        "pf_lower": 193.89,
+                        "pf_upper": 308.87
+                    },
+                    "2050-2079": {
+                        "pf": 284.73,
+                        "pf_lower": 231.66,
+                        "pf_upper": 372.76
+                    },
+                    "2080-2099": {
+                        "pf": 261.71,
+                        "pf_lower": 216.95,
+                        "pf_upper": 336.27
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 214.37,
+                        "pf_lower": 158.71,
+                        "pf_upper": 344.39
+                    },
+                    "2050-2079": {
+                        "pf": 249.97,
+                        "pf_lower": 174.18,
+                        "pf_upper": 396.82
+                    },
+                    "2080-2099": {
+                        "pf": 202.89,
+                        "pf_lower": 163.75,
+                        "pf_upper": 324.02
+                    }
+                }
+            }
+        },
+        "200": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 319.06,
+                        "pf_lower": 261.36,
+                        "pf_upper": 421.53
+                    },
+                    "2050-2079": {
+                        "pf": 353.78,
+                        "pf_lower": 298.31,
+                        "pf_upper": 455.88
+                    },
+                    "2080-2099": {
+                        "pf": 334.09,
+                        "pf_lower": 291.87,
+                        "pf_upper": 407.55
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 266.19,
+                        "pf_lower": 192.26,
+                        "pf_upper": 472.97
+                    },
+                    "2050-2079": {
+                        "pf": 330.23,
+                        "pf_lower": 200.1,
+                        "pf_upper": 607.73
+                    },
+                    "2080-2099": {
+                        "pf": 255.2,
+                        "pf_lower": 204.75,
+                        "pf_upper": 445.54
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 138.37,
+                        "pf_lower": 100.08,
+                        "pf_upper": 224.57
+                    },
+                    "2050-2079": {
+                        "pf": 102.87,
+                        "pf_lower": 86.54,
+                        "pf_upper": 130.2
+                    },
+                    "2080-2099": {
+                        "pf": 87.97,
+                        "pf_lower": 77.6,
+                        "pf_upper": 118.97
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 114.53,
+                        "pf_lower": 91.89,
+                        "pf_upper": 158.87
+                    },
+                    "2050-2079": {
+                        "pf": 81,
+                        "pf_lower": 75.81,
+                        "pf_upper": 88.19
+                    },
+                    "2080-2099": {
+                        "pf": 115.28,
+                        "pf_lower": 89.61,
+                        "pf_upper": 170.22
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 322.25,
+                        "pf_lower": 261.62,
+                        "pf_upper": 432.79
+                    },
+                    "2050-2079": {
+                        "pf": 393.4,
+                        "pf_lower": 316.55,
+                        "pf_upper": 527.66
+                    },
+                    "2080-2099": {
+                        "pf": 391.13,
+                        "pf_lower": 319.45,
+                        "pf_upper": 518.09
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 268.85,
+                        "pf_lower": 205.45,
+                        "pf_upper": 473.45
+                    },
+                    "2050-2079": {
+                        "pf": 333.53,
+                        "pf_lower": 260.39,
+                        "pf_upper": 608.34
+                    },
+                    "2080-2099": {
+                        "pf": 372.47,
+                        "pf_lower": 214.06,
+                        "pf_upper": 731.99
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 170.61,
+                        "pf_lower": 135.35,
+                        "pf_upper": 233.76
+                    },
+                    "2050-2079": {
+                        "pf": 159.44,
+                        "pf_lower": 132,
+                        "pf_upper": 205.57
+                    },
+                    "2080-2099": {
+                        "pf": 190.36,
+                        "pf_lower": 139.93,
+                        "pf_upper": 310.14
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 168.01,
+                        "pf_lower": 134.16,
+                        "pf_upper": 235.72
+                    },
+                    "2050-2079": {
+                        "pf": 153.51,
+                        "pf_lower": 135,
+                        "pf_upper": 181.07
+                    },
+                    "2080-2099": {
+                        "pf": 138.26,
+                        "pf_lower": 116.8,
+                        "pf_upper": 177.03
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 233.27,
+                        "pf_lower": 166.97,
+                        "pf_upper": 378.22
+                    },
+                    "2050-2079": {
+                        "pf": 213.65,
+                        "pf_lower": 164.17,
+                        "pf_upper": 312.22
+                    },
+                    "2080-2099": {
+                        "pf": 200.54,
+                        "pf_lower": 147.9,
+                        "pf_upper": 320.89
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 225.58,
+                        "pf_lower": 171.46,
+                        "pf_upper": 340.6
+                    },
+                    "2050-2079": {
+                        "pf": 233.88,
+                        "pf_lower": 188.34,
+                        "pf_upper": 314.16
+                    },
+                    "2080-2099": {
+                        "pf": 245.24,
+                        "pf_lower": 176.69,
+                        "pf_upper": 400.98
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 50.52,
+                        "pf_lower": 41.64,
+                        "pf_upper": 67.71
+                    },
+                    "2050-2079": {
+                        "pf": 67.62,
+                        "pf_lower": 53.27,
+                        "pf_upper": 101.37
+                    },
+                    "2080-2099": {
+                        "pf": 75.67,
+                        "pf_lower": 58.8,
+                        "pf_upper": 118.62
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 62.95,
+                        "pf_lower": 54.38,
+                        "pf_upper": 81.21
+                    },
+                    "2050-2079": {
+                        "pf": 46.5,
+                        "pf_lower": 42.47,
+                        "pf_upper": 53.19
+                    },
+                    "2080-2099": {
+                        "pf": 41.97,
+                        "pf_lower": 37.96,
+                        "pf_upper": 49.69
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 393.23,
+                        "pf_lower": 318.09,
+                        "pf_upper": 512.76
+                    },
+                    "2050-2079": {
+                        "pf": 395.22,
+                        "pf_lower": 359.64,
+                        "pf_upper": 528.18
+                    },
+                    "2080-2099": {
+                        "pf": 506.91,
+                        "pf_lower": 385.88,
+                        "pf_upper": 741.56
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 283.55,
+                        "pf_lower": 207.03,
+                        "pf_upper": 473.92
+                    },
+                    "2050-2079": {
+                        "pf": 348.67,
+                        "pf_lower": 260.65,
+                        "pf_upper": 608.95
+                    },
+                    "2080-2099": {
+                        "pf": 534.96,
+                        "pf_lower": 214.28,
+                        "pf_upper": 1383.45
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 235.6,
+                        "pf_lower": 200.51,
+                        "pf_upper": 378.59
+                    },
+                    "2050-2079": {
+                        "pf": 240.39,
+                        "pf_lower": 173.56,
+                        "pf_upper": 378.03
+                    },
+                    "2080-2099": {
+                        "pf": 202.54,
+                        "pf_lower": 170.17,
+                        "pf_upper": 321.21
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 227.84,
+                        "pf_lower": 171.63,
+                        "pf_upper": 412.65
+                    },
+                    "2050-2079": {
+                        "pf": 236.22,
+                        "pf_lower": 193.96,
+                        "pf_upper": 314.47
+                    },
+                    "2080-2099": {
+                        "pf": 247.69,
+                        "pf_lower": 176.87,
+                        "pf_upper": 444.2
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 60.21,
+                        "pf_lower": 46.35,
+                        "pf_upper": 88.01
+                    },
+                    "2050-2079": {
+                        "pf": 72.49,
+                        "pf_lower": 54.3,
+                        "pf_upper": 113.11
+                    },
+                    "2080-2099": {
+                        "pf": 76.42,
+                        "pf_lower": 61.19,
+                        "pf_upper": 118.74
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 64.3,
+                        "pf_lower": 56.26,
+                        "pf_upper": 81.29
+                    },
+                    "2050-2079": {
+                        "pf": 53.89,
+                        "pf_lower": 49.34,
+                        "pf_upper": 61.07
+                    },
+                    "2080-2099": {
+                        "pf": 45.95,
+                        "pf_lower": 42.37,
+                        "pf_upper": 52.16
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 402.51,
+                        "pf_lower": 328.05,
+                        "pf_upper": 515.21
+                    },
+                    "2050-2079": {
+                        "pf": 424.42,
+                        "pf_lower": 369.29,
+                        "pf_upper": 528.71
+                    },
+                    "2080-2099": {
+                        "pf": 564.05,
+                        "pf_lower": 403.59,
+                        "pf_upper": 874.56
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 368.08,
+                        "pf_lower": 290.46,
+                        "pf_upper": 480.03
+                    },
+                    "2050-2079": {
+                        "pf": 428.3,
+                        "pf_lower": 330.45,
+                        "pf_upper": 609.56
+                    },
+                    "2080-2099": {
+                        "pf": 695.85,
+                        "pf_lower": 279.08,
+                        "pf_upper": 1774.45
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 275.2,
+                        "pf_lower": 216.25,
+                        "pf_upper": 384.43
+                    },
+                    "2050-2079": {
+                        "pf": 250.37,
+                        "pf_lower": 203.19,
+                        "pf_upper": 378.41
+                    },
+                    "2080-2099": {
+                        "pf": 215.2,
+                        "pf_lower": 181.74,
+                        "pf_upper": 321.53
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 260.94,
+                        "pf_lower": 171.8,
+                        "pf_upper": 472.03
+                    },
+                    "2050-2079": {
+                        "pf": 296.19,
+                        "pf_lower": 199.7,
+                        "pf_upper": 496.28
+                    },
+                    "2080-2099": {
+                        "pf": 250.17,
+                        "pf_lower": 204.34,
+                        "pf_upper": 444.65
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 442.02,
+                        "pf_lower": 375.84,
+                        "pf_upper": 537.83
+                    },
+                    "2050-2079": {
+                        "pf": 506.44,
+                        "pf_lower": 451.89,
+                        "pf_upper": 584.14
+                    },
+                    "2080-2099": {
+                        "pf": 621.91,
+                        "pf_lower": 465.68,
+                        "pf_upper": 911.26
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 474.36,
+                        "pf_lower": 346.11,
+                        "pf_upper": 690.92
+                    },
+                    "2050-2079": {
+                        "pf": 460.9,
+                        "pf_lower": 383.49,
+                        "pf_upper": 610.17
+                    },
+                    "2080-2099": {
+                        "pf": 780.64,
+                        "pf_lower": 331.68,
+                        "pf_upper": 1947.38
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 38.37,
+                        "pf_lower": 32.85,
+                        "pf_upper": 49.74
+                    },
+                    "2050-2079": {
+                        "pf": 63.13,
+                        "pf_lower": 50.84,
+                        "pf_upper": 93.6
+                    },
+                    "2080-2099": {
+                        "pf": 52.72,
+                        "pf_lower": 44.29,
+                        "pf_upper": 73.02
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 44.48,
+                        "pf_lower": 38.78,
+                        "pf_upper": 57.4
+                    },
+                    "2050-2079": {
+                        "pf": 41.09,
+                        "pf_lower": 36.14,
+                        "pf_upper": 51.83
+                    },
+                    "2080-2099": {
+                        "pf": 28.49,
+                        "pf_lower": 25.88,
+                        "pf_upper": 33.94
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 79.94,
+                        "pf_lower": 59.57,
+                        "pf_upper": 120.45
+                    },
+                    "2050-2079": {
+                        "pf": 75.5,
+                        "pf_lower": 58.74,
+                        "pf_upper": 113.23
+                    },
+                    "2080-2099": {
+                        "pf": 77.19,
+                        "pf_lower": 62.32,
+                        "pf_upper": 118.85
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 77,
+                        "pf_lower": 68.04,
+                        "pf_upper": 91.58
+                    },
+                    "2050-2079": {
+                        "pf": 65.08,
+                        "pf_lower": 60.35,
+                        "pf_upper": 72.14
+                    },
+                    "2080-2099": {
+                        "pf": 67.41,
+                        "pf_lower": 60.28,
+                        "pf_upper": 79.99
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 277.96,
+                        "pf_lower": 224.85,
+                        "pf_upper": 384.82
+                    },
+                    "2050-2079": {
+                        "pf": 326.89,
+                        "pf_lower": 259.29,
+                        "pf_upper": 455.42
+                    },
+                    "2080-2099": {
+                        "pf": 292.25,
+                        "pf_lower": 238.03,
+                        "pf_upper": 397.78
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 263.55,
+                        "pf_lower": 192.07,
+                        "pf_upper": 472.5
+                    },
+                    "2050-2079": {
+                        "pf": 299.15,
+                        "pf_lower": 199.9,
+                        "pf_upper": 527.83
+                    },
+                    "2080-2099": {
+                        "pf": 252.67,
+                        "pf_lower": 204.55,
+                        "pf_upper": 445.09
+                    }
+                }
+            }
+        },
+        "500": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 380.52,
+                        "pf_lower": 306.7,
+                        "pf_upper": 559.72
+                    },
+                    "2050-2079": {
+                        "pf": 417.16,
+                        "pf_lower": 346.08,
+                        "pf_upper": 595.3
+                    },
+                    "2080-2099": {
+                        "pf": 376.84,
+                        "pf_lower": 327.54,
+                        "pf_upper": 498.35
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 347.05,
+                        "pf_lower": 248.1,
+                        "pf_upper": 730.96
+                    },
+                    "2050-2079": {
+                        "pf": 398.49,
+                        "pf_lower": 238.72,
+                        "pf_upper": 868.23
+                    },
+                    "2080-2099": {
+                        "pf": 337.33,
+                        "pf_lower": 273.41,
+                        "pf_upper": 702.13
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 182.02,
+                        "pf_lower": 127.65,
+                        "pf_upper": 337.33
+                    },
+                    "2050-2079": {
+                        "pf": 118.54,
+                        "pf_lower": 98.05,
+                        "pf_upper": 164.73
+                    },
+                    "2080-2099": {
+                        "pf": 102.07,
+                        "pf_lower": 89.91,
+                        "pf_upper": 178.89
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 145.57,
+                        "pf_lower": 115.32,
+                        "pf_upper": 217.67
+                    },
+                    "2050-2079": {
+                        "pf": 91.25,
+                        "pf_lower": 85.58,
+                        "pf_upper": 100.31
+                    },
+                    "2080-2099": {
+                        "pf": 147.47,
+                        "pf_lower": 113.27,
+                        "pf_upper": 240.78
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 384.32,
+                        "pf_lower": 307.01,
+                        "pf_upper": 560.28
+                    },
+                    "2050-2079": {
+                        "pf": 447.4,
+                        "pf_lower": 349.13,
+                        "pf_upper": 655.32
+                    },
+                    "2080-2099": {
+                        "pf": 426.96,
+                        "pf_lower": 342.72,
+                        "pf_upper": 608.95
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 350.52,
+                        "pf_lower": 272.36,
+                        "pf_upper": 731.69
+                    },
+                    "2050-2079": {
+                        "pf": 402.48,
+                        "pf_lower": 313.93,
+                        "pf_upper": 869.1
+                    },
+                    "2080-2099": {
+                        "pf": 453.11,
+                        "pf_lower": 273.69,
+                        "pf_upper": 1080.46
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 206.63,
+                        "pf_lower": 161.36,
+                        "pf_upper": 337.67
+                    },
+                    "2050-2079": {
+                        "pf": 187.02,
+                        "pf_lower": 152.51,
+                        "pf_upper": 257.37
+                    },
+                    "2080-2099": {
+                        "pf": 241.85,
+                        "pf_lower": 173.02,
+                        "pf_upper": 454.28
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 218.17,
+                        "pf_lower": 172.51,
+                        "pf_upper": 330.1
+                    },
+                    "2050-2079": {
+                        "pf": 181.91,
+                        "pf_lower": 159.92,
+                        "pf_upper": 220.37
+                    },
+                    "2080-2099": {
+                        "pf": 167.16,
+                        "pf_lower": 140.86,
+                        "pf_upper": 241.02
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 301.29,
+                        "pf_lower": 207.6,
+                        "pf_upper": 557.48
+                    },
+                    "2050-2079": {
+                        "pf": 260.03,
+                        "pf_lower": 193.84,
+                        "pf_upper": 423.2
+                    },
+                    "2080-2099": {
+                        "pf": 245.6,
+                        "pf_lower": 175.58,
+                        "pf_upper": 454.74
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 293.68,
+                        "pf_lower": 218.32,
+                        "pf_upper": 492.68
+                    },
+                    "2050-2079": {
+                        "pf": 285.41,
+                        "pf_lower": 227.49,
+                        "pf_upper": 409.32
+                    },
+                    "2080-2099": {
+                        "pf": 324.17,
+                        "pf_lower": 229.33,
+                        "pf_upper": 597.88
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 62.09,
+                        "pf_lower": 50.38,
+                        "pf_upper": 90
+                    },
+                    "2050-2079": {
+                        "pf": 89.68,
+                        "pf_lower": 69.3,
+                        "pf_upper": 152.41
+                    },
+                    "2080-2099": {
+                        "pf": 99.07,
+                        "pf_lower": 75.35,
+                        "pf_upper": 178.36
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 82.79,
+                        "pf_lower": 70.87,
+                        "pf_upper": 113.58
+                    },
+                    "2050-2079": {
+                        "pf": 55.63,
+                        "pf_lower": 50.65,
+                        "pf_upper": 71.84
+                    },
+                    "2080-2099": {
+                        "pf": 50.37,
+                        "pf_lower": 45.38,
+                        "pf_upper": 62.18
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 427.74,
+                        "pf_lower": 335.33,
+                        "pf_upper": 602.56
+                    },
+                    "2050-2079": {
+                        "pf": 451.88,
+                        "pf_lower": 412.5,
+                        "pf_upper": 655.97
+                    },
+                    "2080-2099": {
+                        "pf": 555.51,
+                        "pf_lower": 407.31,
+                        "pf_upper": 913.97
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 354.02,
+                        "pf_lower": 272.63,
+                        "pf_upper": 732.42
+                    },
+                    "2050-2079": {
+                        "pf": 406.5,
+                        "pf_lower": 314.24,
+                        "pf_upper": 869.97
+                    },
+                    "2080-2099": {
+                        "pf": 708.15,
+                        "pf_lower": 273.96,
+                        "pf_upper": 2433.41
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 304.3,
+                        "pf_lower": 260.4,
+                        "pf_upper": 558.04
+                    },
+                    "2050-2079": {
+                        "pf": 296.64,
+                        "pf_lower": 204.99,
+                        "pf_upper": 532.45
+                    },
+                    "2080-2099": {
+                        "pf": 248.06,
+                        "pf_lower": 209.55,
+                        "pf_upper": 455.19
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 296.62,
+                        "pf_lower": 218.54,
+                        "pf_upper": 632.84
+                    },
+                    "2050-2079": {
+                        "pf": 288.27,
+                        "pf_lower": 236.87,
+                        "pf_upper": 409.73
+                    },
+                    "2080-2099": {
+                        "pf": 327.41,
+                        "pf_lower": 229.56,
+                        "pf_upper": 700.03
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 72.66,
+                        "pf_lower": 54.07,
+                        "pf_upper": 118.76
+                    },
+                    "2050-2079": {
+                        "pf": 90.52,
+                        "pf_lower": 69.37,
+                        "pf_upper": 164.4
+                    },
+                    "2080-2099": {
+                        "pf": 100.06,
+                        "pf_lower": 79.91,
+                        "pf_upper": 178.54
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 83.62,
+                        "pf_lower": 73.05,
+                        "pf_upper": 113.69
+                    },
+                    "2050-2079": {
+                        "pf": 63.77,
+                        "pf_lower": 58.25,
+                        "pf_upper": 74.16
+                    },
+                    "2080-2099": {
+                        "pf": 53.69,
+                        "pf_lower": 49.43,
+                        "pf_upper": 62.77
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 432.02,
+                        "pf_lower": 343.76,
+                        "pf_upper": 603.16
+                    },
+                    "2050-2079": {
+                        "pf": 456.4,
+                        "pf_lower": 412.91,
+                        "pf_upper": 656.63
+                    },
+                    "2080-2099": {
+                        "pf": 611.6,
+                        "pf_lower": 415.16,
+                        "pf_upper": 1086.71
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 385.11,
+                        "pf_lower": 294.01,
+                        "pf_upper": 733.16
+                    },
+                    "2050-2079": {
+                        "pf": 451.78,
+                        "pf_lower": 335.8,
+                        "pf_upper": 870.84
+                    },
+                    "2080-2099": {
+                        "pf": 904.85,
+                        "pf_lower": 279.36,
+                        "pf_upper": 3059.71
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 337.81,
+                        "pf_lower": 261.33,
+                        "pf_upper": 558.6
+                    },
+                    "2050-2079": {
+                        "pf": 307.92,
+                        "pf_lower": 243.58,
+                        "pf_upper": 532.98
+                    },
+                    "2080-2099": {
+                        "pf": 248.22,
+                        "pf_lower": 209.76,
+                        "pf_upper": 455.65
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 340.21,
+                        "pf_lower": 218.75,
+                        "pf_upper": 729.5
+                    },
+                    "2050-2079": {
+                        "pf": 370.68,
+                        "pf_lower": 238.25,
+                        "pf_upper": 707.14
+                    },
+                    "2080-2099": {
+                        "pf": 330.68,
+                        "pf_lower": 272.87,
+                        "pf_upper": 700.73
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 454.7,
+                        "pf_lower": 378.69,
+                        "pf_upper": 603.77
+                    },
+                    "2050-2079": {
+                        "pf": 515.71,
+                        "pf_lower": 454.79,
+                        "pf_upper": 657.28
+                    },
+                    "2080-2099": {
+                        "pf": 656.87,
+                        "pf_lower": 469.13,
+                        "pf_upper": 1094.29
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 518.18,
+                        "pf_lower": 358.39,
+                        "pf_upper": 840.81
+                    },
+                    "2050-2079": {
+                        "pf": 482.47,
+                        "pf_lower": 392.91,
+                        "pf_upper": 871.71
+                    },
+                    "2080-2099": {
+                        "pf": 1010.82,
+                        "pf_lower": 342.98,
+                        "pf_upper": 3301.05
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 47.49,
+                        "pf_lower": 39.98,
+                        "pf_upper": 66.6
+                    },
+                    "2050-2079": {
+                        "pf": 88.2,
+                        "pf_lower": 69.23,
+                        "pf_upper": 151.1
+                    },
+                    "2080-2099": {
+                        "pf": 65.79,
+                        "pf_lower": 54.33,
+                        "pf_upper": 101.63
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 58.51,
+                        "pf_lower": 50.29,
+                        "pf_upper": 82.19
+                    },
+                    "2050-2079": {
+                        "pf": 52.19,
+                        "pf_lower": 45.18,
+                        "pf_upper": 71.77
+                    },
+                    "2080-2099": {
+                        "pf": 33.53,
+                        "pf_lower": 30.21,
+                        "pf_upper": 42.28
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 95.14,
+                        "pf_lower": 67.92,
+                        "pf_upper": 162.12
+                    },
+                    "2050-2079": {
+                        "pf": 91.43,
+                        "pf_lower": 69.44,
+                        "pf_upper": 164.57
+                    },
+                    "2080-2099": {
+                        "pf": 101.06,
+                        "pf_lower": 81.93,
+                        "pf_upper": 178.71
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 92.6,
+                        "pf_lower": 81.61,
+                        "pf_upper": 114.25
+                    },
+                    "2050-2079": {
+                        "pf": 75.23,
+                        "pf_lower": 69.76,
+                        "pf_upper": 84.8
+                    },
+                    "2080-2099": {
+                        "pf": 79.45,
+                        "pf_lower": 70.91,
+                        "pf_upper": 97.89
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 341.19,
+                        "pf_lower": 271.32,
+                        "pf_upper": 559.16
+                    },
+                    "2050-2079": {
+                        "pf": 388.77,
+                        "pf_lower": 299.86,
+                        "pf_upper": 594.71
+                    },
+                    "2080-2099": {
+                        "pf": 334.52,
+                        "pf_lower": 267.84,
+                        "pf_upper": 497.85
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 343.61,
+                        "pf_lower": 247.85,
+                        "pf_upper": 730.23
+                    },
+                    "2050-2079": {
+                        "pf": 374.39,
+                        "pf_lower": 238.48,
+                        "pf_upper": 763.89
+                    },
+                    "2080-2099": {
+                        "pf": 333.99,
+                        "pf_lower": 273.14,
+                        "pf_upper": 701.43
+                    }
+                }
+            }
+        },
+        "1000": {
+            "10d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 431.22,
+                        "pf_lower": 344.57,
+                        "pf_upper": 758.72
+                    },
+                    "2050-2079": {
+                        "pf": 469.35,
+                        "pf_lower": 385.78,
+                        "pf_upper": 729.03
+                    },
+                    "2080-2099": {
+                        "pf": 409.6,
+                        "pf_lower": 355.7,
+                        "pf_upper": 607.37
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 422.24,
+                        "pf_lower": 301.35,
+                        "pf_upper": 1012.86
+                    },
+                    "2050-2079": {
+                        "pf": 456.97,
+                        "pf_lower": 273.55,
+                        "pf_upper": 1147.83
+                    },
+                    "2080-2099": {
+                        "pf": 414.18,
+                        "pf_lower": 339.41,
+                        "pf_upper": 990.05
+                    }
+                }
+            },
+            "12h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 222.51,
+                        "pf_lower": 153.31,
+                        "pf_upper": 457.69
+                    },
+                    "2050-2079": {
+                        "pf": 130.51,
+                        "pf_lower": 106.68,
+                        "pf_upper": 229.55
+                    },
+                    "2080-2099": {
+                        "pf": 125.01,
+                        "pf_lower": 111.51,
+                        "pf_upper": 245.4
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 172.56,
+                        "pf_lower": 135.76,
+                        "pf_upper": 275.18
+                    },
+                    "2050-2079": {
+                        "pf": 98.82,
+                        "pf_lower": 92.85,
+                        "pf_upper": 109.22
+                    },
+                    "2080-2099": {
+                        "pf": 175.97,
+                        "pf_lower": 134.38,
+                        "pf_upper": 313.69
+                    }
+                }
+            },
+            "20d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 435.53,
+                        "pf_lower": 344.91,
+                        "pf_upper": 759.48
+                    },
+                    "2050-2079": {
+                        "pf": 491.55,
+                        "pf_lower": 386.17,
+                        "pf_upper": 770.1
+                    },
+                    "2080-2099": {
+                        "pf": 453.85,
+                        "pf_lower": 361.09,
+                        "pf_upper": 688.43
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 426.46,
+                        "pf_lower": 336.78,
+                        "pf_upper": 1013.88
+                    },
+                    "2050-2079": {
+                        "pf": 461.54,
+                        "pf_lower": 361.42,
+                        "pf_upper": 1148.98
+                    },
+                    "2080-2099": {
+                        "pf": 525.22,
+                        "pf_lower": 339.75,
+                        "pf_upper": 1460.77
+                    }
+                }
+            },
+            "24h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 235.99,
+                        "pf_lower": 182.62,
+                        "pf_upper": 458.15
+                    },
+                    "2050-2079": {
+                        "pf": 208.55,
+                        "pf_lower": 168.39,
+                        "pf_upper": 301.77
+                    },
+                    "2080-2099": {
+                        "pf": 287.52,
+                        "pf_lower": 202.31,
+                        "pf_upper": 604.34
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 262.64,
+                        "pf_lower": 206.74,
+                        "pf_upper": 422.12
+                    },
+                    "2050-2079": {
+                        "pf": 204,
+                        "pf_lower": 179.47,
+                        "pf_upper": 252.35
+                    },
+                    "2080-2099": {
+                        "pf": 190.59,
+                        "pf_lower": 160.59,
+                        "pf_upper": 314.01
+                    }
+                }
+            },
+            "2d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 363.76,
+                        "pf_lower": 244.81,
+                        "pf_upper": 755.69
+                    },
+                    "2050-2079": {
+                        "pf": 299.59,
+                        "pf_lower": 218.64,
+                        "pf_upper": 531.16
+                    },
+                    "2080-2099": {
+                        "pf": 290.39,
+                        "pf_lower": 205.47,
+                        "pf_upper": 604.94
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 355.84,
+                        "pf_lower": 261.2,
+                        "pf_upper": 647.75
+                    },
+                    "2050-2079": {
+                        "pf": 327.96,
+                        "pf_lower": 259.88,
+                        "pf_upper": 495.25
+                    },
+                    "2080-2099": {
+                        "pf": 398.01,
+                        "pf_lower": 279.26,
+                        "pf_upper": 817.27
+                    }
+                }
+            },
+            "2h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 72.06,
+                        "pf_lower": 57.9,
+                        "pf_upper": 110.67
+                    },
+                    "2050-2079": {
+                        "pf": 114.95,
+                        "pf_lower": 88.09,
+                        "pf_upper": 218.34
+                    },
+                    "2080-2099": {
+                        "pf": 121.34,
+                        "pf_lower": 91.32,
+                        "pf_upper": 244.66
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 101.02,
+                        "pf_lower": 86.09,
+                        "pf_upper": 147.36
+                    },
+                    "2050-2079": {
+                        "pf": 63.01,
+                        "pf_lower": 57.27,
+                        "pf_upper": 92.22
+                    },
+                    "2080-2099": {
+                        "pf": 57.25,
+                        "pf_lower": 51.46,
+                        "pf_upper": 73.41
+                    }
+                }
+            },
+            "30d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 453.91,
+                        "pf_lower": 348.29,
+                        "pf_upper": 760.24
+                    },
+                    "2050-2079": {
+                        "pf": 496.47,
+                        "pf_lower": 454.56,
+                        "pf_upper": 770.87
+                    },
+                    "2080-2099": {
+                        "pf": 593.11,
+                        "pf_lower": 423.41,
+                        "pf_upper": 1081.44
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 430.73,
+                        "pf_lower": 337.12,
+                        "pf_upper": 1014.89
+                    },
+                    "2050-2079": {
+                        "pf": 466.16,
+                        "pf_lower": 361.78,
+                        "pf_upper": 1150.13
+                    },
+                    "2080-2099": {
+                        "pf": 882.83,
+                        "pf_lower": 340.09,
+                        "pf_upper": 3803.72
+                    }
+                }
+            },
+            "3d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 367.4,
+                        "pf_lower": 316.6,
+                        "pf_upper": 756.45
+                    },
+                    "2050-2079": {
+                        "pf": 346.01,
+                        "pf_lower": 232.15,
+                        "pf_upper": 692.36
+                    },
+                    "2080-2099": {
+                        "pf": 293.3,
+                        "pf_lower": 250.46,
+                        "pf_upper": 605.55
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 359.4,
+                        "pf_lower": 261.46,
+                        "pf_upper": 885.6
+                    },
+                    "2050-2079": {
+                        "pf": 331.24,
+                        "pf_lower": 272.73,
+                        "pf_upper": 495.75
+                    },
+                    "2080-2099": {
+                        "pf": 401.99,
+                        "pf_lower": 279.54,
+                        "pf_upper": 987.09
+                    }
+                }
+            },
+            "3h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 83.1,
+                        "pf_lower": 60.35,
+                        "pf_upper": 148.12
+                    },
+                    "2050-2079": {
+                        "pf": 116.1,
+                        "pf_lower": 88.18,
+                        "pf_upper": 229.09
+                    },
+                    "2080-2099": {
+                        "pf": 122.55,
+                        "pf_lower": 98.19,
+                        "pf_upper": 244.91
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 102.03,
+                        "pf_lower": 89.33,
+                        "pf_upper": 147.51
+                    },
+                    "2050-2079": {
+                        "pf": 71.63,
+                        "pf_lower": 65.37,
+                        "pf_upper": 92.31
+                    },
+                    "2080-2099": {
+                        "pf": 59.82,
+                        "pf_lower": 55.07,
+                        "pf_upper": 73.49
+                    }
+                }
+            },
+            "45d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 458.45,
+                        "pf_lower": 360.21,
+                        "pf_upper": 761
+                    },
+                    "2050-2079": {
+                        "pf": 501.43,
+                        "pf_lower": 455.02,
+                        "pf_upper": 771.64
+                    },
+                    "2080-2099": {
+                        "pf": 648.69,
+                        "pf_lower": 423.68,
+                        "pf_upper": 1292.68
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 435.03,
+                        "pf_lower": 337.46,
+                        "pf_upper": 1015.9
+                    },
+                    "2050-2079": {
+                        "pf": 468.75,
+                        "pf_lower": 362.14,
+                        "pf_upper": 1151.28
+                    },
+                    "2080-2099": {
+                        "pf": 1110.75,
+                        "pf_lower": 340.43,
+                        "pf_upper": 4607.19
+                    }
+                }
+            },
+            "4d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 390.89,
+                        "pf_lower": 316.91,
+                        "pf_upper": 757.2
+                    },
+                    "2050-2079": {
+                        "pf": 359.25,
+                        "pf_lower": 279.55,
+                        "pf_upper": 693.06
+                    },
+                    "2080-2099": {
+                        "pf": 296.23,
+                        "pf_lower": 251.2,
+                        "pf_upper": 606.16
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 413.92,
+                        "pf_lower": 261.72,
+                        "pf_upper": 1010.84
+                    },
+                    "2050-2079": {
+                        "pf": 435.79,
+                        "pf_lower": 273.01,
+                        "pf_upper": 931.07
+                    },
+                    "2080-2099": {
+                        "pf": 406.01,
+                        "pf_lower": 338.73,
+                        "pf_upper": 988.07
+                    }
+                }
+            },
+            "60d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 463.55,
+                        "pf_lower": 381.01,
+                        "pf_upper": 761.76
+                    },
+                    "2050-2079": {
+                        "pf": 522.37,
+                        "pf_lower": 457.59,
+                        "pf_upper": 772.41
+                    },
+                    "2080-2099": {
+                        "pf": 683.06,
+                        "pf_lower": 471.38,
+                        "pf_upper": 1293.98
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 552.05,
+                        "pf_lower": 367.68,
+                        "pf_upper": 1016.92
+                    },
+                    "2050-2079": {
+                        "pf": 498.25,
+                        "pf_lower": 400.69,
+                        "pf_upper": 1152.43
+                    },
+                    "2080-2099": {
+                        "pf": 1236.49,
+                        "pf_lower": 350.31,
+                        "pf_upper": 5020.64
+                    }
+                }
+            },
+            "60m": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 55.4,
+                        "pf_lower": 46.17,
+                        "pf_upper": 83.05
+                    },
+                    "2050-2079": {
+                        "pf": 113.82,
+                        "pf_lower": 88,
+                        "pf_upper": 218.12
+                    },
+                    "2080-2099": {
+                        "pf": 77.39,
+                        "pf_lower": 63.23,
+                        "pf_upper": 131.4
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 71.6,
+                        "pf_lower": 61.01,
+                        "pf_upper": 107.74
+                    },
+                    "2050-2079": {
+                        "pf": 62.22,
+                        "pf_lower": 53.3,
+                        "pf_upper": 92.13
+                    },
+                    "2080-2099": {
+                        "pf": 37.59,
+                        "pf_lower": 33.69,
+                        "pf_upper": 49.96
+                    }
+                }
+            },
+            "6h": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 107.55,
+                        "pf_lower": 74.31,
+                        "pf_upper": 201.69
+                    },
+                    "2050-2079": {
+                        "pf": 117.26,
+                        "pf_lower": 89.38,
+                        "pf_upper": 229.32
+                    },
+                    "2080-2099": {
+                        "pf": 123.78,
+                        "pf_lower": 100.98,
+                        "pf_upper": 245.15
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 105.12,
+                        "pf_lower": 92.51,
+                        "pf_upper": 147.66
+                    },
+                    "2050-2079": {
+                        "pf": 82.97,
+                        "pf_lower": 76.98,
+                        "pf_upper": 94.51
+                    },
+                    "2080-2099": {
+                        "pf": 88.92,
+                        "pf_lower": 79.35,
+                        "pf_upper": 113.12
+                    }
+                }
+            },
+            "7d": {
+                "GFDL-CM3": {
+                    "2020-2049": {
+                        "pf": 394.8,
+                        "pf_lower": 317.23,
+                        "pf_upper": 757.96
+                    },
+                    "2050-2079": {
+                        "pf": 440.54,
+                        "pf_lower": 333.74,
+                        "pf_upper": 728.3
+                    },
+                    "2080-2099": {
+                        "pf": 367.86,
+                        "pf_lower": 291.24,
+                        "pf_upper": 606.76
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "2020-2049": {
+                        "pf": 418.06,
+                        "pf_lower": 301.04,
+                        "pf_upper": 1011.85
+                    },
+                    "2050-2079": {
+                        "pf": 440.15,
+                        "pf_lower": 273.28,
+                        "pf_upper": 1009.83
+                    },
+                    "2080-2099": {
+                        "pf": 410.07,
+                        "pf_lower": 339.07,
+                        "pf_upper": 989.06
+                    }
+                }
+            }
+        }
+    },
+    "precipitation": {
+        "preview": "model,scenario,year,pr\r\nCRU-TS,historical,1901,778\r\nCRU-TS,historical,1902,778\r\nCRU-TS,historical,1903,518\r\nCRU-TS,historical,1904,520\r\nCRU-TS,historical,1905,824\r\nNCAR-CCSM4,rcp85,2096,1270\r\nNCAR-CCSM4,rcp85,2097,1219\r\nNCAR-CCSM4,rcp85,2098,977\r\nNCAR-CCSM4,rcp85,2099,983\r\nNCAR-CCSM4,rcp85,2100,1015\r\n",
+        "summary": {
+            "2010-2039": {
+                "prmax": 1175,
+                "prmean": 870,
+                "prmin": 556
+            },
+            "2040-2069": {
+                "prmax": 1411,
+                "prmean": 922,
+                "prmin": 538
+            },
+            "2070-2099": {
+                "prmax": 1477,
+                "prmean": 977,
+                "prmin": 627
+            },
+            "historical": {
+                "prmax": 1126,
+                "prmean": 794,
+                "prmin": 471
+            }
+        }
+    },
+    "snowfall": {
+        "preview": "model,scenario,decade,SFE\r\nCRU-TS,historical,1910-1919,188\r\nCRU-TS,historical,1920-1929,190\r\nCRU-TS,historical,1930-1939,202\r\nCRU-TS,historical,1940-1949,207\r\nCRU-TS,historical,1950-1959,170\r\nNCAR-CCSM4,rcp85,2050-2059,217\r\nNCAR-CCSM4,rcp85,2060-2069,199\r\nNCAR-CCSM4,rcp85,2070-2079,163\r\nNCAR-CCSM4,rcp85,2080-2089,177\r\nNCAR-CCSM4,rcp85,2090-2099,161\r\n",
+        "summary": {
+            "historical": {
+                "sfemax": 207,
+                "sfemean": 189,
+                "sfemin": 153
+            },
+            "projected": {
+                "sfemax": 245,
+                "sfemean": 200,
+                "sfemin": 149
+            }
+        }
+    },
+    "temperature": {
+        "preview": "model,scenario,month,year,tasmin,tasmean,tasmax\r\nCRU-TS,historical,January,1901,-25.2,-19.9,-15.4\r\nCRU-TS,historical,January,1902,-23.6,-18.1,-13.4\r\nCRU-TS,historical,January,1903,-29.9,-23,-16.9\r\nCRU-TS,historical,January,1904,-28.4,-22.5,-17.4\r\nCRU-TS,historical,January,1905,-21.2,-16,-11.7\r\nNCAR-CCSM4,rcp85,December,2096,-4.9,-9.1,-0.9\r\nNCAR-CCSM4,rcp85,December,2097,-17.8,-4.9,-10.9\r\nNCAR-CCSM4,rcp85,December,2098,-5.2,-4.2,-0.9\r\nNCAR-CCSM4,rcp85,December,2099,-8.4,-6.8,-3.4\r\nNCAR-CCSM4,rcp85,December,2100,-11.9,-11.1,-7.1\r\n",
+        "summary": {
+            "historical": {
+                "CRU-TS": {
+                    "historical": {
+                        "Annual": {
+                            "tasmax": -0.1,
+                            "tasmean": -3.1,
+                            "tasmin": -5.8
+                        },
+                        "April": {
+                            "tasmax": 8.5,
+                            "tasmean": -2.7,
+                            "tasmin": -16.6
+                        },
+                        "August": {
+                            "tasmax": 19.9,
+                            "tasmean": 10.8,
+                            "tasmin": 2.9
+                        },
+                        "December": {
+                            "tasmax": -4.4,
+                            "tasmean": -17.8,
+                            "tasmin": -31.2
+                        },
+                        "February": {
+                            "tasmax": -3.3,
+                            "tasmean": -15.2,
+                            "tasmin": -33.1
+                        },
+                        "January": {
+                            "tasmax": -3.9,
+                            "tasmean": -18.3,
+                            "tasmin": -36.2
+                        },
+                        "July": {
+                            "tasmax": 21.5,
+                            "tasmean": 12.8,
+                            "tasmin": 5.5
+                        },
+                        "June": {
+                            "tasmax": 21.1,
+                            "tasmean": 11.3,
+                            "tasmin": 3.2
+                        },
+                        "March": {
+                            "tasmax": 1,
+                            "tasmean": -12,
+                            "tasmin": -28
+                        },
+                        "May": {
+                            "tasmax": 14.6,
+                            "tasmean": 5.2,
+                            "tasmin": -3.9
+                        },
+                        "November": {
+                            "tasmax": -1.5,
+                            "tasmean": -12,
+                            "tasmin": -23.7
+                        },
+                        "October": {
+                            "tasmax": 3.6,
+                            "tasmean": -4.7,
+                            "tasmin": -14.3
+                        },
+                        "September": {
+                            "tasmax": 13.4,
+                            "tasmean": 5.5,
+                            "tasmin": -2.4
+                        }
+                    }
+                }
+            },
+            "projected": {
+                "5ModelAvg": {
+                    "rcp45": {
+                        "April": {
+                            "2010-2039": {
+                                "tasmax": 2,
+                                "tasmean": -1,
+                                "tasmin": -2.6
+                            },
+                            "2040-2069": {
+                                "tasmax": 2.2,
+                                "tasmean": 0.5,
+                                "tasmin": -1.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 3.6,
+                                "tasmean": 0.9,
+                                "tasmin": -2.2
+                            }
+                        },
+                        "August": {
+                            "2010-2039": {
+                                "tasmax": 13.7,
+                                "tasmean": 12.4,
+                                "tasmin": 10.6
+                            },
+                            "2040-2069": {
+                                "tasmax": 14.7,
+                                "tasmean": 13.4,
+                                "tasmin": 12.5
+                            },
+                            "2070-2099": {
+                                "tasmax": 15.1,
+                                "tasmean": 13.9,
+                                "tasmin": 13.1
+                            }
+                        },
+                        "December": {
+                            "2010-2039": {
+                                "tasmax": -9.2,
+                                "tasmean": -15.1,
+                                "tasmin": -19
+                            },
+                            "2040-2069": {
+                                "tasmax": -10.3,
+                                "tasmean": -13.2,
+                                "tasmin": -17.4
+                            },
+                            "2070-2099": {
+                                "tasmax": -7.9,
+                                "tasmean": -11.7,
+                                "tasmin": -14.8
+                            }
+                        },
+                        "February": {
+                            "2010-2039": {
+                                "tasmax": -10.4,
+                                "tasmean": -12.9,
+                                "tasmin": -16.5
+                            },
+                            "2040-2069": {
+                                "tasmax": -7.7,
+                                "tasmean": -11.4,
+                                "tasmin": -13.9
+                            },
+                            "2070-2099": {
+                                "tasmax": -7.1,
+                                "tasmean": -10.6,
+                                "tasmin": -15.2
+                            }
+                        },
+                        "January": {
+                            "2010-2039": {
+                                "tasmax": -12.4,
+                                "tasmean": -16.2,
+                                "tasmin": -22
+                            },
+                            "2040-2069": {
+                                "tasmax": -11.8,
+                                "tasmean": -14.1,
+                                "tasmin": -16.9
+                            },
+                            "2070-2099": {
+                                "tasmax": -9.7,
+                                "tasmean": -13,
+                                "tasmin": -15.8
+                            }
+                        },
+                        "July": {
+                            "2010-2039": {
+                                "tasmax": 15.6,
+                                "tasmean": 14.4,
+                                "tasmin": 13.2
+                            },
+                            "2040-2069": {
+                                "tasmax": 17.4,
+                                "tasmean": 15.6,
+                                "tasmin": 14.4
+                            },
+                            "2070-2099": {
+                                "tasmax": 17.5,
+                                "tasmean": 16.2,
+                                "tasmin": 14.7
+                            }
+                        },
+                        "June": {
+                            "2010-2039": {
+                                "tasmax": 14.8,
+                                "tasmean": 12.6,
+                                "tasmin": 10.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 15,
+                                "tasmean": 13.6,
+                                "tasmin": 12.3
+                            },
+                            "2070-2099": {
+                                "tasmax": 15.7,
+                                "tasmean": 14.4,
+                                "tasmin": 12.3
+                            }
+                        },
+                        "March": {
+                            "2010-2039": {
+                                "tasmax": -4.7,
+                                "tasmean": -8.8,
+                                "tasmin": -11.1
+                            },
+                            "2040-2069": {
+                                "tasmax": -4.2,
+                                "tasmean": -7.7,
+                                "tasmin": -11.3
+                            },
+                            "2070-2099": {
+                                "tasmax": -2.8,
+                                "tasmean": -6.7,
+                                "tasmin": -9.2
+                            }
+                        },
+                        "May": {
+                            "2010-2039": {
+                                "tasmax": 8.3,
+                                "tasmean": 6.6,
+                                "tasmin": 5.1
+                            },
+                            "2040-2069": {
+                                "tasmax": 9.5,
+                                "tasmean": 8,
+                                "tasmin": 6.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 9.5,
+                                "tasmean": 8.2,
+                                "tasmin": 6.7
+                            }
+                        },
+                        "November": {
+                            "2010-2039": {
+                                "tasmax": -5.6,
+                                "tasmean": -9.9,
+                                "tasmin": -13.1
+                            },
+                            "2040-2069": {
+                                "tasmax": -5.6,
+                                "tasmean": -8.4,
+                                "tasmin": -11.5
+                            },
+                            "2070-2099": {
+                                "tasmax": -4.5,
+                                "tasmean": -7.1,
+                                "tasmin": -10.1
+                            }
+                        },
+                        "October": {
+                            "2010-2039": {
+                                "tasmax": -0.7,
+                                "tasmean": -3.5,
+                                "tasmin": -6.2
+                            },
+                            "2040-2069": {
+                                "tasmax": -0.1,
+                                "tasmean": -2.3,
+                                "tasmin": -4.3
+                            },
+                            "2070-2099": {
+                                "tasmax": 0.6,
+                                "tasmean": -1.4,
+                                "tasmin": -3.4
+                            }
+                        },
+                        "September": {
+                            "2010-2039": {
+                                "tasmax": 8.6,
+                                "tasmean": 7.1,
+                                "tasmin": 5.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 9.9,
+                                "tasmean": 8.2,
+                                "tasmin": 6.4
+                            },
+                            "2070-2099": {
+                                "tasmax": 9.9,
+                                "tasmean": 8.9,
+                                "tasmin": 8
+                            }
+                        }
+                    },
+                    "rcp85": {
+                        "Annual": {
+                            "2010-2039": {
+                                "tasmax": 0.6,
+                                "tasmean": -0.8,
+                                "tasmin": -1.8
+                            },
+                            "2040-2069": {
+                                "tasmax": 2.7,
+                                "tasmean": 1.1,
+                                "tasmin": -0.3
+                            },
+                            "2070-2099": {
+                                "tasmax": 4.7,
+                                "tasmean": 3.1,
+                                "tasmin": 1.8
+                            }
+                        },
+                        "April": {
+                            "2010-2039": {
+                                "tasmax": 1.9,
+                                "tasmean": -0.9,
+                                "tasmin": -3
+                            },
+                            "2040-2069": {
+                                "tasmax": 3.1,
+                                "tasmean": 1.1,
+                                "tasmin": -1.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 4.9,
+                                "tasmean": 2.6,
+                                "tasmin": 0.6
+                            }
+                        },
+                        "August": {
+                            "2010-2039": {
+                                "tasmax": 14,
+                                "tasmean": 12.6,
+                                "tasmin": 11.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 16,
+                                "tasmean": 14.2,
+                                "tasmin": 12.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 16.8,
+                                "tasmean": 15.7,
+                                "tasmin": 13.8
+                            }
+                        },
+                        "December": {
+                            "2010-2039": {
+                                "tasmax": -9.7,
+                                "tasmean": -14.2,
+                                "tasmin": -20.6
+                            },
+                            "2040-2069": {
+                                "tasmax": -8.6,
+                                "tasmean": -11.9,
+                                "tasmin": -17.5
+                            },
+                            "2070-2099": {
+                                "tasmax": -5.7,
+                                "tasmean": -8.7,
+                                "tasmin": -11.6
+                            }
+                        },
+                        "February": {
+                            "2010-2039": {
+                                "tasmax": -9.5,
+                                "tasmean": -11.8,
+                                "tasmin": -15.7
+                            },
+                            "2040-2069": {
+                                "tasmax": -6.3,
+                                "tasmean": -10.3,
+                                "tasmin": -14.1
+                            },
+                            "2070-2099": {
+                                "tasmax": -4.8,
+                                "tasmean": -8.9,
+                                "tasmin": -13.2
+                            }
+                        },
+                        "January": {
+                            "2010-2039": {
+                                "tasmax": -11,
+                                "tasmean": -14.6,
+                                "tasmin": -19
+                            },
+                            "2040-2069": {
+                                "tasmax": -8.9,
+                                "tasmean": -12.3,
+                                "tasmin": -16.2
+                            },
+                            "2070-2099": {
+                                "tasmax": -6.1,
+                                "tasmean": -9.4,
+                                "tasmin": -12.9
+                            }
+                        },
+                        "July": {
+                            "2010-2039": {
+                                "tasmax": 16,
+                                "tasmean": 14.6,
+                                "tasmin": 13.1
+                            },
+                            "2040-2069": {
+                                "tasmax": 17.2,
+                                "tasmean": 16.2,
+                                "tasmin": 14.7
+                            },
+                            "2070-2099": {
+                                "tasmax": 19.7,
+                                "tasmean": 18,
+                                "tasmin": 16.8
+                            }
+                        },
+                        "June": {
+                            "2010-2039": {
+                                "tasmax": 14.4,
+                                "tasmean": 12.7,
+                                "tasmin": 11
+                            },
+                            "2040-2069": {
+                                "tasmax": 16.4,
+                                "tasmean": 14.4,
+                                "tasmin": 12.5
+                            },
+                            "2070-2099": {
+                                "tasmax": 18.3,
+                                "tasmean": 16.1,
+                                "tasmin": 13.9
+                            }
+                        },
+                        "March": {
+                            "2010-2039": {
+                                "tasmax": -5.6,
+                                "tasmean": -8.6,
+                                "tasmin": -12.8
+                            },
+                            "2040-2069": {
+                                "tasmax": -3.5,
+                                "tasmean": -6.2,
+                                "tasmin": -8.9
+                            },
+                            "2070-2099": {
+                                "tasmax": -0.7,
+                                "tasmean": -4.6,
+                                "tasmin": -7.4
+                            }
+                        },
+                        "May": {
+                            "2010-2039": {
+                                "tasmax": 9,
+                                "tasmean": 6.9,
+                                "tasmin": 4.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 10.2,
+                                "tasmean": 8.4,
+                                "tasmin": 5.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 12.2,
+                                "tasmean": 10.1,
+                                "tasmin": 8.7
+                            }
+                        },
+                        "November": {
+                            "2010-2039": {
+                                "tasmax": -6.4,
+                                "tasmean": -9.5,
+                                "tasmin": -12.6
+                            },
+                            "2040-2069": {
+                                "tasmax": -3.8,
+                                "tasmean": -7.1,
+                                "tasmin": -11
+                            },
+                            "2070-2099": {
+                                "tasmax": -1.3,
+                                "tasmean": -4.5,
+                                "tasmin": -7.3
+                            }
+                        },
+                        "October": {
+                            "2010-2039": {
+                                "tasmax": -0.5,
+                                "tasmean": -3.3,
+                                "tasmin": -5.9
+                            },
+                            "2040-2069": {
+                                "tasmax": 0.5,
+                                "tasmean": -1.7,
+                                "tasmin": -3.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 2.7,
+                                "tasmean": 0.2,
+                                "tasmin": -1.9
+                            }
+                        },
+                        "September": {
+                            "2010-2039": {
+                                "tasmax": 9.3,
+                                "tasmean": 7.3,
+                                "tasmin": 6
+                            },
+                            "2040-2069": {
+                                "tasmax": 9.9,
+                                "tasmean": 8.9,
+                                "tasmin": 7.4
+                            },
+                            "2070-2099": {
+                                "tasmax": 11.8,
+                                "tasmean": 10.5,
+                                "tasmin": 8.9
+                            }
+                        }
+                    }
+                },
+                "GFDL-CM3": {
+                    "rcp45": {
+                        "April": {
+                            "2010-2039": {
+                                "tasmax": 4.4,
+                                "tasmean": 1,
+                                "tasmin": -3.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 7.6,
+                                "tasmean": 3.5,
+                                "tasmin": -0.5
+                            },
+                            "2070-2099": {
+                                "tasmax": 7.2,
+                                "tasmean": 4.3,
+                                "tasmin": -1
+                            }
+                        },
+                        "August": {
+                            "2010-2039": {
+                                "tasmax": 15.1,
+                                "tasmean": 13.3,
+                                "tasmin": 10.9
+                            },
+                            "2040-2069": {
+                                "tasmax": 17.5,
+                                "tasmean": 15,
+                                "tasmin": 12.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 17.7,
+                                "tasmean": 15.4,
+                                "tasmin": 12.8
+                            }
+                        },
+                        "December": {
+                            "2010-2039": {
+                                "tasmax": -6.3,
+                                "tasmean": -13.9,
+                                "tasmin": -21.4
+                            },
+                            "2040-2069": {
+                                "tasmax": -3.4,
+                                "tasmean": -10.7,
+                                "tasmin": -19.4
+                            },
+                            "2070-2099": {
+                                "tasmax": -3.8,
+                                "tasmean": -9.2,
+                                "tasmin": -14
+                            }
+                        },
+                        "February": {
+                            "2010-2039": {
+                                "tasmax": -5.9,
+                                "tasmean": -11.9,
+                                "tasmin": -19.5
+                            },
+                            "2040-2069": {
+                                "tasmax": -3.6,
+                                "tasmean": -9.4,
+                                "tasmin": -20
+                            },
+                            "2070-2099": {
+                                "tasmax": -1.3,
+                                "tasmean": -7.6,
+                                "tasmin": -14.7
+                            }
+                        },
+                        "January": {
+                            "2010-2039": {
+                                "tasmax": -8.5,
+                                "tasmean": -15.5,
+                                "tasmin": -23.3
+                            },
+                            "2040-2069": {
+                                "tasmax": -4.9,
+                                "tasmean": -11.4,
+                                "tasmin": -19.5
+                            },
+                            "2070-2099": {
+                                "tasmax": -3.7,
+                                "tasmean": -11.2,
+                                "tasmin": -19.6
+                            }
+                        },
+                        "July": {
+                            "2010-2039": {
+                                "tasmax": 17.6,
+                                "tasmean": 15.2,
+                                "tasmin": 12.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 18.9,
+                                "tasmean": 17.1,
+                                "tasmin": 15.5
+                            },
+                            "2070-2099": {
+                                "tasmax": 19.4,
+                                "tasmean": 17.8,
+                                "tasmin": 14.8
+                            }
+                        },
+                        "June": {
+                            "2010-2039": {
+                                "tasmax": 16,
+                                "tasmean": 13.6,
+                                "tasmin": 11.1
+                            },
+                            "2040-2069": {
+                                "tasmax": 17.6,
+                                "tasmean": 15.8,
+                                "tasmin": 13.5
+                            },
+                            "2070-2099": {
+                                "tasmax": 18.3,
+                                "tasmean": 16.4,
+                                "tasmin": 13.4
+                            }
+                        },
+                        "March": {
+                            "2010-2039": {
+                                "tasmax": -3.1,
+                                "tasmean": -8.3,
+                                "tasmin": -14.9
+                            },
+                            "2040-2069": {
+                                "tasmax": -0.9,
+                                "tasmean": -4.9,
+                                "tasmin": -11.5
+                            },
+                            "2070-2099": {
+                                "tasmax": -0.2,
+                                "tasmean": -4.5,
+                                "tasmin": -12.6
+                            }
+                        },
+                        "May": {
+                            "2010-2039": {
+                                "tasmax": 11.6,
+                                "tasmean": 8.3,
+                                "tasmin": 5.1
+                            },
+                            "2040-2069": {
+                                "tasmax": 12.7,
+                                "tasmean": 10.3,
+                                "tasmin": 4.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 14.3,
+                                "tasmean": 11.3,
+                                "tasmin": 6.8
+                            }
+                        },
+                        "November": {
+                            "2010-2039": {
+                                "tasmax": -1.4,
+                                "tasmean": -9.2,
+                                "tasmin": -16.2
+                            },
+                            "2040-2069": {
+                                "tasmax": -2.1,
+                                "tasmean": -6.6,
+                                "tasmin": -10.8
+                            },
+                            "2070-2099": {
+                                "tasmax": -0.7,
+                                "tasmean": -4.9,
+                                "tasmin": -10.2
+                            }
+                        },
+                        "October": {
+                            "2010-2039": {
+                                "tasmax": 1.7,
+                                "tasmean": -3.3,
+                                "tasmin": -7.8
+                            },
+                            "2040-2069": {
+                                "tasmax": 3.2,
+                                "tasmean": -0.8,
+                                "tasmin": -3.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 4.4,
+                                "tasmean": -0.4,
+                                "tasmin": -5.2
+                            }
+                        },
+                        "September": {
+                            "2010-2039": {
+                                "tasmax": 11.1,
+                                "tasmean": 8.1,
+                                "tasmin": 4.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 13.3,
+                                "tasmean": 10.2,
+                                "tasmin": 7.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 13.7,
+                                "tasmean": 10.5,
+                                "tasmin": 8.4
+                            }
+                        }
+                    },
+                    "rcp85": {
+                        "April": {
+                            "2010-2039": {
+                                "tasmax": 5.5,
+                                "tasmean": 0.8,
+                                "tasmin": -5.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 8.2,
+                                "tasmean": 3.9,
+                                "tasmin": -0.7
+                            },
+                            "2070-2099": {
+                                "tasmax": 9.4,
+                                "tasmean": 5.8,
+                                "tasmin": 0.7
+                            }
+                        },
+                        "August": {
+                            "2010-2039": {
+                                "tasmax": 16.6,
+                                "tasmean": 13.5,
+                                "tasmin": 10.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 18.3,
+                                "tasmean": 15.6,
+                                "tasmin": 12
+                            },
+                            "2070-2099": {
+                                "tasmax": 19.8,
+                                "tasmean": 17.5,
+                                "tasmin": 13.8
+                            }
+                        },
+                        "December": {
+                            "2010-2039": {
+                                "tasmax": -7.6,
+                                "tasmean": -13.2,
+                                "tasmin": -20.1
+                            },
+                            "2040-2069": {
+                                "tasmax": -4.2,
+                                "tasmean": -9.5,
+                                "tasmin": -15.3
+                            },
+                            "2070-2099": {
+                                "tasmax": -3.5,
+                                "tasmean": -6.8,
+                                "tasmin": -10.8
+                            }
+                        },
+                        "February": {
+                            "2010-2039": {
+                                "tasmax": -4.3,
+                                "tasmean": -11.1,
+                                "tasmin": -18.7
+                            },
+                            "2040-2069": {
+                                "tasmax": -2.2,
+                                "tasmean": -8.2,
+                                "tasmin": -15.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 1.2,
+                                "tasmean": -6.2,
+                                "tasmin": -16.3
+                            }
+                        },
+                        "January": {
+                            "2010-2039": {
+                                "tasmax": -6.9,
+                                "tasmean": -12.9,
+                                "tasmin": -20.9
+                            },
+                            "2040-2069": {
+                                "tasmax": -3.2,
+                                "tasmean": -9.5,
+                                "tasmin": -19.7
+                            },
+                            "2070-2099": {
+                                "tasmax": -1.9,
+                                "tasmean": -7.1,
+                                "tasmin": -12.8
+                            }
+                        },
+                        "July": {
+                            "2010-2039": {
+                                "tasmax": 17.9,
+                                "tasmean": 15.5,
+                                "tasmin": 12.9
+                            },
+                            "2040-2069": {
+                                "tasmax": 19.9,
+                                "tasmean": 17.6,
+                                "tasmin": 14.7
+                            },
+                            "2070-2099": {
+                                "tasmax": 22,
+                                "tasmean": 20.1,
+                                "tasmin": 18.2
+                            }
+                        },
+                        "June": {
+                            "2010-2039": {
+                                "tasmax": 16.1,
+                                "tasmean": 13.6,
+                                "tasmin": 10.6
+                            },
+                            "2040-2069": {
+                                "tasmax": 18.6,
+                                "tasmean": 16.7,
+                                "tasmin": 12.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 21.2,
+                                "tasmean": 18.1,
+                                "tasmin": 15.3
+                            }
+                        },
+                        "March": {
+                            "2010-2039": {
+                                "tasmax": -1.5,
+                                "tasmean": -7.7,
+                                "tasmin": -15.8
+                            },
+                            "2040-2069": {
+                                "tasmax": 0,
+                                "tasmean": -4.5,
+                                "tasmin": -10.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 2.5,
+                                "tasmean": -2.4,
+                                "tasmin": -10.1
+                            }
+                        },
+                        "May": {
+                            "2010-2039": {
+                                "tasmax": 12,
+                                "tasmean": 8.1,
+                                "tasmin": 3.7
+                            },
+                            "2040-2069": {
+                                "tasmax": 14.4,
+                                "tasmean": 11.1,
+                                "tasmin": 7.7
+                            },
+                            "2070-2099": {
+                                "tasmax": 16.9,
+                                "tasmean": 13,
+                                "tasmin": 8.9
+                            }
+                        },
+                        "November": {
+                            "2010-2039": {
+                                "tasmax": -0.9,
+                                "tasmean": -8.1,
+                                "tasmin": -14
+                            },
+                            "2040-2069": {
+                                "tasmax": -1.3,
+                                "tasmean": -5.9,
+                                "tasmin": -11.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 0.9,
+                                "tasmean": -2.4,
+                                "tasmin": -6.3
+                            }
+                        },
+                        "October": {
+                            "2010-2039": {
+                                "tasmax": 0.6,
+                                "tasmean": -3.3,
+                                "tasmin": -6.2
+                            },
+                            "2040-2069": {
+                                "tasmax": 3.7,
+                                "tasmean": -0.6,
+                                "tasmin": -4.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 5.1,
+                                "tasmean": 2,
+                                "tasmin": -2.8
+                            }
+                        },
+                        "September": {
+                            "2010-2039": {
+                                "tasmax": 11.1,
+                                "tasmean": 8.1,
+                                "tasmin": 3.1
+                            },
+                            "2040-2069": {
+                                "tasmax": 13.2,
+                                "tasmean": 10.4,
+                                "tasmin": 8.2
+                            },
+                            "2070-2099": {
+                                "tasmax": 15.4,
+                                "tasmean": 12.3,
+                                "tasmin": 9.8
+                            }
+                        }
+                    }
+                },
+                "NCAR-CCSM4": {
+                    "rcp45": {
+                        "April": {
+                            "2010-2039": {
+                                "tasmax": 4.8,
+                                "tasmean": -1,
+                                "tasmin": -6.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 4.9,
+                                "tasmean": 0.6,
+                                "tasmin": -5.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 6.5,
+                                "tasmean": 0.8,
+                                "tasmin": -3.8
+                            }
+                        },
+                        "August": {
+                            "2010-2039": {
+                                "tasmax": 14.7,
+                                "tasmean": 11.8,
+                                "tasmin": 8.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 16.7,
+                                "tasmean": 13.2,
+                                "tasmin": 10.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 17.1,
+                                "tasmean": 13.7,
+                                "tasmin": 10.6
+                            }
+                        },
+                        "December": {
+                            "2010-2039": {
+                                "tasmax": -7.4,
+                                "tasmean": -16.7,
+                                "tasmin": -25.7
+                            },
+                            "2040-2069": {
+                                "tasmax": -6,
+                                "tasmean": -14.3,
+                                "tasmin": -20.8
+                            },
+                            "2070-2099": {
+                                "tasmax": -4.1,
+                                "tasmean": -12.8,
+                                "tasmin": -22.1
+                            }
+                        },
+                        "February": {
+                            "2010-2039": {
+                                "tasmax": -3.2,
+                                "tasmean": -10.2,
+                                "tasmin": -17.3
+                            },
+                            "2040-2069": {
+                                "tasmax": -2.9,
+                                "tasmean": -9.7,
+                                "tasmin": -18.7
+                            },
+                            "2070-2099": {
+                                "tasmax": -2.8,
+                                "tasmean": -8.6,
+                                "tasmin": -18.2
+                            }
+                        },
+                        "January": {
+                            "2010-2039": {
+                                "tasmax": -7.6,
+                                "tasmean": -15.9,
+                                "tasmin": -25.5
+                            },
+                            "2040-2069": {
+                                "tasmax": -4.6,
+                                "tasmean": -14.6,
+                                "tasmin": -25.5
+                            },
+                            "2070-2099": {
+                                "tasmax": -5.7,
+                                "tasmean": -12.9,
+                                "tasmin": -24.4
+                            }
+                        },
+                        "July": {
+                            "2010-2039": {
+                                "tasmax": 20.1,
+                                "tasmean": 14.3,
+                                "tasmin": 10.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 22.3,
+                                "tasmean": 15.8,
+                                "tasmin": 11.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 22.1,
+                                "tasmean": 16.7,
+                                "tasmin": 12
+                            }
+                        },
+                        "June": {
+                            "2010-2039": {
+                                "tasmax": 19.1,
+                                "tasmean": 13.6,
+                                "tasmin": 7
+                            },
+                            "2040-2069": {
+                                "tasmax": 18.2,
+                                "tasmean": 13.9,
+                                "tasmin": 9.3
+                            },
+                            "2070-2099": {
+                                "tasmax": 19.5,
+                                "tasmean": 15.2,
+                                "tasmin": 8.5
+                            }
+                        },
+                        "March": {
+                            "2010-2039": {
+                                "tasmax": -1.2,
+                                "tasmean": -7.6,
+                                "tasmin": -16.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 0,
+                                "tasmean": -8,
+                                "tasmin": -14.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 3.1,
+                                "tasmean": -5.6,
+                                "tasmin": -13.5
+                            }
+                        },
+                        "May": {
+                            "2010-2039": {
+                                "tasmax": 11.2,
+                                "tasmean": 6.9,
+                                "tasmin": 1.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 12.2,
+                                "tasmean": 8.3,
+                                "tasmin": 3.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 13,
+                                "tasmean": 9,
+                                "tasmin": 3.7
+                            }
+                        },
+                        "November": {
+                            "2010-2039": {
+                                "tasmax": -1.5,
+                                "tasmean": -9.5,
+                                "tasmin": -16.8
+                            },
+                            "2040-2069": {
+                                "tasmax": -2.1,
+                                "tasmean": -9.2,
+                                "tasmin": -15.6
+                            },
+                            "2070-2099": {
+                                "tasmax": -0.4,
+                                "tasmean": -8.1,
+                                "tasmin": -14.5
+                            }
+                        },
+                        "October": {
+                            "2010-2039": {
+                                "tasmax": 1.6,
+                                "tasmean": -2.9,
+                                "tasmin": -8.3
+                            },
+                            "2040-2069": {
+                                "tasmax": 1.6,
+                                "tasmean": -2.1,
+                                "tasmin": -7.3
+                            },
+                            "2070-2099": {
+                                "tasmax": 2.8,
+                                "tasmean": -1.3,
+                                "tasmin": -8.4
+                            }
+                        },
+                        "September": {
+                            "2010-2039": {
+                                "tasmax": 9.9,
+                                "tasmean": 7.2,
+                                "tasmin": 4
+                            },
+                            "2040-2069": {
+                                "tasmax": 12.6,
+                                "tasmean": 7.8,
+                                "tasmin": 4
+                            },
+                            "2070-2099": {
+                                "tasmax": 11.8,
+                                "tasmean": 8.9,
+                                "tasmin": 6.6
+                            }
+                        }
+                    },
+                    "rcp85": {
+                        "April": {
+                            "2010-2039": {
+                                "tasmax": 3.7,
+                                "tasmean": -1.3,
+                                "tasmin": -5.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 6.1,
+                                "tasmean": 1.2,
+                                "tasmin": -4.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 8.5,
+                                "tasmean": 3.5,
+                                "tasmin": -1.6
+                            }
+                        },
+                        "August": {
+                            "2010-2039": {
+                                "tasmax": 17.8,
+                                "tasmean": 12.2,
+                                "tasmin": 9.4
+                            },
+                            "2040-2069": {
+                                "tasmax": 18.3,
+                                "tasmean": 14.1,
+                                "tasmin": 11.6
+                            },
+                            "2070-2099": {
+                                "tasmax": 20.4,
+                                "tasmean": 15.8,
+                                "tasmin": 11.7
+                            }
+                        },
+                        "December": {
+                            "2010-2039": {
+                                "tasmax": -6,
+                                "tasmean": -15.8,
+                                "tasmin": -23.9
+                            },
+                            "2040-2069": {
+                                "tasmax": -6.1,
+                                "tasmean": -13.3,
+                                "tasmin": -23.5
+                            },
+                            "2070-2099": {
+                                "tasmax": -1.1,
+                                "tasmean": -8.2,
+                                "tasmin": -19.1
+                            }
+                        },
+                        "February": {
+                            "2010-2039": {
+                                "tasmax": -3.3,
+                                "tasmean": -9.7,
+                                "tasmin": -16
+                            },
+                            "2040-2069": {
+                                "tasmax": -0.9,
+                                "tasmean": -8,
+                                "tasmin": -16.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 2.3,
+                                "tasmean": -6.2,
+                                "tasmin": -18.6
+                            }
+                        },
+                        "January": {
+                            "2010-2039": {
+                                "tasmax": -6.1,
+                                "tasmean": -15.6,
+                                "tasmin": -23.5
+                            },
+                            "2040-2069": {
+                                "tasmax": -3.7,
+                                "tasmean": -12.8,
+                                "tasmin": -21.6
+                            },
+                            "2070-2099": {
+                                "tasmax": -1.3,
+                                "tasmean": -8.9,
+                                "tasmin": -19.1
+                            }
+                        },
+                        "July": {
+                            "2010-2039": {
+                                "tasmax": 16.4,
+                                "tasmean": 13.9,
+                                "tasmin": 10.6
+                            },
+                            "2040-2069": {
+                                "tasmax": 20,
+                                "tasmean": 16.5,
+                                "tasmin": 12.1
+                            },
+                            "2070-2099": {
+                                "tasmax": 22.3,
+                                "tasmean": 17.8,
+                                "tasmin": 14.4
+                            }
+                        },
+                        "June": {
+                            "2010-2039": {
+                                "tasmax": 18.1,
+                                "tasmean": 12.8,
+                                "tasmin": 8.6
+                            },
+                            "2040-2069": {
+                                "tasmax": 20,
+                                "tasmean": 14.8,
+                                "tasmin": 10.8
+                            },
+                            "2070-2099": {
+                                "tasmax": 23.8,
+                                "tasmean": 17.4,
+                                "tasmin": 12.7
+                            }
+                        },
+                        "March": {
+                            "2010-2039": {
+                                "tasmax": -1.9,
+                                "tasmean": -8.8,
+                                "tasmin": -15.5
+                            },
+                            "2040-2069": {
+                                "tasmax": 1.9,
+                                "tasmean": -6,
+                                "tasmin": -12.2
+                            },
+                            "2070-2099": {
+                                "tasmax": 4.4,
+                                "tasmean": -2.9,
+                                "tasmin": -11.8
+                            }
+                        },
+                        "May": {
+                            "2010-2039": {
+                                "tasmax": 10.8,
+                                "tasmean": 6.7,
+                                "tasmin": 2.1
+                            },
+                            "2040-2069": {
+                                "tasmax": 13.6,
+                                "tasmean": 8.9,
+                                "tasmin": 3.7
+                            },
+                            "2070-2099": {
+                                "tasmax": 16.6,
+                                "tasmean": 11,
+                                "tasmin": 6.8
+                            }
+                        },
+                        "November": {
+                            "2010-2039": {
+                                "tasmax": -2.1,
+                                "tasmean": -9.4,
+                                "tasmin": -15.6
+                            },
+                            "2040-2069": {
+                                "tasmax": -3,
+                                "tasmean": -7.7,
+                                "tasmin": -13.4
+                            },
+                            "2070-2099": {
+                                "tasmax": 2.4,
+                                "tasmean": -5.2,
+                                "tasmin": -11.3
+                            }
+                        },
+                        "October": {
+                            "2010-2039": {
+                                "tasmax": 1.3,
+                                "tasmean": -2.5,
+                                "tasmin": -8.2
+                            },
+                            "2040-2069": {
+                                "tasmax": 3.7,
+                                "tasmean": -0.7,
+                                "tasmin": -3.9
+                            },
+                            "2070-2099": {
+                                "tasmax": 3.8,
+                                "tasmean": 1.3,
+                                "tasmin": -4.1
+                            }
+                        },
+                        "September": {
+                            "2010-2039": {
+                                "tasmax": 9.6,
+                                "tasmean": 6.9,
+                                "tasmin": 5
+                            },
+                            "2040-2069": {
+                                "tasmax": 12,
+                                "tasmean": 8.7,
+                                "tasmin": 5.3
+                            },
+                            "2070-2099": {
+                                "tasmax": 14.2,
+                                "tasmean": 10.6,
+                                "tasmin": 7.5
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "thawing_index": {
+        "preview": "model,scenario,year,dd\r\ndaymet,modeled_baseline,1980,2100\r\ndaymet,modeled_baseline,1981,2249\r\ndaymet,modeled_baseline,1982,2165\r\ndaymet,modeled_baseline,1983,2176\r\ndaymet,modeled_baseline,1984,2390\r\ninmcm4,rcp85,2095,4292\r\ninmcm4,rcp85,2096,3778\r\ninmcm4,rcp85,2097,4578\r\ninmcm4,rcp85,2098,3255\r\ninmcm4,rcp85,2099,3667\r\n",
+        "summary": {
+            "2010-2039": {
+                "ddmax": 4389,
+                "ddmean": 2773,
+                "ddmin": 1509
+            },
+            "2040-2069": {
+                "ddmax": 5459,
+                "ddmean": 3207,
+                "ddmin": 2035
+            },
+            "2070-2099": {
+                "ddmax": 6191,
+                "ddmean": 3661,
+                "ddmin": 1912
+            },
+            "modeled_baseline": {
+                "ddmax": 2831,
+                "ddmean": 2382,
+                "ddmin": 1953
+            }
+        }
+    },
+    "wet_days_per_year": {
+        "2010-2039": {
+            "wdpymax": 217,
+            "wdpymean": 177,
+            "wdpymin": 131
+        },
+        "2040-2069": {
+            "wdpymax": 224,
+            "wdpymean": 190,
+            "wdpymin": 130
+        },
+        "2070-2099": {
+            "wdpymax": 240,
+            "wdpymean": 191,
+            "wdpymin": 133
+        },
+        "historical": {
+            "wdpymax": 194,
+            "wdpymean": 173,
+            "wdpymin": 154
+        }
+    }
+}

--- a/tests/test_eds_all.py
+++ b/tests/test_eds_all.py
@@ -1,0 +1,16 @@
+import json
+
+
+def test_eds_all(client):
+    """
+    Tests the /eds/all/<lat>/<lon>/ endpoint to ensure the output
+    remains consistent with production for the given latitude and longitude.
+    """
+    response = client.get("/eds/all/62.27/-154.61")
+    assert response.status_code == 200
+    actual_data = response.get_json()
+
+    with open("tests/eds_point.json") as f:
+        expected_data = json.load(f)
+
+    assert actual_data == expected_data


### PR DESCRIPTION
This PR updates the permafrost endpoints to utilize the new dimensionality of the crrel_gipl_outputs_nc coverage. The coverage has changed on the backend, where a dimension previously called "year" is now displayed as "time". This PR changes the calls to the WCS commands to Rasdaman to use that dimension.

Additionally, this PR has a LUT to translate the coverage's variable names to the expected API outputs, as all of the endpoints were returning the incorrect keys for the JSON output. 

**Testing**

This impacts all of our websites that use permafrost data so we need to verify that all of the endpoints are working as expected again after this change.

The following endpoints need to be tested:
- /eds/permafrost/<lat>/<lon>
- /ncr/permafrost/<lat>/<lon>
- /permafrost/point/<lat>/<lon>
- /permafrost/point/gipl/<lat>/<lon>