### PR TITLE
Add source parameter to CONUS hydrology + arctic hydrology endpoints

### DIFF
--- a/application.py
+++ b/application.py
@@ -178,6 +178,14 @@ def validate_get_params():
             required=False,
         )
 
+        # Make sure "source" parameter is one of the predefined sources for stats coverage
+        source = fields.Str(
+            validate=validate.OneOf(
+                ["original_gcm", "gcm_diff", "gcm_diff_applied_to_maurer"]
+            ),
+            required=False,
+        )
+
     schema = QueryParamsSchema()
     errors = schema.validate(request.args)
     if errors:

--- a/application.py
+++ b/application.py
@@ -181,7 +181,12 @@ def validate_get_params():
         # Make sure "source" parameter is one of the predefined sources for stats coverage
         source = fields.Str(
             validate=validate.OneOf(
-                ["original_gcm", "gcm_diff", "gcm_diff_applied_to_maurer"]
+                [
+                    "original_gcm",
+                    "gcm_diff",
+                    "gcm_diff_applied_to_maurer",
+                    "gcm_diff_applied_to_cheng",
+                ]
             ),
             required=False,
         )

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1325,9 +1325,9 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
     # substrings in filename_prefix denotes endpoint ("Statistics", "Modeled") to aid in packaging CSV
 
     source_notes = {
-        "original_gcm": "Values are derived from the original GCM runs.",
-        "gcm_diff": "Values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values. See LaFontaine and Riley (2023) to find each variable's difference method (ratio or absolute).",
-        "gcm_diff_applied_to_maurer": "Values are derived from applying the GCM-projected changes to the historical Maurer baseline.",
+        "original_gcm": "These values are derived from the original GCM runs.",
+        "gcm_diff": "These values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values. See LaFontaine and Riley (2023) to find the difference method for each variable (ratio or absolute).",
+        "gcm_diff_applied_to_maurer": "These values are derived from applying the GCM-projected changes to the historical Maurer baseline.",
     }
 
     # data structure for all endpoints:
@@ -1352,9 +1352,17 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
         if key != "data":
             continue
         for landcover in data["data"].keys():
+            if data["data"][landcover] is None:
+                continue
             for model in data["data"][landcover].keys():
+                if data["data"][landcover][model] is None:
+                    continue
                 for scenario in data["data"][landcover][model].keys():
+                    if data["data"][landcover][model][scenario] is None:
+                        continue
                     for era in data["data"][landcover][model][scenario].keys():
