### PR TITLE
Include all hydroviz stat keys in response even if they are null

### DIFF
--- a/postprocessing.py
+++ b/postprocessing.py
@@ -146,12 +146,17 @@ def prune_nodata_list(data):
     return pruned
 
 
-def prune_nulls_with_max_intensity(data, keys_to_keep=[]):
+def prune_nulls_with_max_intensity(data, keys_to_keep=None):
     """
     Recursively remove all None values from dicts and remove any empty dicts that remain.
 
     In practice, this will trim keys with `null` values from the API response even in the case when a sibling key does have data.
+    The optional keys_to_keep argument allows you to specify keys that should be retained even if their value is None.
     """
+    if keys_to_keep is None:
+        keys_to_keep = set()
+    else:
+        keys_to_keep = set(keys_to_keep)
     if isinstance(data, dict):
         return {
             k: v

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -146,7 +146,7 @@ def prune_nodata_list(data):
     return pruned
 
 
-def prune_nulls_with_max_intensity(data):
+def prune_nulls_with_max_intensity(data, keys_to_keep=[]):
     """
     Recursively remove all None values from dicts and remove any empty dicts that remain.
 
@@ -156,9 +156,10 @@ def prune_nulls_with_max_intensity(data):
         return {
             k: v
             for k, v in (
-                (k, prune_nulls_with_max_intensity(v)) for k, v in data.items()
+                (k, prune_nulls_with_max_intensity(v, keys_to_keep))
+                for k, v in data.items()
             )
-            if v is not None
+            if v is not None or k in keys_to_keep
         }
     else:
         return data

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -285,11 +285,12 @@ def package_stats_data(stream_id, ds):
                     if np.isnan(vals).all():
                         continue
 
-                    scen_dict[era] = {
-                        vars_[i]: round(float(v), 2)
-                        for i, v in enumerate(vals)
-                        if not np.isnan(v)
-                    }
+                    scen_dict[era] = {}
+                    for i, v in enumerate(vals):
+                        if not np.isnan(v):
+                            scen_dict[era][vars_[i]] = round(float(v), 2)
+                        else:
+                            scen_dict[era][vars_[i]] = None
 
     return prune_missing_scenarios(stats_dict)
 
@@ -880,7 +881,9 @@ def run_get_conus_hydrology_stats_data(stream_id):
         data_dict = package_metadata(ds, data_dict, source=source)
         data_dict = populate_feature_name_and_location_attributes(data_dict, gdf)
 
-        data_dict = prune_nulls_with_max_intensity(data_dict)
+        # Get all variable keys and keep them during pruning process.
+        data_vars = list(ds.data_vars)
+        data_dict = prune_nulls_with_max_intensity(data_dict, keys_to_keep=data_vars)
 
         if request.args.get("format") == "csv":
             try:
@@ -1300,11 +1303,20 @@ def fetch_all_hydroviz_route(stream_id):
                     table_stats["projected"][era][scenario] = {}
                 for stat in scenario_stat_arrays[scenario][era].keys():
                     values = scenario_stat_arrays[scenario][era][stat]
-                    table_stats["projected"][era][scenario][stat] = {
-                        "min": round(min(values), 3),
-                        "median": round(statistics.median(values), 3),
-                        "max": round(max(values), 3),
-                    }
+                    if all(v is None for v in values):
+                        table_stats["projected"][era][scenario][stat] = {
+                            "min": None,
+                            "median": None,
+                            "max": None,
+                        }
+                    else:
+                        # If values are not all None, calculate min/median/max using non-None values.
+                        values = [v for v in values if v is not None]
+                        table_stats["projected"][era][scenario][stat] = {
+                            "min": round(min(values), 3),
+                            "median": round(statistics.median(values), 3),
+                            "max": round(max(values), 3),
+                        }
 
         gauge_id = None
         h8_outlet = False


### PR DESCRIPTION
This PR makes a few small tweaks to the `hydroviz_diff` branch to ensure that the full set of stats are included in the response, even if they are `null`.

While testing the hydroviz webapp against this branch, the report page was frequently failing to load because the `lf1` stat was missing from projected data because it had been pruned from the response. Pruning null values is a valid approach, but IMO it's less confusing for the end user to always include the full set of stats and indicate which values are null explicitly. On the webapp, we'll display these values as "N/A".