+                        if data["data"][landcover][model][scenario][era] is None:
+                            continue
                         row = {
                             "landcover": landcover,
                             "model": model,
@@ -1392,7 +1400,10 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
 
     metadata = ""
     if "Statistics" in filename_prefix:
-        metadata += "# The following hydrologic statistics are calculated from modeled daily streamflow data:\n"
+        if isinstance(source_metadata, str) and source_metadata in source_notes:
+            metadata += f"# The following hydrologic statistics are calculated from modeled daily streamflow data. {source_notes[source_metadata]}\n"
+        else:
+            metadata += "# The following hydrologic statistics are calculated from modeled daily streamflow data:\n"
         metadata += "# dh1: Annual maximum daily flow. Compute the maximum of a 1-day moving average flow for each year. DH1 is the mean of these values (cubic feet per second - temporal).\n"
         metadata += "# dh2: Annual maximum of 3-day moving average flows. Compute the maximum of a 3-day moving average flow for each year. DH2 is the mean of these values (cubic feet per second - temporal).\n"
         metadata += "# dh3: Annual maximum of 7-day moving average flows. Compute the maximum of a 7-day moving average flow for each year. DH3 is the mean of these values (cubic feet per second - temporal).\n"
@@ -1446,18 +1457,17 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
         metadata += "# sum_ord: Julian date of summer (July-September) minimum. Determine the Julian date that the minimum flow occurs for each water year. SUM_ORD is the median of these values (Julian day - temporal).\n"
         metadata += "# th1: Julian date of annual maximum. Determine the Julian date that the maximum flow occurs for each year. TH1 is the median of these values (Julian day - temporal).\n"
         metadata += "# tl1: Julian date of annual minimum. Determine the Julian date that the minimum flow occurs for each water year. TL1 is the median of these values (Julian day - temporal).\n"
-        if isinstance(source_metadata, str) and source_metadata in source_notes:
-            metadata += f"# Data source notes: {source_notes[source_metadata]}\n"
     else:
         if "Modeled" in filename_prefix:
-            metadata += "# Climatologies are calculated from from modeled daily streamflow data.\n"
+            if isinstance(source_metadata, str) and source_metadata in source_notes:
+                metadata += f"# Climatologies are calculated from from modeled daily streamflow data. {source_notes[source_metadata]}\n"
+            else:
+                metadata += "# Climatologies are calculated from from modeled daily streamflow data.\n"
             metadata += "# doy is the day of year (1-366) for which the climatology value is reported. \n"
             metadata += "# water_year_index is the water year index (1-366) for which the climatology value is reported. The water year is defined as starting on October 1 (DOY 275 in a 366 day year = water year index 1) and ending September 30 (DOY 274 in a 366 day year = water year index 366).\n"
             metadata += "# doy_min is the minimum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_mean is the mean streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_max is the maximum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
-            if isinstance(source_metadata, str) and source_metadata in source_notes:
-                metadata += f"# Data source notes: {source_notes[source_metadata]}\n"
         else:
             metadata += "# Climatologies are calculated from from observed daily streamflow data.\n"
             metadata += (

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1460,16 +1460,16 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
     else:
         if "Modeled" in filename_prefix:
             if isinstance(source_metadata, str) and source_metadata in source_notes:
-                metadata += f"# Climatologies are calculated from from modeled daily streamflow data. {source_notes[source_metadata]}\n"
+                metadata += f"# Climatologies are calculated from modeled daily streamflow data. {source_notes[source_metadata]}\n"
             else:
-                metadata += "# Climatologies are calculated from from modeled daily streamflow data.\n"
+                metadata += "# Climatologies are calculated from modeled daily streamflow data.\n"
             metadata += "# doy is the day of year (1-366) for which the climatology value is reported. \n"
             metadata += "# water_year_index is the water year index (1-366) for which the climatology value is reported. The water year is defined as starting on October 1 (DOY 275 in a 366 day year = water year index 1) and ending September 30 (DOY 274 in a 366 day year = water year index 366).\n"
             metadata += "# doy_min is the minimum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_mean is the mean streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_max is the maximum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
         else:
-            metadata += "# Climatologies are calculated from from observed daily streamflow data.\n"
+            metadata += "# Climatologies are calculated from observed daily streamflow data.\n"
             metadata += (
                 "# The observation record for this time period is "
                 + str(source_metadata["percent_complete"])

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1324,6 +1324,12 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
 
     # substrings in filename_prefix denotes endpoint ("Statistics", "Modeled") to aid in packaging CSV
 
+    source_notes = {
+        "original_gcm": "Values are derived from the original GCM runs.",
+        "gcm_diff": "Values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values. See LaFontaine and Riley (2023) to find each variable's difference method (ratio or absolute).",
+        "gcm_diff_applied_to_maurer": "Values are derived from applying the GCM-projected changes to the historical Maurer baseline.",
+    }
+
     # data structure for all endpoints:
     # first level of data are strings "data", "id", "latitude", "longitude", "metadata", "name"
 
@@ -1440,6 +1446,8 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
         metadata += "# sum_ord: Julian date of summer (July-September) minimum. Determine the Julian date that the minimum flow occurs for each water year. SUM_ORD is the median of these values (Julian day - temporal).\n"
         metadata += "# th1: Julian date of annual maximum. Determine the Julian date that the maximum flow occurs for each year. TH1 is the median of these values (Julian day - temporal).\n"
         metadata += "# tl1: Julian date of annual minimum. Determine the Julian date that the minimum flow occurs for each water year. TL1 is the median of these values (Julian day - temporal).\n"
+        if isinstance(source_metadata, str) and source_metadata in source_notes:
+            metadata += f"# Data source notes: {source_notes[source_metadata]}\n"
     else:
         if "Modeled" in filename_prefix:
             metadata += "# Climatologies are calculated from from modeled daily streamflow data.\n"
@@ -1448,6 +1456,8 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
             metadata += "# doy_min is the minimum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_mean is the mean streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_max is the maximum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
+            if isinstance(source_metadata, str) and source_metadata in source_notes:
+                metadata += f"# Data source notes: {source_notes[source_metadata]}\n"
         else:
             metadata += "# Climatologies are calculated from from observed daily streamflow data.\n"
             metadata += (

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -122,7 +122,7 @@ def create_csv(
     elif endpoint == "conus_hydrology":
         properties = conus_hydrology_csv(data, filename_prefix, source_metadata)
     elif endpoint == "arctic_hydrology":
-        properties = arctic_hydrology_csv(data, filename_prefix)
+        properties = arctic_hydrology_csv(data, filename_prefix, source_metadata)
 
     else:
         return render_template("500/server_error.html"), 500
@@ -1494,9 +1494,15 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
     }
 
 
-def arctic_hydrology_csv(data, filename_prefix):
+def arctic_hydrology_csv(data, filename_prefix, source_metadata):
 
     # substrings in filename_prefix denotes endpoint ("Statistics", "Modeled") to aid in packaging CSV
+
+    source_notes = {
+        "original_gcm": "These values are derived from the original GCM runs.",
+        "gcm_diff": "These values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values.",
+        "gcm_diff_applied_to_cheng": "These values are derived from applying the GCM-projected changes to the historical Cheng baseline.",
+    }
 
     # data structure for all endpoints:
     # first level of data are strings "data", "id", "latitude", "longitude", "metadata", "name"
@@ -1515,7 +1521,11 @@ def arctic_hydrology_csv(data, filename_prefix):
         if key != "data":
             continue
         for model in data["data"].keys():
+            if data["data"][model] is None:
+                continue
             for era in data["data"][model].keys():
+                if data["data"][model][era] is None:
+                    continue
                 row = {
                     "model": model,
                     "era": era,
@@ -1546,7 +1556,10 @@ def arctic_hydrology_csv(data, filename_prefix):
 
     metadata = ""
     if "Statistics" in filename_prefix:
-        metadata += "# The following hydrologic statistics are calculated from modeled daily streamflow data:\n"
+        if isinstance(source_metadata, str) and source_metadata in source_notes:
+            metadata += f"# The following hydrologic statistics are calculated from modeled daily streamflow data. {source_notes[source_metadata]}\n"
+        else:
+            metadata += "# The following hydrologic statistics are calculated from modeled daily streamflow data:\n"
         metadata += "# ma12: Mean of monthly flow values for January (cubic feet per second - temporal).\n"
         metadata += "# ma13: Mean of monthly flow values for February (cubic feet per second - temporal).\n"
         metadata += "# ma14: Mean of monthly flow values for March (cubic feet per second - temporal).\n"
@@ -1561,9 +1574,10 @@ def arctic_hydrology_csv(data, filename_prefix):
         metadata += "# ma23: Mean of monthly flow values for December (cubic feet per second - temporal).\n"
         metadata += "# ma99: Mean of monthly flow values for the entire year. Compute the mean of the monthly mean flows for each month of the year. MA99 is the mean of these 12 values (cubic feet per second - temporal).\n"
     else:
-        metadata += (
-            "# Climatologies are calculated from modeled daily streamflow data.\n"
-        )
+        if isinstance(source_metadata, str) and source_metadata in source_notes:
+            metadata += f"# Climatologies are calculated from modeled daily streamflow data. {source_notes[source_metadata]}\n"
+        else:
+            metadata += "# Climatologies are calculated from modeled daily streamflow data.\n"
         metadata += "# doy is the day of year (1-366) for which the climatology value is reported. \n"
         metadata += "# water_year_index is the water year index (1-366) for which the climatology value is reported. The water year is defined as starting on October 1 (DOY 275 in a 366 day year = water year index 1) and ending September 30 (DOY 274 in a 366 day year = water year index 366).\n"
         metadata += "# doy_min is the minimum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1469,7 +1469,9 @@ def conus_hydrology_csv(data, filename_prefix, source_metadata):
             metadata += "# doy_mean is the mean streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
             metadata += "# doy_max is the maximum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"
         else:
-            metadata += "# Climatologies are calculated from observed daily streamflow data.\n"
+            metadata += (
+                "# Climatologies are calculated from observed daily streamflow data.\n"
+            )
             metadata += (
                 "# The observation record for this time period is "
                 + str(source_metadata["percent_complete"])
@@ -1499,9 +1501,9 @@ def arctic_hydrology_csv(data, filename_prefix, source_metadata):
     # substrings in filename_prefix denotes endpoint ("Statistics", "Modeled") to aid in packaging CSV
 
     source_notes = {
-        "original_gcm": "These values are derived from the original GCM runs.",
-        "gcm_diff": "These values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values.",
-        "gcm_diff_applied_to_cheng": "These values are derived from applying the GCM-projected changes to the historical Cheng baseline.",
+        "original_gcm": "These values are derived from the original GCM or PGW runs.",
+        "gcm_diff": "These values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values. PGW runs are not included.",
+        "gcm_diff_applied_to_cheng": "These values are derived from applying the GCM-projected changes to the historical Cheng baseline. PGW runs are not included.",
     }
 
     # data structure for all endpoints:
@@ -1577,7 +1579,9 @@ def arctic_hydrology_csv(data, filename_prefix, source_metadata):
         if isinstance(source_metadata, str) and source_metadata in source_notes:
             metadata += f"# Climatologies are calculated from modeled daily streamflow data. {source_notes[source_metadata]}\n"
         else:
-            metadata += "# Climatologies are calculated from modeled daily streamflow data.\n"
+            metadata += (
+                "# Climatologies are calculated from modeled daily streamflow data.\n"
+            )
         metadata += "# doy is the day of year (1-366) for which the climatology value is reported. \n"
         metadata += "# water_year_index is the water year index (1-366) for which the climatology value is reported. The water year is defined as starting on October 1 (DOY 275 in a 366 day year = water year index 1) and ending September 30 (DOY 274 in a 366 day year = water year index 366).\n"
         metadata += "# doy_min is the minimum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"

--- a/generate_requests.py
+++ b/generate_requests.py
@@ -107,7 +107,7 @@ def generate_netcdf_wcs_getcov_str(bbox_bounds, cov_id, var_coord=None):
     Returns:
         netcdf_wcs_getcov_str (str): WCS GetCoverage Request to append to a query URL
     """
-    (x1, y1, x2, y2) = bbox_bounds
+    x1, y1, x2, y2 = bbox_bounds
     x = f"{x1},{x2}"
     y = f"{y1},{y2}"
     netcdf_wcs_getcov_str = generate_wcs_getcov_str(
@@ -170,7 +170,7 @@ def generate_netcdf_average_wcps_str(bbox_bounds, generate_average_wcps_str_kwar
     Returns:
         netcdf_avg_wcps_str (str): WCPS GetCoverage Request to append to a query URL
     """
-    (x1, y1, x2, y2) = bbox_bounds
+    x1, y1, x2, y2 = bbox_bounds
     x = f"{x1}:{x2}"
     y = f"{y1}:{y2}"
     netcdf_avg_wcps_str = generate_average_wcps_str(
@@ -195,17 +195,21 @@ def generate_wcps_describe_coverage_str(cov_id):
     return quote(query_str)
 
 
-def generate_conus_hydrology_wcs_str(cov_id, stream_id):
+def generate_conus_hydrology_wcs_str(cov_id, stream_id, source=None):
     """Generate a WCS GetCoverage request for fetching CONUS hydrology data as netCDF.
     Args:
         cov_id (str): Coverage ID
         stream_id (str): Stream ID
+        source (str, optional): Source ID (for stats coverage only)
     Returns:
         request_string (str): WCS GetCoverage Request to append to a query URL
     """
     request_string = f"ows?&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&"
     request_string += f"COVERAGEID={cov_id}&"
     request_string += f"SUBSET=stream_id({stream_id})&"
+    if source is not None:
+        request_string += f"SUBSET=source({source})&"
+
     request_string += f"FORMAT=application/netcdf"
 
     return request_string

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -146,19 +146,25 @@ def prune_nodata_list(data):
     return pruned
 
 
-def prune_nulls_with_max_intensity(data):
+def prune_nulls_with_max_intensity(data, keys_to_keep=None):
     """
     Recursively remove all None values from dicts and remove any empty dicts that remain.
 
     In practice, this will trim keys with `null` values from the API response even in the case when a sibling key does have data.
+    The optional keys_to_keep argument allows you to specify keys that should be retained even if their value is None.
     """
+    if keys_to_keep is None:
+        keys_to_keep = set()
+    else:
+        keys_to_keep = set(keys_to_keep)
     if isinstance(data, dict):
         return {
             k: v
             for k, v in (
-                (k, prune_nulls_with_max_intensity(v)) for k, v in data.items()
+                (k, prune_nulls_with_max_intensity(v, keys_to_keep))
+                for k, v in data.items()
             )
-            if v is not None
+            if v is not None or k in keys_to_keep
         }
     else:
         return data

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -41,5 +41,4 @@ from .places import *
 from .era5wrf import *
 from .fire_weather import *
 from .conus_hydrology import *
-
-# from .arctic_hydrology import *
+from .arctic_hydrology import *

--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -1,9 +1,11 @@
 import asyncio
+import copy
 import io
 import numpy as np
 import xarray as xr
 import ast
 import geopandas as gpd
+import statistics
 from aiohttp import ClientSession
 from flask import (
     Blueprint,
@@ -23,10 +25,103 @@ from csv_functions import create_csv
 from config import RAS_BASE_URL
 from . import routes
 
-
 coverages = {
-    "stats": ["ak_hydro_segments_stats"],
+    "stats": ["ak_hydro_segments_stats_combined"],
     "doy_climatology": ["ak_hydro_segments_doy_climatology"],
+}
+
+stat_source_encodings = {
+    "original_gcm": 0,
+    "gcm_diff": 1,
+    "gcm_diff_applied_to_cheng": 2,
+}
+
+# TODO: populate this with actual values from the GS layer after computing via MHIT
+_SUMMARY_STUB = {
+    "ma99_hist": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "cfs",
+        "description": "historical mean annual flow",
+    },
+    "ma99_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "percent",
+        "description": "projected change in mean annual flow",
+    },
+    "dh1_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "percent",
+        "description": "projected change in maximum 1-day flow",
+    },
+    "dl1_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "percent",
+        "description": "projected change in minimum 1-day flow",
+    },
+    "dh15_hist": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "days",
+        "description": "historical high flow pulse duration",
+    },
+    "dh15_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "days",
+        "description": "projected change in high flow pulse duration",
+    },
+    "dl16_hist": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "days",
+        "description": "historical low flow pulse duration",
+    },
+    "dl16_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "days",
+        "description": "projected change in low flow pulse duration",
+    },
+    "fh1_hist": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "events",
+        "description": "historical high flood pulse count",
+    },
+    "fh1_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "events",
+        "description": "projected change in high flood pulse count",
+    },
+    "fl1_hist": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "events",
+        "description": "historical low flood pulse count",
+    },
+    "fl1_delta": {
+        "value": None,
+        "range_low": None,
+        "range_high": None,
+        "units": "events",
+        "description": "projected change in low flood pulse count",
+    },
 }
 
 
@@ -45,20 +140,27 @@ async def get_decode_dicts_from_axis_attributes(cov_ids):
     return decode_dicts
 
 
-async def fetch_hydro_data(cov_ids, stream_id):
+async def fetch_hydro_data(cov_ids, stream_id, source=None):
     """
     Function to fetch hydrology data from Rasdaman. Data is fetched for one stream ID at a time!
     Args:
         cov_ids (list): list of coverage IDs for the hydrology data
         stream_id (str): Stream ID for the hydrology data
+        source (str, optional): Source ID (for stats coverage only)
 
     Returns:
         results (list): list of responses from Rasdaman for each coverage ID
     """
-    urls = [
-        RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, stream_id)
-        for cov_id in cov_ids
-    ]
+    if source is not None:
+        urls = [
+            RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, stream_id, source)
+            for cov_id in cov_ids
+        ]
+    else:
+        urls = [
+            RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, stream_id)
+            for cov_id in cov_ids
+        ]
 
     results = await fetch_data(urls)
 
@@ -114,11 +216,11 @@ def package_stats_data(stream_id, ds):
 
     vars_ = list(ds.data_vars)
 
-    # stack everything except "variable" into one array
-    arr = ds[vars_].to_array().values  # (variable, model, era)
-
     models = ds.model.values
     eras = ds.era.values
+
+    # stack variables and transpose to guaranteed (variable, model, era) order
+    arr = ds[vars_].to_array().transpose("variable", "model", "era").values
 
     for i_m, model in enumerate(models):
         model_dict = stats_dict["data"].setdefault(model, {})
@@ -129,8 +231,8 @@ def package_stats_data(stream_id, ds):
         for i_e, era in enumerate(eras):
             vals = block[:, i_e]
 
-            # skip if all NaN
-            if np.isnan(vals).all():
+            # skip if all NaN or all zero (zero is sometimes Rasdaman's fill for missing data, and can be inconsistent in the same coverage)
+            if np.isnan(vals).all() or (vals == 0).all():
                 continue
 
             model_dict[era] = {
@@ -184,8 +286,8 @@ def package_hydrograph_data(stream_id, datasets):
             for i_e, era in enumerate(eras):
                 block = arr[i_m, i_e]  # (doy, variable)
 
-                # skip empty combos
-                if np.isnan(block).all():
+                # skip empty combos (all NaN or all zero — zero is Rasdaman's fill for missing data)
+                if np.isnan(block).all() or (block == 0).all():
                     continue
 
                 rows = []
@@ -225,47 +327,56 @@ def convert_doy_to_water_year_index(doy):
     return wy_index
 
 
-def calculate_and_populate_annual_mean_flow(data_dict):
+def calculate_and_apply_gcm_diffs_to_cheng_climatology(data_dict):
     """
-    Function to calculate and populate the annual mean flow (ma99) in the stats data dictionary.
+    Function to calculate GCM-projected changes in streamflow and apply them to the historical Cheng climatology.
+    Models without a '1990-2021' era (e.g. PGW models with no historical baseline) are silently skipped.
     Args:
-        data_dict (dict): Data dictionary with the stats data populated
+        data_dict (dict): Climatology data dict keyed by model then era
     Returns:
-        Data dictionary with the annual mean flow populated.
+        dict: Adjusted data dict with Cheng baseline applied to all eligible models.
     """
-    monthly_stats_codes = [
-        "ma12",
-        "ma13",
-        "ma14",
-        "ma15",
-        "ma16",
-        "ma17",
-        "ma18",
-        "ma19",
-        "ma20",
-        "ma21",
-        "ma22",
-        "ma23",
-    ]
-    for model_, model_dict in data_dict["data"].items():
-        for era_, era_dict in model_dict.items():
-            # check if all monthly stats are present
-            if all(code in era_dict for code in monthly_stats_codes):
-                # calculate annual mean flow
-                monthly_values = [era_dict[code] for code in monthly_stats_codes]
-                annual_mean_flow = sum(monthly_values) / len(monthly_values)
-                # populate the annual mean flow in the stats dictionary
-                era_dict["ma99"] = round(annual_mean_flow, 2)
+    adjusted_data_dict = {}
+    for model in data_dict.keys():
+        if model == "historical":
+            adjusted_data_dict[model] = data_dict[model]
+            continue
+        if "1990-2021" not in data_dict[model]:
+            continue
+        adjusted_data_dict[model] = {}
+        for era in data_dict[model].keys():
+            if era == "1990-2021":
+                continue  # historical era is identical across all GCM models; only expose it under "historical"
+            adjusted_data_dict[model][era] = []
+            for i in range(len(data_dict[model][era])):
+                entry = data_dict[model][era][i]
+                doy_stats = {
+                    "doy": entry["doy"],
+                    "water_year_index": entry["water_year_index"],
+                }
+                for stat in entry.keys():
+                    if stat in ("doy", "water_year_index"):
+                        continue
+                    cheng_historical = data_dict["historical"]["1990-2021"][i][stat]
+                    gcm_historical = data_dict[model]["1990-2021"][i][stat]
+                    gcm_projected = entry[stat]
+                    denominator = gcm_historical
+                    if denominator == 0:
+                        denominator = 0.0001
+                    projected_quotient = gcm_projected / denominator
+                    cheng_adjusted = round(cheng_historical * projected_quotient, 3)
+                    doy_stats[stat] = cheng_adjusted
+                adjusted_data_dict[model][era].append(doy_stats)
+    return adjusted_data_dict
 
-    return data_dict
 
-
-def package_metadata(ds, data_dict):
+def package_metadata(ds, data_dict, source=None):
     """
     Function to package the metadata from the dataset into the data dictionary.
     Args:
         ds (xarray dataset): Dataset with hydrology data
         data_dict (dict): Data dictionary to populate with metadata.
+        source (str, optional): Source ID string
     Returns:
         Data dictionary with the metadata populated."""
     try:
@@ -287,18 +398,29 @@ def package_metadata(ds, data_dict):
         )
 
         # special cases:
+        source_notes = {
+            "original_gcm": "Values are derived from the original GCM or PGW runs.",
+            "gcm_diff": "Values are the ratio or absolute difference between the original GCM runs and the historical GCM runs - these are not actual statistic values! Apply these differences to a historical baseline value to approximate future values. PGW runs are not included.",
+            "gcm_diff_applied_to_cheng": "Values are derived from applying the GCM-projected changes to the historical Cheng baseline. PGW runs are not included.",
+        }
 
-        # add derived "ma99" annual mean flow stat
-        # if "ma12" is present (indicating we are dealing with a stats dataset)
-        if var == "ma12":
-            data_dict["metadata"]["variables"]["ma99"] = {}
-            data_dict["metadata"]["variables"]["ma99"]["units"] = "cfs"
-            data_dict["metadata"]["variables"]["ma99"][
+        if source == "original_gcm":
+            data_dict["metadata"]["variables"][var][
                 "description"
-            ] = "Annual mean streamflow (cfs), calculated as the mean of the monthly mean flows."
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['original_gcm']}"
+
+        if source == "gcm_diff":
+            data_dict["metadata"]["variables"][var][
+                "description"
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff']}"
+
+        if source == "gcm_diff_applied_to_cheng":
+            data_dict["metadata"]["variables"][var][
+                "description"
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff_applied_to_cheng']}"
 
         # "doy" vars from hydrograph datasets
-        elif var in ["doy_min", "doy_mean", "doy_max"]:
+        if var in ["doy_min", "doy_mean", "doy_max"]:
             data_dict["metadata"]["variables"][var]["units"] = "cfs"
             if var == "doy_min":
                 op = "Minimum"
@@ -309,6 +431,11 @@ def package_metadata(ds, data_dict):
             data_dict["metadata"]["variables"][var][
                 "description"
             ] = f"{op} streamflow value (cfs) on the specified day of year, aggregated over all years in the era."
+            # add source notes
+            if source in source_notes:
+                data_dict["metadata"]["variables"][var][
+                    "description"
+                ] += f" {source_notes[source]}"
 
             # also add doy and water_year_index metadata:
             # these will be overwritten multiple times, but the values are the same for all three vars and we will only see them once in the final output
@@ -336,6 +463,8 @@ def populate_feature_attributes(data_dict, gdf):
         Data dictionary with the vector attributes populated."""
 
     data_dict["name"] = ""
+    data_dict["huc8"] = None
+    data_dict["huc8_outlet"] = None
     data_dict["latitude"] = round(gdf.loc[0].geometry.representative_point().y, 4)
     data_dict["longitude"] = round(gdf.loc[0].geometry.representative_point().x, 4)
 
@@ -357,6 +486,11 @@ def run_get_arctic_hydrology_stats_data(stream_id):
     Returns:
         JSON response with hydrological stats for the requested stream ID.
     """
+    # validate get request query parameters
+    source = request.args.get("source", None)
+    if source is None:
+        source = "gcm_diff_applied_to_cheng"
+
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
 
@@ -369,10 +503,17 @@ def run_get_arctic_hydrology_stats_data(stream_id):
         decode_dict = asyncio.run(
             get_decode_dicts_from_axis_attributes(coverages["stats"])
         )[0]
-        ds = asyncio.run(fetch_hydro_data(coverages["stats"], stream_id))[0]
 
-        # decode the dimension values
+        ds = asyncio.run(
+            fetch_hydro_data(
+                coverages["stats"], stream_id, source=stat_source_encodings[source]
+            )
+        )[0]
+
+        # decode the dimension values, ignoring "source"
         for dim, mapping in decode_dict.items():
+            if dim == "source":
+                continue
             ds = ds.assign_coords({dim: [mapping[int(v)] for v in ds[dim].values]})
 
         # package the stats data + metadata into a dictionary for JSON serialization
@@ -381,8 +522,7 @@ def run_get_arctic_hydrology_stats_data(stream_id):
         except Exception:
             return render_template("500/server_error.html"), 500
 
-        data_dict = calculate_and_populate_annual_mean_flow(data_dict)
-        data_dict = package_metadata(ds, data_dict)
+        data_dict = package_metadata(ds, data_dict, source=source)
         data_dict = populate_feature_attributes(data_dict, gdf)
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
@@ -395,9 +535,13 @@ def run_get_arctic_hydrology_stats_data(stream_id):
                     place_id=stream_id,
                     lat=str(data_dict["latitude"]),
                     lon=str(data_dict["longitude"]),
+                    source_metadata=source,
                 )
             except Exception:
                 return render_template("500/server_error.html"), 500
+
+        # add stub summary dict for frontend interoperability with conus_hydrology
+        data_dict["summary"] = copy.deepcopy(_SUMMARY_STUB)
 
         return jsonify(data_dict)
 
@@ -417,6 +561,13 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
     Returns:
         JSON response with modeled daily climatology data for the requested stream ID.
     """
+    # validate get request query parameters
+    source = request.args.get("source", None)
+    if source is None:
+        source = "gcm_diff_applied_to_cheng"
+    elif source == "gcm_diff":
+        return render_template("400/bad_request.html"), 400
+
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
 
@@ -444,7 +595,7 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
         # package the hydrograph datasets into a dictionary for JSON serialization
         data_dict = package_hydrograph_data(stream_id, datasets)
         data_dict = package_metadata(
-            datasets[0], data_dict
+            datasets[0], data_dict, source=source
         )  # all datasets should have same metadata, just use the first one
         data_dict = populate_feature_attributes(data_dict, gdf)
         data_dict = prune_nulls_with_max_intensity(data_dict)
@@ -458,13 +609,258 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
                     place_id=stream_id,
                     lat=str(data_dict["latitude"]),
                     lon=str(data_dict["longitude"]),
+                    source_metadata=source,
                 )
             except Exception:
                 return render_template("500/server_error.html"), 500
+
+        # apply GCM-projected changes to Cheng climatology if source is "gcm_diff_applied_to_cheng"
+        # PGW models without a 1990-2021 historical era are silently absent from this source;
+        # they are only available via source=original_gcm.
+        if source == "gcm_diff_applied_to_cheng":
+            data_dict["data"] = calculate_and_apply_gcm_diffs_to_cheng_climatology(
+                data_dict["data"]
+            )
 
         return jsonify(data_dict)
 
     except Exception as exc:
         if hasattr(exc, "status") and exc.status == 404:
             return render_template("404/no_data.html"), 404
+        return render_template("500/server_error.html"), 500
+
+
+@routes.route("/arctic_hydrology/hydroviz/<stream_id>")
+def run_get_arctic_hydrology_hydroviz(stream_id):
+    """
+    Function to fetch all data for the hydroviz webapp for a given arctic stream ID.
+    Args:
+        stream_id (str): Stream ID for the hydrology data
+    Returns:
+        JSON response with the following top-level keys:
+        {
+            "gauge_id": null,
+            "huc8": null,
+            "huc8_outlet": null,
+            "hydrograph": ...,
+            "id": ...,
+            "monthly_flow": ...,
+            "max_flow_dates": ...,
+            "name": ...,
+            "stats": ...,
+            "summary": ...
+        }
+        Unlike the CONUS hydroviz, projected data is not nested by scenario since the Arctic
+        dataset has no scenario dimension. Projected structures are keyed directly by era.
+    """
+    chart_era = "2034-2065"
+    historical_era = "1990-2021"
+
+    # fetch stats with default source (gcm_diff_applied_to_cheng)
+    stats_response = run_get_arctic_hydrology_stats_data(stream_id)
+    if isinstance(stats_response, tuple):
+        return stats_response
+
+    try:
+        stats = stats_response.get_json()
+
+        # Fetch original_gcm stats to get PGW models (absent from gcm_diff_applied_to_cheng).
+        # The describe call is a duplicate of what run_get_arctic_hydrology_stats_data already did,
+        # but keeping the fetch inline here avoids a larger refactor of the route function.
+        stats_decode_dict = asyncio.run(
+            get_decode_dicts_from_axis_attributes(coverages["stats"])
+        )[0]
+        pgw_ds = asyncio.run(
+            fetch_hydro_data(
+                coverages["stats"], stream_id, source=stat_source_encodings["original_gcm"]
+            )
+        )[0]
+        for dim, mapping in stats_decode_dict.items():
+            if dim == "source":
+                continue
+            pgw_ds = pgw_ds.assign_coords(
+                {dim: [mapping[int(v)] for v in pgw_ds[dim].values]}
+            )
+        pgw_stats = package_stats_data(stream_id, pgw_ds)
+        for model, model_data in pgw_stats["data"].items():
+            if chart_era not in stats["data"].get(model, {}):
+                stats["data"][model] = model_data
+
+        # Fetch and decode climatology once; compute both Cheng-adjusted and original_gcm
+        # versions in memory rather than making two network calls (the doy_climatology coverage
+        # has no source dimension, so both versions start from the same raw data).
+        datasets = asyncio.run(
+            fetch_hydro_data(coverages["doy_climatology"], stream_id)
+        )
+        decode_dicts = asyncio.run(
+            get_decode_dicts_from_axis_attributes(coverages["doy_climatology"])
+        )
+
+        decoded_datasets = []
+        for ds, decode_dict in zip(datasets, decode_dicts):
+            for dim, mapping in decode_dict.items():
+                ds = ds.assign_coords({dim: [mapping[int(v)] for v in ds[dim].values]})
+            decoded_datasets.append(ds)
+
+        raw_data_dict = package_hydrograph_data(stream_id, decoded_datasets)
+
+        # Build Cheng-adjusted version; PGW models missing a 1990-2021 era are silently skipped.
+        cheng_adjusted = calculate_and_apply_gcm_diffs_to_cheng_climatology(
+            copy.deepcopy(raw_data_dict["data"])
+        )
+
+        # Fill in PGW models (absent from cheng_adjusted) using their original_gcm values.
+        for model, model_data in raw_data_dict["data"].items():
+            if model not in cheng_adjusted:
+                cheng_adjusted[model] = model_data
+
+        climatology_data = cheng_adjusted
+
+        historical_climatology = climatology_data["historical"][historical_era]
+        historical_stats = stats["data"]["historical"]
+
+        # Non-"historical" models at the future era only.
+        projected_climatology = {
+            model: model_data
+            for model, model_data in climatology_data.items()
+            if model != "historical" and chart_era in model_data
+        }
+        projected_stats = {
+            model: model_data
+            for model, model_data in stats["data"].items()
+            if model != "historical" and chart_era in model_data
+        }
+
+        ########## Populate arrays for hydrograph. ##########
+
+        hydrograph = {
+            "historical": {
+                "doy_min": [x["doy_min"] for x in historical_climatology],
+                "doy_mean": [x["doy_mean"] for x in historical_climatology],
+                "doy_max": [x["doy_max"] for x in historical_climatology],
+            },
+            "projected": {
+                chart_era: {
+                    "doy_min_min": [],
+                    "doy_mean_min": [],
+                    "doy_mean_mean": [],
+                    "doy_mean_max": [],
+                    "doy_max_max": [],
+                }
+            },
+        }
+
+        for i in range(366):
+            doy_mins = []
+            doy_means = []
+            doy_maxes = []
+            for model_data in projected_climatology.values():
+                doy_mins.append(model_data[chart_era][i]["doy_min"])
+                doy_means.append(model_data[chart_era][i]["doy_mean"])
+                doy_maxes.append(model_data[chart_era][i]["doy_max"])
+
+            hydrograph["projected"][chart_era]["doy_min_min"].append(
+                round(min(doy_mins), 3)
+            )
+            hydrograph["projected"][chart_era]["doy_mean_min"].append(
+                round(min(doy_means), 3)
+            )
+            hydrograph["projected"][chart_era]["doy_mean_mean"].append(
+                round(statistics.mean(doy_means), 3)
+            )
+            hydrograph["projected"][chart_era]["doy_mean_max"].append(
+                round(max(doy_means), 3)
+            )
+            hydrograph["projected"][chart_era]["doy_max_max"].append(
+                round(max(doy_maxes), 3)
+            )
+
+        ########## Populate arrays for monthly modeled flow rate chart. ##########
+
+        monthly_flow_keys = [
+            "ma12",
+            "ma13",
+            "ma14",
+            "ma15",
+            "ma16",
+            "ma17",
+            "ma18",
+            "ma19",
+            "ma20",
+            "ma21",
+            "ma22",
+            "ma23",
+        ]
+
+        monthly_flow = {
+            "historical": {},
+            "projected": {chart_era: {}},
+        }
+
+        for key in monthly_flow_keys:
+            monthly_flow["historical"][key] = historical_stats[historical_era][key]
+
+        for model_stats in projected_stats.values():
+            for key in monthly_flow_keys:
+                if key not in monthly_flow["projected"][chart_era]:
+                    monthly_flow["projected"][chart_era][key] = []
+                monthly_flow["projected"][chart_era][key].append(
+                    model_stats[chart_era][key]
+                )
+
+        ########## Populate arrays for max flow date chart. ##########
+
+        max_flow_dates = {
+            "historical": {
+                "flow": historical_stats[historical_era].get("dh1"),
+                "date": historical_stats[historical_era].get("th1"),
+            },
+            "projected": {chart_era: {"flow": [], "date": []}},
+        }
+
+        for model_stats in projected_stats.values():
+            max_flow_dates["projected"][chart_era]["flow"].append(
+                model_stats[chart_era].get("dh1")
+            )
+            max_flow_dates["projected"][chart_era]["date"].append(
+                model_stats[chart_era].get("th1")
+            )
+
+        ########## Calculate stats for the stats table. ##########
+
+        table_stats = {
+            "historical": historical_stats,
+            "projected": {chart_era: {}},
+        }
+
+        stat_arrays = {}
+        for model_stats in projected_stats.values():
+            for stat, val in model_stats[chart_era].items():
+                if stat not in stat_arrays:
+                    stat_arrays[stat] = []
+                stat_arrays[stat].append(val)
+
+        for stat, values in stat_arrays.items():
+            table_stats["projected"][chart_era][stat] = {
+                "min": round(min(values), 3),
+                "median": round(statistics.median(values), 3),
+                "max": round(max(values), 3),
+            }
+
+        response = {
+            "gauge_id": None,
+            "huc8": None,
+            "huc8_outlet": None,
+            "hydrograph": hydrograph,
+            "id": stats["id"],
+            "name": stats["name"],
+            "monthly_flow": monthly_flow,
+            "max_flow_dates": max_flow_dates,
+            "stats": table_stats,
+            "summary": copy.deepcopy(_SUMMARY_STUB),
+        }
+
+        return jsonify(response)
+
+    except Exception as exc:
         return render_template("500/server_error.html"), 500

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -828,6 +828,7 @@ def run_get_conus_hydrology_stats_data(stream_id):
                 return render_template("500/server_error.html"), 500
 
         # add stats for data sentences to metadata: this is not included in the CSV output, but should be in JSON response
+        # TODO: drop the summary if not used in the front end
         data_dict = populate_feature_stat_attributes_summary(data_dict, gdf)
 
         return jsonify(data_dict)

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -397,14 +397,15 @@ def package_metadata(ds, data_dict):
 
         # special cases:
 
-        # add derived "ma99" annual mean flow stat
-        # if "ma12" is present (indicating we are dealing with a stats dataset)
-        # if var == "ma12":
-        #     data_dict["metadata"]["variables"]["ma99"] = {}
-        #     data_dict["metadata"]["variables"]["ma99"]["units"] = "cfs"
-        #     data_dict["metadata"]["variables"]["ma99"][
-        #         "description"
-        #     ] = "Annual mean streamflow (cfs), calculated as the mean of the monthly mean flows."
+        # TODO: if stat source is "original_gcm", then we should update the description of the stat variables
+        # to indicate that these are actual stat values derived from the original GCM runs
+
+        # TODO: if stat source is "gcm_diff", then we should update the description of the stat variables
+        # to indicate that these are ratios or absolute diffs, not actual stat values
+
+        # TODO: if the stat source is "gcm_diff_applied_to_maurer", then we should update the description
+        # of the stat variables to indicate that these are actual stat values derived from applying the
+        # GCM-projected changes to the historical Maurer stats
 
         # "doy" vars from hydrograph datasets
         if var in ["doy_min", "doy_mean", "doy_max"]:
@@ -724,45 +725,6 @@ def populate_feature_stat_attributes_summary(data_dict, gdf):
     return data_dict
 
 
-def calculate_and_populate_annual_mean_flow(data_dict):
-    """
-    Function to calculate and populate the annual mean flow (ma99) in the stats data dictionary.
-    Args:
-        data_dict (dict): Data dictionary with the stats data populated
-    Returns:
-        Data dictionary with the annual mean flow populated.
-    """
-    monthly_stats_codes = [
-        "ma12",
-        "ma13",
-        "ma14",
-        "ma15",
-        "ma16",
-        "ma17",
-        "ma18",
-        "ma19",
-        "ma20",
-        "ma21",
-        "ma22",
-        "ma23",
-    ]
-    for landcover_, land_dict in data_dict["data"].items():
-        for model_, model_dict in land_dict.items():
-            for scenario_, scen_dict in model_dict.items():
-                for era_, era_dict in scen_dict.items():
-                    # check if all monthly stats are present
-                    if all(code in era_dict for code in monthly_stats_codes):
-                        # calculate annual mean flow
-                        monthly_values = [
-                            era_dict[code] for code in monthly_stats_codes
-                        ]
-                        annual_mean_flow = sum(monthly_values) / len(monthly_values)
-                        # populate the annual mean flow in the stats dictionary
-                        era_dict["ma99"] = round(annual_mean_flow, 2)
-
-    return data_dict
-
-
 def prune_missing_scenarios(data_dict):
     """
     Function to prune scenarios with no data from the data dictionary.
@@ -843,13 +805,16 @@ def run_get_conus_hydrology_stats_data(stream_id):
 
         # package the stats data + metadata into a dictionary for JSON serialization
         data_dict = package_stats_data(stream_id, ds)
-        # data_dict = calculate_and_populate_annual_mean_flow(data_dict)
         data_dict = package_metadata(ds, data_dict)
         data_dict = populate_feature_name_and_location_attributes(data_dict, gdf)
 
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
         if request.args.get("format") == "csv":
+
+            # TODO: pass stat source through to CSV creation function so that an appropriate stat description
+            #  can be included in the metadata of the CSV output metadata
+
             try:
                 return create_csv(
                     data=data_dict,

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -32,8 +32,14 @@ from . import routes
 import statistics
 
 coverages = {
-    "stats": ["conus_hydro_segments_stats"],
+    "stats": ["conus_hydro_segments_stats_combined"],
     "doy_climatology": ["conus_hydro_segments_doy_climatology"],
+}
+
+stat_source_encodings = {
+    "original_gcm": 0,
+    "gcm_diff": 1,
+    "gcm_diff_applied_to_maurer": 2,
 }
 
 
@@ -52,20 +58,27 @@ async def get_decode_dicts_from_axis_attributes(cov_ids):
     return decode_dicts
 
 
-async def fetch_hydro_data(cov_ids, stream_id):
+async def fetch_hydro_data(cov_ids, stream_id, source=None):
     """
     Function to fetch hydrology data from Rasdaman. Data is fetched for one stream ID at a time!
     Args:
         cov_ids (list): list of coverage IDs for the hydrology data
         stream_id (str): Stream ID for the hydrology data
+        source (str, optional): Source ID (for stats coverage only)
 
     Returns:
         results (list): list of responses from Rasdaman for each coverage ID
     """
-    urls = [
-        RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, stream_id)
-        for cov_id in cov_ids
-    ]
+    if source is not None:
+        urls = [
+            RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, stream_id, source)
+            for cov_id in cov_ids
+        ]
+    else:
+        urls = [
+            RAS_BASE_URL + generate_conus_hydrology_wcs_str(cov_id, stream_id)
+            for cov_id in cov_ids
+        ]
 
     results = await fetch_data(urls)
 
@@ -386,15 +399,15 @@ def package_metadata(ds, data_dict):
 
         # add derived "ma99" annual mean flow stat
         # if "ma12" is present (indicating we are dealing with a stats dataset)
-        if var == "ma12":
-            data_dict["metadata"]["variables"]["ma99"] = {}
-            data_dict["metadata"]["variables"]["ma99"]["units"] = "cfs"
-            data_dict["metadata"]["variables"]["ma99"][
-                "description"
-            ] = "Annual mean streamflow (cfs), calculated as the mean of the monthly mean flows."
+        # if var == "ma12":
+        #     data_dict["metadata"]["variables"]["ma99"] = {}
+        #     data_dict["metadata"]["variables"]["ma99"]["units"] = "cfs"
+        #     data_dict["metadata"]["variables"]["ma99"][
+        #         "description"
+        #     ] = "Annual mean streamflow (cfs), calculated as the mean of the monthly mean flows."
 
         # "doy" vars from hydrograph datasets
-        elif var in ["doy_min", "doy_mean", "doy_max"]:
+        if var in ["doy_min", "doy_mean", "doy_max"]:
             data_dict["metadata"]["variables"][var]["units"] = "cfs"
             if var == "doy_min":
                 op = "Minimum"
@@ -798,6 +811,11 @@ def run_get_conus_hydrology_stats_data(stream_id):
     Returns:
         JSON response with hydrological stats for the requested stream ID.
     """
+    # validate get request query parameters
+    source = request.args.get("source", None)
+    if source is None:
+        source = "gcm_diff_applied_to_maurer"
+
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
 
@@ -810,15 +828,22 @@ def run_get_conus_hydrology_stats_data(stream_id):
         decode_dict = asyncio.run(
             get_decode_dicts_from_axis_attributes(coverages["stats"])
         )[0]
-        ds = asyncio.run(fetch_hydro_data(coverages["stats"], stream_id))[0]
 
-        # decode the dimension values
+        ds = asyncio.run(
+            fetch_hydro_data(
+                coverages["stats"], stream_id, source=stat_source_encodings[source]
+            )
+        )[0]
+
+        # decode the dimension values, ignoring "source"
         for dim, mapping in decode_dict.items():
+            if dim == "source":
+                continue
             ds = ds.assign_coords({dim: [mapping[int(v)] for v in ds[dim].values]})
 
         # package the stats data + metadata into a dictionary for JSON serialization
         data_dict = package_stats_data(stream_id, ds)
-        data_dict = calculate_and_populate_annual_mean_flow(data_dict)
+        # data_dict = calculate_and_populate_annual_mean_flow(data_dict)
         data_dict = package_metadata(ds, data_dict)
         data_dict = populate_feature_name_and_location_attributes(data_dict, gdf)
 

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -369,7 +369,7 @@ def package_hydrograph_data(stream_id, datasets):
     return prune_missing_scenarios(hydrograph_dict)
 
 
-def package_metadata(ds, data_dict):
+def package_metadata(ds, data_dict, source=None):
     """
     Function to package the metadata from the dataset into the data dictionary.
     Args:
@@ -396,16 +396,31 @@ def package_metadata(ds, data_dict):
         )
 
         # special cases:
+        source_notes = {
+            "original_gcm": "Values are derived from the original GCM runs.",
+            "gcm_diff": "Values are derived from the ratio or absolute difference between the original GCM runs and the historical GCM runs; these are not actual statistic values.",
+            "gcm_diff_applied_to_maurer": "Values are derived from applying the GCM-projected changes to the historical Maurer baseline.",
+        }
 
-        # TODO: if stat source is "original_gcm", then we should update the description of the stat variables
-        # to indicate that these are actual stat values derived from the original GCM runs
+        # if source is "original_gcm", update var description to say values are derived from the original GCM runs
+        if source == "original_gcm":
+            data_dict["metadata"]["variables"][var][
+                "description"
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['original_gcm']}"
 
-        # TODO: if stat source is "gcm_diff", then we should update the description of the stat variables
-        # to indicate that these are ratios or absolute diffs, not actual stat values
+        # if source is "gcm_diff" (stats only), update var description to say values are ratio or
+        # absolute differences from the original GCM runs, not actual stat values
+        if source == "gcm_diff":
+            data_dict["metadata"]["variables"][var][
+                "description"
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff']}"
 
-        # TODO: if the stat source is "gcm_diff_applied_to_maurer", then we should update the description
-        # of the stat variables to indicate that these are actual stat values derived from applying the
-        # GCM-projected changes to the historical Maurer stats
+        # if source is "gcm_diff_applied_to_maurer", update var description to say values are derived from
+        # applying the GCM-projected changes to the historical Maurer stats
+        if source == "gcm_diff_applied_to_maurer":
+            data_dict["metadata"]["variables"][var][
+                "description"
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff_applied_to_maurer']}"
 
         # "doy" vars from hydrograph datasets
         if var in ["doy_min", "doy_mean", "doy_max"]:
@@ -419,6 +434,11 @@ def package_metadata(ds, data_dict):
             data_dict["metadata"]["variables"][var][
                 "description"
             ] = f"{op} streamflow value (cfs) on the specified day of year, aggregated over all years in the era."
+            # add source notes
+            if source in source_notes:
+                data_dict["metadata"]["variables"][var][
+                    "description"
+                ] += f" {source_notes[source]}"
 
             # also add doy and water_year_index metadata:
             # these will be overwritten multiple times, but the values are the same for all three vars and we will only see them once in the final output
@@ -758,6 +778,52 @@ def convert_doy_to_water_year_index(doy):
     return wy_index
 
 
+def calculate_and_apply_gcm_diffs_to_maurer_climatology(data_dict):
+    """
+    Function to calculate the GCM-projected changes in streamflow stats and apply those changes to the historical Maurer climatology stats.
+    This is done by first calculating the percent change between the GCM-projected future stat values and the GCM historical stat values,
+    then applying that percent change to the Maurer historical stat values.
+    Args:
+        data_dict (dict): Data dictionary with the hydrology data populated
+    Returns:
+        dict: Data dictionary with the GCM-projected changes applied to the Maurer climatology stats.
+    """
+    adjusted_data_dict = {}
+    for model in data_dict.keys():
+        # no need to adjust Maurer historical stats, so just copy them over to the adjusted data dict
+        if model == "Maurer":
+            adjusted_data_dict[model] = data_dict[model]
+            continue
+        if model not in adjusted_data_dict:
+            adjusted_data_dict[model] = {}
+        for scenario in data_dict[model].keys():
+            if scenario not in adjusted_data_dict[model]:
+                adjusted_data_dict[model][scenario] = {}
+            for era in data_dict[model][scenario].keys():
+                if era not in adjusted_data_dict[model][scenario]:
+                    adjusted_data_dict[model][scenario][era] = []
+                for i in range(len(data_dict[model][scenario][era])):
+                    doy_stats = {}
+                    for stat in data_dict[model][scenario][era][i].keys():
+                        maurer_historical = data_dict["Maurer"]["historical"][
+                            "1976-2005"
+                        ][i][stat]
+                        gcm_historical = data_dict[model]["historical"]["1976-2005"][i][
+                            stat
+                        ]
+                        gcm_projected = data_dict[model][scenario][era][i][stat]
+                        denominator = gcm_historical
+                        if denominator == 0:
+                            denominator = 0.0001
+                        projected_quotient = gcm_projected / denominator
+                        maurer_adjusted = round(
+                            maurer_historical * projected_quotient, 3
+                        )
+                        doy_stats[stat] = maurer_adjusted
+                    adjusted_data_dict[model][scenario][era].append(doy_stats)
+    return adjusted_data_dict
+
+
 @routes.route("/conus_hydrology/")
 def conus_hydrology_about():
     return render_template("/documentation/conus_hydrology.html")
@@ -805,7 +871,7 @@ def run_get_conus_hydrology_stats_data(stream_id):
 
         # package the stats data + metadata into a dictionary for JSON serialization
         data_dict = package_stats_data(stream_id, ds)
-        data_dict = package_metadata(ds, data_dict)
+        data_dict = package_metadata(ds, data_dict, source=source)
         data_dict = populate_feature_name_and_location_attributes(data_dict, gdf)
 
         data_dict = prune_nulls_with_max_intensity(data_dict)
@@ -828,7 +894,6 @@ def run_get_conus_hydrology_stats_data(stream_id):
                 return render_template("500/server_error.html"), 500
 
         # add stats for data sentences to metadata: this is not included in the CSV output, but should be in JSON response
-        # TODO: drop the summary if not used in the front end
         data_dict = populate_feature_stat_attributes_summary(data_dict, gdf)
 
         return jsonify(data_dict)
@@ -852,6 +917,13 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
     Returns:
         JSON response with modeled daily climatology data for the requested stream ID.
     """
+    # validate get request query parameters
+    source = request.args.get("source", None)
+    if source is None:
+        source = "gcm_diff_applied_to_maurer"
+    elif source == "gcm_diff":
+        return render_template("400/bad_request.html"), 400
+
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
 
@@ -879,7 +951,7 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
         # package the hydrograph datasets into a dictionary for JSON serialization
         data_dict = package_hydrograph_data(stream_id, datasets)
         data_dict = package_metadata(
-            datasets[0], data_dict
+            datasets[0], data_dict, source=source
         )  # all datasets should have same metadata, just use the first one
         data_dict = populate_feature_name_and_location_attributes(data_dict, gdf)
         data_dict = prune_nulls_with_max_intensity(data_dict)
@@ -896,6 +968,11 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
                 )
             except Exception as exc:
                 return render_template("500/server_error.html"), 500
+
+        # apply GCM-projected changes to Maurer climatology stats if source is "gcm_diff_applied_to_maurer"
+        # otherwise, if source is "original_gcm", then we are just returning the original GCM stats with no adjustments
+        if source == "gcm_diff_applied_to_maurer":
+            data_dict = calculate_and_apply_gcm_diffs_to_maurer_climatology(data_dict)
 
         return jsonify(data_dict)
 
@@ -1013,8 +1090,10 @@ def fetch_all_hydroviz_route(stream_id):
             "summary": ...
         }
     """
-
+    # fetch stats with default source of "gcm_diff_applied_to_maurer" (Maurer data is also included in this source)
     stats_response = run_get_conus_hydrology_stats_data(stream_id)
+
+    # fetch daily climatology default source of "gcm_diff_applied_to_maurer" (Maurer data is also included in this source)
     climatology_response = run_get_conus_hydrology_modeled_climatology(stream_id)
 
     # Projected eras to use for the hydrograph and monthly flow charts.
@@ -1026,93 +1105,23 @@ def fetch_all_hydroviz_route(stream_id):
             return response
 
     try:
-        # Fetch all needed data.
         stats = stats_response.get_json()
         climatology = climatology_response.get_json()
 
-        # Convert static stats to Maurer * (GCM projected / GCM historical).
-        static_stats = stats["data"]["static"]
-        maurer_adjusted_stats = {}
-        for model in static_stats.keys():
-            if model not in maurer_adjusted_stats:
-                maurer_adjusted_stats[model] = {}
-            for scenario in static_stats[model].keys():
+        # Subset just static data for future eras used in the app
+        # Maurer historical will be added back in below
+
+        maurer_adjusted_stats = stats["data"]["static"]
+        for model in maurer_adjusted_stats.keys():
+            for scenario in maurer_adjusted_stats[model].keys():
                 if scenario in ["historical", "rcp26"]:
-                    continue
-                if scenario not in maurer_adjusted_stats[model]:
-                    maurer_adjusted_stats[model][scenario] = {}
-                for era in static_stats[model][scenario].keys():
-                    if era not in maurer_adjusted_stats[model][scenario]:
-                        maurer_adjusted_stats[model][scenario][era] = {}
-                    for stat in static_stats[model][scenario][era].keys():
-                        maurer_historical = static_stats["Maurer"]["historical"][
-                            "1976-2005"
-                        ][stat]
-                        gcm_historical = static_stats[model]["historical"]["1976-2005"][
-                            stat
-                        ]
-                        gcm_projected = static_stats[model][scenario][era][stat]
+                    del maurer_adjusted_stats[model][scenario]
 
-                        denominator = gcm_historical
-                        if denominator == 0:
-                            denominator = 0.0001
-                        projected_quotient = gcm_projected / denominator
-                        maurer_adjusted = round(
-                            maurer_historical * projected_quotient, 3
-                        )
-
-                        # Use modulo adjustment for stats with Julian day units.
-                        # This will roll a date over to the next year if necessary.
-                        # Subtracting 1 before, then adding 1 after, prevents days of 0.
-                        if stat in ["spr_ord", "sum_ord", "th1", "tl1"]:
-                            maurer_adjusted = ((maurer_adjusted - 1) % 366) + 1
-
-                        # Make sure no stats with "number of days" units exceeds 366.
-                        if stat in ["dh15", "dl16", "lf1", "ra8"]:
-                            if maurer_adjusted > 366:
-                                maurer_adjusted = 366
-
-                        maurer_adjusted_stats[model][scenario][era][
-                            stat
-                        ] = maurer_adjusted
-
-        # Convert static climatology to Maurer * (GCM projected / GCM historical).
-        static_climatology = climatology["data"]["static"]
-        maurer_adjusted_climatology = {}
-        for model in static_climatology.keys():
-            if model not in maurer_adjusted_climatology:
-                maurer_adjusted_climatology[model] = {}
-            for scenario in static_climatology[model].keys():
+        maurer_adjusted_climatology = climatology["data"]["static"]
+        for model in maurer_adjusted_climatology.keys():
+            for scenario in maurer_adjusted_climatology[model].keys():
                 if scenario in ["historical", "rcp26"]:
-                    continue
-                if scenario not in maurer_adjusted_climatology[model]:
-                    maurer_adjusted_climatology[model][scenario] = {}
-                for era in static_climatology[model][scenario].keys():
-                    if era not in maurer_adjusted_climatology[model][scenario]:
-                        maurer_adjusted_climatology[model][scenario][era] = []
-                    for i in range(len(static_climatology[model][scenario][era])):
-                        doy_stats = {}
-                        for stat in static_climatology[model][scenario][era][i].keys():
-                            maurer_historical = static_climatology["Maurer"][
-                                "historical"
-                            ]["1976-2005"][i][stat]
-                            gcm_historical = static_climatology[model]["historical"][
-                                "1976-2005"
-                            ][i][stat]
-                            gcm_projected = static_climatology[model][scenario][era][i][
-                                stat
-                            ]
-                            denominator = gcm_historical
-                            if denominator == 0:
-                                denominator = 0.0001
-                            projected_quotient = gcm_projected / denominator
-                            maurer_adjusted = round(
-                                maurer_historical * projected_quotient, 3
-                            )
-                            doy_stats[stat] = maurer_adjusted
-                        maurer_adjusted_climatology[model][scenario][era].append(
-                            doy_stats
-                        )
+                    del maurer_adjusted_climatology[model][scenario]
 
         ########## Populate arrays for hydrograph. ##########
 

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -883,10 +883,6 @@ def run_get_conus_hydrology_stats_data(stream_id):
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
         if request.args.get("format") == "csv":
-
-            # TODO: pass source_notes through to CSV creation function so that an appropriate variable
-            #  description can be included in the CSV metadata
-
             try:
                 return create_csv(
                     data=data_dict,
@@ -895,6 +891,7 @@ def run_get_conus_hydrology_stats_data(stream_id):
                     place_id=stream_id,
                     lat=str(data_dict["latitude"]),
                     lon=str(data_dict["longitude"]),
+                    source_metadata=source,
                 )
             except Exception as exc:
                 return render_template("500/server_error.html"), 500
@@ -963,10 +960,6 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
         if request.args.get("format") == "csv":
-
-            # TODO: pass source_notes through to CSV creation function so that an appropriate variable
-            #  description can be included in the CSV metadata
-
             try:
                 return create_csv(
                     data=data_dict,
@@ -975,6 +968,7 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
                     place_id=stream_id,
                     lat=str(data_dict["latitude"]),
                     lon=str(data_dict["longitude"]),
+                    source_metadata=source,
                 )
             except Exception as exc:
                 return render_template("500/server_error.html"), 500

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -398,7 +398,7 @@ def package_metadata(ds, data_dict, source=None):
         # special cases:
         source_notes = {
             "original_gcm": "Values are derived from the original GCM runs.",
-            "gcm_diff": "Values are derived from the ratio or absolute difference between the original GCM runs and the historical GCM runs; these are not actual statistic values.",
+            "gcm_diff": "Values are the ratio or absolute difference between the original GCM runs and the historical GCM runs - these are not actual statistic values! Apply these differences to a historical baseline value to approximate future values. See LaFontaine and Riley (2023) to find each variable's difference method (ratio or absolute).",
             "gcm_diff_applied_to_maurer": "Values are derived from applying the GCM-projected changes to the historical Maurer baseline.",
         }
 
@@ -803,15 +803,21 @@ def calculate_and_apply_gcm_diffs_to_maurer_climatology(data_dict):
                 if era not in adjusted_data_dict[model][scenario]:
                     adjusted_data_dict[model][scenario][era] = []
                 for i in range(len(data_dict[model][scenario][era])):
-                    doy_stats = {}
-                    for stat in data_dict[model][scenario][era][i].keys():
+                    entry = data_dict[model][scenario][era][i]
+                    doy_stats = {
+                        "doy": entry["doy"],
+                        "water_year_index": entry["water_year_index"],
+                    }
+                    for stat in entry.keys():
+                        if stat in ("doy", "water_year_index"):
+                            continue
                         maurer_historical = data_dict["Maurer"]["historical"][
                             "1976-2005"
                         ][i][stat]
                         gcm_historical = data_dict[model]["historical"]["1976-2005"][i][
                             stat
                         ]
-                        gcm_projected = data_dict[model][scenario][era][i][stat]
+                        gcm_projected = entry[stat]
                         denominator = gcm_historical
                         if denominator == 0:
                             denominator = 0.0001
@@ -878,8 +884,8 @@ def run_get_conus_hydrology_stats_data(stream_id):
 
         if request.args.get("format") == "csv":
 
-            # TODO: pass stat source through to CSV creation function so that an appropriate stat description
-            #  can be included in the metadata of the CSV output metadata
+            # TODO: pass source_notes through to CSV creation function so that an appropriate variable
+            #  description can be included in the CSV metadata
 
             try:
                 return create_csv(
@@ -957,6 +963,10 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
         if request.args.get("format") == "csv":
+
+            # TODO: pass source_notes through to CSV creation function so that an appropriate variable
+            #  description can be included in the CSV metadata
+
             try:
                 return create_csv(
                     data=data_dict,
@@ -972,7 +982,12 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
         # apply GCM-projected changes to Maurer climatology stats if source is "gcm_diff_applied_to_maurer"
         # otherwise, if source is "original_gcm", then we are just returning the original GCM stats with no adjustments
         if source == "gcm_diff_applied_to_maurer":
-            data_dict = calculate_and_apply_gcm_diffs_to_maurer_climatology(data_dict)
+            for landcover in data_dict["data"]:
+                data_dict["data"][landcover] = (
+                    calculate_and_apply_gcm_diffs_to_maurer_climatology(
+                        data_dict["data"][landcover]
+                    )
+                )
 
         return jsonify(data_dict)
 
@@ -1108,18 +1123,22 @@ def fetch_all_hydroviz_route(stream_id):
         stats = stats_response.get_json()
         climatology = climatology_response.get_json()
 
-        # Subset just static data for future eras used in the app
-        # Maurer historical will be added back in below
+        # Save Maurer historical data before pruning scenarios from the dicts below.
+        historical_climatology = climatology["data"]["static"]["Maurer"]["historical"][
+            "1976-2005"
+        ]
+        historical_stats = stats["data"]["static"]["Maurer"]["historical"]
 
+        # Subset just static data for future eras used in the app
         maurer_adjusted_stats = stats["data"]["static"]
         for model in maurer_adjusted_stats.keys():
-            for scenario in maurer_adjusted_stats[model].keys():
+            for scenario in list(maurer_adjusted_stats[model].keys()):
                 if scenario in ["historical", "rcp26"]:
                     del maurer_adjusted_stats[model][scenario]
 
         maurer_adjusted_climatology = climatology["data"]["static"]
         for model in maurer_adjusted_climatology.keys():
-            for scenario in maurer_adjusted_climatology[model].keys():
+            for scenario in list(maurer_adjusted_climatology[model].keys()):
                 if scenario in ["historical", "rcp26"]:
                     del maurer_adjusted_climatology[model][scenario]
 
@@ -1129,10 +1148,6 @@ def fetch_all_hydroviz_route(stream_id):
             "historical": {},
             "projected": {},
         }
-
-        historical_climatology = climatology["data"]["static"]["Maurer"]["historical"][
-            "1976-2005"
-        ]
         hydrograph_historical = {
             "doy_min": list(map(lambda x: x["doy_min"], historical_climatology)),
             "doy_mean": list(map(lambda x: x["doy_mean"], historical_climatology)),
@@ -1204,9 +1219,7 @@ def fetch_all_hydroviz_route(stream_id):
 
         # Get historical data for each month.
         for key in monthly_flow_keys:
-            monthly_flow["historical"][key] = stats["data"]["static"]["Maurer"][
-                "historical"
-            ]["1976-2005"][key]
+            monthly_flow["historical"][key] = historical_stats["1976-2005"][key]
 
         # Populate lists of values for each month for each projected model.
         # These values will be used to generate box plots in the webapp.
@@ -1234,12 +1247,8 @@ def fetch_all_hydroviz_route(stream_id):
         }
 
         # Get historical data for max flow date.
-        max_flow_dates["historical"]["flow"] = stats["data"]["static"]["Maurer"][
-            "historical"
-        ]["1976-2005"]["dh1"]
-        max_flow_dates["historical"]["date"] = stats["data"]["static"]["Maurer"][
-            "historical"
-        ]["1976-2005"]["th1"]
+        max_flow_dates["historical"]["flow"] = historical_stats["1976-2005"]["dh1"]
+        max_flow_dates["historical"]["date"] = historical_stats["1976-2005"]["th1"]
 
         # Populate lists of values for max flow date for each projected model.
         for era in chart_eras:
@@ -1268,7 +1277,7 @@ def fetch_all_hydroviz_route(stream_id):
             "projected": {},
         }
 
-        table_stats["historical"] = stats["data"]["static"]["Maurer"]["historical"]
+        table_stats["historical"] = historical_stats
 
         scenario_stat_arrays = {}
         for era in chart_eras:

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -781,8 +781,8 @@ def convert_doy_to_water_year_index(doy):
 def calculate_and_apply_gcm_diffs_to_maurer_climatology(data_dict):
     """
     Function to calculate the GCM-projected changes in streamflow stats and apply those changes to the historical Maurer climatology stats.
-    This is done by first calculating the percent change between the GCM-projected future stat values and the GCM historical stat values,
-    then applying that percent change to the Maurer historical stat values.
+    This is done by first calculating the ratio between the GCM-projected future stat values and the GCM historical stat values,
+    then applying that scaling factor to the Maurer historical stat values.
     Args:
         data_dict (dict): Data dictionary with the hydrology data populated
     Returns:

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -285,11 +285,12 @@ def package_stats_data(stream_id, ds):
                     if np.isnan(vals).all():
                         continue
 
-                    scen_dict[era] = {
-                        vars_[i]: round(float(v), 2)
-                        for i, v in enumerate(vals)
-                        if not np.isnan(v)
-                    }
+                    scen_dict[era] = {}
+                    for i, v in enumerate(vals):
+                        if not np.isnan(v):
+                            scen_dict[era][vars_[i]] = round(float(v), 2)
+                        else:
+                            scen_dict[era][vars_[i]] = None
 
     return prune_missing_scenarios(stats_dict)
 
@@ -880,7 +881,9 @@ def run_get_conus_hydrology_stats_data(stream_id):
         data_dict = package_metadata(ds, data_dict, source=source)
         data_dict = populate_feature_name_and_location_attributes(data_dict, gdf)
 
-        data_dict = prune_nulls_with_max_intensity(data_dict)
+        # Get all variable keys and keep them during pruning process.
+        data_vars = list(ds.data_vars)
+        data_dict = prune_nulls_with_max_intensity(data_dict, keys_to_keep=data_vars)
 
         if request.args.get("format") == "csv":
             try:
@@ -1300,11 +1303,20 @@ def fetch_all_hydroviz_route(stream_id):
                     table_stats["projected"][era][scenario] = {}
                 for stat in scenario_stat_arrays[scenario][era].keys():
                     values = scenario_stat_arrays[scenario][era][stat]
-                    table_stats["projected"][era][scenario][stat] = {
-                        "min": round(min(values), 3),
-                        "median": round(statistics.median(values), 3),
-                        "max": round(max(values), 3),
-                    }
+                    if all(v is None for v in values):
+                        table_stats["projected"][era][scenario][stat] = {
+                            "min": None,
+                            "median": None,
+                            "max": None,
+                        }
+                    else:
+                        # If values are not all None, calculate min/median/max using non-None values.
+                        values = [v for v in values if v is not None]
+                        table_stats["projected"][era][scenario][stat] = {
+                            "min": round(min(values), 3),
+                            "median": round(statistics.median(values), 3),
+                            "max": round(max(values), 3),
+                        }
 
         gauge_id = None
         h8_outlet = False

--- a/templates/documentation/conus_hydrology.html
+++ b/templates/documentation/conus_hydrology.html
@@ -58,7 +58,27 @@
     <tr>
       <td colspan="2">
         CSV output is also available by appending <code>?format=csv</code> to
-        the URL. <br />
+        the URL.<br />
+        The data source can be controlled with the <code>?source=</code>
+        parameter. Accepted values are:
+        <ul>
+          <li>
+            <code>gcm_diff_applied_to_maurer</code> (default) &mdash; GCM-projected
+            changes applied to the historical Maurer baseline.
+          </li>
+          <li>
+            <code>original_gcm</code> &mdash; raw output from the original GCM
+            runs.
+          </li>
+          <li>
+            <code>gcm_diff</code> &mdash; ratio or absolute difference between
+            the projected and historical GCM runs. These are not actual statistic
+            values; apply them to your own historical baseline to approximate future
+            values.
+          </li>
+        </ul>
+        Chaining of multiple arguments is supported (e.g.,
+        <code>?source=original_gcm&amp;format=csv</code>).
       </td>
     </tr>
   </tfoot>
@@ -94,7 +114,21 @@
     <tr>
       <td colspan="2">
         CSV output is also available by appending <code>?format=csv</code> to
-        the URL. <br />
+        the URL.<br />
+        The data source can be controlled with the <code>?source=</code>
+        parameter. Accepted values are:
+        <ul>
+          <li>
+            <code>gcm_diff_applied_to_maurer</code> (default) &mdash; GCM-projected
+            changes applied to the historical Maurer baseline.
+          </li>
+          <li>
+            <code>original_gcm</code> &mdash; raw output from the original GCM
+            runs.
+          </li>
+        </ul>
+        Chaining of multiple arguments is supported (e.g.,
+        <code>?source=original_gcm&amp;format=csv</code>).
       </td>
     </tr>
   </tfoot>


### PR DESCRIPTION
### Summary
Both the CONUS hydrology and arctic hydrology stats coverages in Rasdaman have been updated (`conus_hydro_segments_stats_combined` and `ak_hydro_segments_stats_combined`) to include a source dimension encoding three variants of the data. This branch wires up that new dimension as a `?source=` query parameter and simplifies the `conus_hydrology/stats/{stream_id}` and `arctic_hydrology/stats/{stream_id}` endpoints by moving the historical baseline adjustment math out of inline application code and into the coverage itself. 

### Changes:

- New `?source=` parameter on `/conus_hydrology/stats/{stream_id}`, `arctic_hydrology/stats/{stream_id}`,  `/conus_hydrology/modeled_climatology/{stream_id}`, and `/arctic_hydrology/modeled_climatology/{stream_id}`. Accepted values are:
  - **gcm_diff_applied_to_maurer** (default for conus hydrology): GCM-projected changes applied to the Maurer historical baseline
  -  **gcm_diff_applied_to_cheng** (default for arctic hydrology): GCM-projected changes applied to the Cheng historical baseline
  - **original_gcm**: raw GCM output
  - **gcm_diff**: ratio/absolute difference between projected and historical GCM (for stats endpoint only; not valid for climatology)
- Hidden hydroviz app `/conus_hydrology/hydroviz/{stream_id}` and `/arctic_hydrology/hydroviz/{stream_id}` endpoints are simplified: the historical baseline adjustment calculation previously done inline is now handled by `calculate_and_apply_gcm_diffs_to_maurer_climatology()` or `calculate_and_apply_gcm_diffs_to_cheng_climatology()`, and is called from the modeled climatology endpoint when source is "gcm_diff_applied_to_maurer" (the conus default) or "gcm_diff_applied_to_cheng" (the arctic default). Note that this math is now optional depending on the choice of source: the user can get an un-adjusted hydrograph too by using source="original_gcm", if that's what they want.
- `ma99` removed from client-side calculation: annual mean flow is now stored in the coverage, so `calculate_and_populate_annual_mean_flow()` is deleted.
- Source notes in metadata: variable descriptions in JSON and CSV output include a brief note describing what the values represent for the selected source. For the JSON, notes were included in each variable description to be very explicit about what data the user is getting. I did this because I don't think it's safe to assume anyone is reading a JSON completely top to bottom - they might be accessing only certain parts and so the redundancy might be useful. For the CSV, the note is included near the top of the metadata as I expect users will read the notes at the top before accessing values.
- Application-level validation: `?source=` values are validated via marshmallow in `application.py`.
- Documentation: `?source=` options and parameter chaining documented for both endpoints. 

Note that the source notes (in variable metadata descriptions and CSV headers) and their documentation wording are first drafts. The language describing what each source mode means should be revised if there is a better way to clearly communicate the data provenance. Any ideas here are welcome, or we could workshop it with the rest of the team later.

XREF: https://github.com/ua-snap/hydroviz/pull/184
XREF: https://github.com/ua-snap/rasdaman-ingest/pull/157

XREF: https://github.com/ua-snap/arctic_rivers/pull/4
XREF: https://github.com/ua-snap/rasdaman-ingest/pull/158