### PR TITLE
Use latest hydroviz layers from GeoServer (Gage not Gauge) and correct Arctic Rivers citation (Blaskey not Cheng)

### DIFF
--- a/application.py
+++ b/application.py
@@ -185,7 +185,7 @@ def validate_get_params():
                     "original_gcm",
                     "gcm_diff",
                     "gcm_diff_applied_to_maurer",
-                    "gcm_diff_applied_to_cheng",
+                    "gcm_diff_applied_to_blaskey",
                 ]
             ),
             required=False,

--- a/csv_functions.py
+++ b/csv_functions.py
@@ -1503,7 +1503,7 @@ def arctic_hydrology_csv(data, filename_prefix, source_metadata):
     source_notes = {
         "original_gcm": "These values are derived from the original GCM or PGW runs.",
         "gcm_diff": "These values are the ratio or absolute difference between the original GCM runs and the historical GCM runs — these are not actual statistic values. Apply these differences to a historical baseline value to approximate future values. PGW runs are not included.",
-        "gcm_diff_applied_to_cheng": "These values are derived from applying the GCM-projected changes to the historical Cheng baseline. PGW runs are not included.",
+        "gcm_diff_applied_to_blaskey": "These values are derived from applying the GCM-projected changes to the historical Blaskey baseline. PGW runs are not included.",
     }
 
     # data structure for all endpoints:
@@ -1680,9 +1680,7 @@ def arctic_hydrology_csv(data, filename_prefix, source_metadata):
             if isinstance(source_metadata, str) and source_metadata in source_notes:
                 metadata += f"# Climatologies are calculated from modeled daily streamflow data. {source_notes[source_metadata]}\n"
             else:
-                metadata += (
-                    "# Climatologies are calculated from modeled daily streamflow data.\n"
-                )
+                metadata += "# Climatologies are calculated from modeled daily streamflow data.\n"
             metadata += "# doy is the day of year (1-366) for which the climatology value is reported. \n"
             metadata += "# water_year_index is the water year index (1-366) for which the climatology value is reported. The water year is defined as starting on October 1 (DOY 275 in a 366 day year = water year index 1) and ending September 30 (DOY 274 in a 366 day year = water year index 366).\n"
             metadata += "# doy_min is the minimum streamflow value for the given day of year across all years in the era (cubic feet per second).\n"

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -138,13 +138,13 @@ def generate_wfs_arctic_hydrology_url(stream_id):
     if stream_id == "":
         wfs_url = (
             GS_BASE_URL
-            + "wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_joined_3338_simplified&propertyName=(COMID)&outputFormat=application/json"
+            + "wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_joined_3338_simplified_v2&propertyName=(COMID)&outputFormat=application/json"
         )
         return wfs_url
     else:
         wfs_url = (
             GS_BASE_URL
-            + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_joined_3338_simplified&propertyName=(COMID,the_geom,Gage_ID,ID_1,ID_2,Name,outlet)&outputFormat=application/json&cql_filter=(COMID={stream_id})"
+            + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_joined_3338_simplified_v2&propertyName=(COMID,the_geom,Gage_ID,ID_1,ID_2,Name,outlet)&outputFormat=application/json&cql_filter=(COMID={stream_id})"
         )
     return wfs_url
 
@@ -152,11 +152,11 @@ def generate_wfs_arctic_hydrology_url(stream_id):
 def generate_wfs_arctic_hydrology_stats_url(stream_id):
     """
     Generate a WFS URL for fetching arctic hydrology summary stats for a given stream ID
-    from the arctic_rivers_segments_stats_simplified layer.
+    from the arctic_rivers_segments_stats_simplified_v2 layer.
     """
     return (
         GS_BASE_URL
-        + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_stats_simplified&outputFormat=application/json&cql_filter=(COMID={stream_id})"
+        + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_stats_simplified_v2&outputFormat=application/json&cql_filter=(COMID={stream_id})"
     )
 
 

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -119,13 +119,13 @@ def generate_wfs_conus_hydrology_url(stream_id):
     if stream_id == "":
         wfs_url = (
             GS_BASE_URL
-            + "wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:seg_h8_outlet_stats_simplified&outputFormat=application/json"
+            + "wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:seg_h8_outlet_stats_simplified_v2&outputFormat=application/json"
         )
         return wfs_url
     else:
         wfs_url = (
             GS_BASE_URL
-            + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:seg_h8_outlet_stats_simplified&outputFormat=application/json&cql_filter=(seg_id_nat={stream_id})"
+            + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:seg_h8_outlet_stats_simplified_v2&outputFormat=application/json&cql_filter=(seg_id_nat={stream_id})"
         )
     return wfs_url
 

--- a/generate_urls.py
+++ b/generate_urls.py
@@ -144,7 +144,7 @@ def generate_wfs_arctic_hydrology_url(stream_id):
     else:
         wfs_url = (
             GS_BASE_URL
-            + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_joined_3338_simplified&propertyName=(COMID,the_geom,Gauge_ID,ID_1,ID_2,Name,outlet)&outputFormat=application/json&cql_filter=(COMID={stream_id})"
+            + f"wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=hydrology:arctic_rivers_segments_joined_3338_simplified&propertyName=(COMID,the_geom,Gage_ID,ID_1,ID_2,Name,outlet)&outputFormat=application/json&cql_filter=(COMID={stream_id})"
         )
     return wfs_url
 
@@ -160,11 +160,11 @@ def generate_wfs_arctic_hydrology_stats_url(stream_id):
     )
 
 
-def generate_usgs_gauge_daily_streamflow_data_url(gauge_id, start_date, end_date):
+def generate_usgs_gage_daily_streamflow_data_url(gage_id, start_date, end_date):
     """
-    Generate a USGS OGC API URL for fetching daily streamflow data for a given gauge ID and date range.
+    Generate a USGS OGC API URL for fetching daily streamflow data for a given gage ID and date range.
     Args:
-        gauge_id (str): USGS gauge ID (e.g. "USGS-07032000")
+        gage_id (str): USGS gage ID (e.g. "USGS-07032000")
         start_date (str): Start date in YYYY-MM-DD format
         end_date (str): End date in YYYY-MM-DD format
     Returns:
@@ -174,20 +174,20 @@ def generate_usgs_gauge_daily_streamflow_data_url(gauge_id, start_date, end_date
     param = "00060"  # parameter code for daily discharge in CFS (see here: https://help.waterdata.usgs.gov/parameter_cd?group_cd=PHY)
     properties = "time,value,unit_of_measure"
     time = start_date + "/" + end_date
-    request_str = f"collections/daily/items?f=json&lang=en-US&limit=50000&properties={properties}&skipGeometry=true&sortby=%2Btime&offset=0&datetime={time}&monitoring_location_id={gauge_id}&parameter_code={param}&approval_status=Approved"
+    request_str = f"collections/daily/items?f=json&lang=en-US&limit=50000&properties={properties}&skipGeometry=true&sortby=%2Btime&offset=0&datetime={time}&monitoring_location_id={gage_id}&parameter_code={param}&approval_status=Approved"
     url = base_url + request_str
     return url
 
 
-def generate_usgs_gauge_metadata_url(gauge_id):
+def generate_usgs_gage_metadata_url(gage_id):
     """
-    Generate a USGS OGC API URL for fetching metadata for a given gauge ID.
+    Generate a USGS OGC API URL for fetching metadata for a given gage ID.
     Args:
-        gauge_id (str): USGS gauge ID (e.g. "USGS-07032000")
+        gage_id (str): USGS gage ID (e.g. "USGS-07032000")
     Returns:
-        url (str): USGS OGC API URL for gauge metadata (gauge name and location)"""
+        url (str): USGS OGC API URL for gage metadata (gage name and location)"""
     base_url = "https://api.waterdata.usgs.gov/ogcapi/v0/"
     properties = "monitoring_location_name"
-    request_str = f"collections/monitoring-locations/items?f=json&lang=en-US&limit=1&properties={properties}&skipGeometry=false&offset=0&id={gauge_id}"
+    request_str = f"collections/monitoring-locations/items?f=json&lang=en-US&limit=1&properties={properties}&skipGeometry=false&offset=0&id={gage_id}"
     url = base_url + request_str
     return url

--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -672,9 +672,9 @@ def populate_feature_attributes(data_dict, gdf):
 
     # data_dict["name"] = "" # arctic rivers segments do not have stream names associated
 
-    # gauge ID is blank for most features; normalize None/NaN to "" so the key is always present
-    gauge_id_raw = gdf.loc[0].get("Gauge_ID", None)
-    data_dict["gauge_id"] = gauge_id_raw if isinstance(gauge_id_raw, str) else ""
+    # gage ID is blank for most features; normalize None/NaN to "" so the key is always present
+    gage_id_raw = gdf.loc[0].get("Gage_ID", None)
+    data_dict["gage_id"] = gage_id_raw if isinstance(gage_id_raw, str) else ""
 
     # the watershed ID matches the GVV code for HUC8 in Alaska or Yukon watershed in Canada
     # all Yukon watersheds begin with "YTHYDRO" while HUC8s are just numeric
@@ -1002,7 +1002,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
     Returns:
         JSON response with the following top-level keys:
         {
-            "gauge_id": null,
+            "gage_id": null,
             "huc8": null,
             "huc8_outlet": null,
             "hydrograph": ...,
@@ -1213,7 +1213,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
             }
 
         response = {
-            "gauge_id": stats.get("gauge_id"),
+            "gage_id": stats.get("gage_id"),
             "huc8": stats.get("watershed"),
             "huc8_outlet": stats.get("watershed_outlet"),
             "hydrograph": hydrograph,

--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -38,7 +38,7 @@ coverages = {
 stat_source_encodings = {
     "original_gcm": 0,
     "gcm_diff": 1,
-    "gcm_diff_applied_to_cheng": 2,
+    "gcm_diff_applied_to_blaskey": 2,
 }
 
 
@@ -486,14 +486,14 @@ def convert_doy_to_water_year_index(doy):
     return wy_index
 
 
-def calculate_and_apply_gcm_diffs_to_cheng_climatology(data_dict):
+def calculate_and_apply_gcm_diffs_to_blaskey_climatology(data_dict):
     """
-    Function to calculate GCM-projected changes in streamflow and apply them to the historical Cheng climatology.
+    Function to calculate GCM-projected changes in streamflow and apply them to the historical Blaskey climatology.
     Models without a '1990-2021' era (e.g. PGW models with no historical baseline) are silently skipped.
     Args:
         data_dict (dict): Climatology data dict keyed by model then era
     Returns:
-        dict: Adjusted data dict with Cheng baseline applied to all eligible models.
+        dict: Adjusted data dict with Blaskey baseline applied to all eligible models.
     """
     adjusted_data_dict = {}
     for model in data_dict.keys():
@@ -516,29 +516,29 @@ def calculate_and_apply_gcm_diffs_to_cheng_climatology(data_dict):
                 for stat in entry.keys():
                     if stat in ("doy", "water_year_index"):
                         continue
-                    cheng_historical = data_dict["historical"]["1990-2021"][i][stat]
+                    blaskey_historical = data_dict["historical"]["1990-2021"][i][stat]
                     gcm_historical = data_dict[model]["1990-2021"][i][stat]
                     gcm_projected = entry[stat]
                     denominator = gcm_historical
                     if denominator == 0:
                         denominator = 0.0001
                     projected_quotient = gcm_projected / denominator
-                    cheng_adjusted = round(cheng_historical * projected_quotient, 3)
-                    doy_stats[stat] = cheng_adjusted
+                    blaskey_adjusted = round(blaskey_historical * projected_quotient, 3)
+                    doy_stats[stat] = blaskey_adjusted
                 adjusted_data_dict[model][era].append(doy_stats)
     return adjusted_data_dict
 
 
-def calculate_and_apply_gcm_diffs_to_cheng_wt_climatology(data_dict):
+def calculate_and_apply_gcm_diffs_to_blaskey_wt_climatology(data_dict):
     """
-    Applies GCM-projected water temperature changes to the historical Cheng climatology
+    Applies GCM-projected water temperature changes to the historical Blaskey climatology
     using additive differences rather than the multiplicative ratios used for streamflow.
 
     Temperature deltas must be additive because water temperature is measured on an
     absolute scale (C). The upstream processing in the arctic_rivers repo
     (calculate_wt_stats.py) uses the same additive approach:
         gcm_diff = future − past
-        gcm_diff_applied_to_cheng = cheng_historical + gcm_diff
+        gcm_diff_applied_to_blaskey = blaskey_historical + gcm_diff
 
     Models without a '1990-2021' era (e.g. PGWh, PGWm) are absent from the returned
     dict entirely — they receive no entry, not even unadjusted values. A hydroviz-style
@@ -547,7 +547,7 @@ def calculate_and_apply_gcm_diffs_to_cheng_wt_climatology(data_dict):
     Args:
         data_dict (dict): DOY climatology data dict keyed by model then era
     Returns:
-        dict: Adjusted data dict with Cheng baseline applied to all eligible models.
+        dict: Adjusted data dict with Blaskey baseline applied to all eligible models.
     """
     adjusted_data_dict = {}
     for model in data_dict.keys():
@@ -570,11 +570,11 @@ def calculate_and_apply_gcm_diffs_to_cheng_wt_climatology(data_dict):
                 for stat in entry.keys():
                     if stat in ("doy", "water_year_index"):
                         continue
-                    cheng_historical = data_dict["historical"]["1990-2021"][i][stat]
+                    blaskey_historical = data_dict["historical"]["1990-2021"][i][stat]
                     gcm_historical = data_dict[model]["1990-2021"][i][stat]
                     gcm_projected = entry[stat]
                     gcm_delta = gcm_projected - gcm_historical
-                    doy_stats[stat] = round(cheng_historical + gcm_delta, 3)
+                    doy_stats[stat] = round(blaskey_historical + gcm_delta, 3)
                 adjusted_data_dict[model][era].append(doy_stats)
     return adjusted_data_dict
 
@@ -610,7 +610,7 @@ def package_metadata(ds, data_dict, source=None, var_context="streamflow"):
         source_notes = {
             "original_gcm": "Values are derived from the original GCM or PGW runs.",
             "gcm_diff": "Values are the ratio or absolute difference between the original GCM runs and the historical GCM runs - these are not actual statistic values! Apply these differences to a historical baseline value to approximate future values. PGW runs are not included.",
-            "gcm_diff_applied_to_cheng": "Values are derived from applying the GCM-projected changes to the historical Cheng baseline. PGW runs are not included.",
+            "gcm_diff_applied_to_blaskey": "Values are derived from applying the GCM-projected changes to the historical Blaskey baseline. PGW runs are not included.",
         }
 
         if source == "original_gcm":
@@ -623,10 +623,10 @@ def package_metadata(ds, data_dict, source=None, var_context="streamflow"):
                 "description"
             ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff']}"
 
-        if source == "gcm_diff_applied_to_cheng":
+        if source == "gcm_diff_applied_to_blaskey":
             data_dict["metadata"]["variables"][var][
                 "description"
-            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff_applied_to_cheng']}"
+            ] = f"{data_dict['metadata']['variables'][var]['description']} {source_notes['gcm_diff_applied_to_blaskey']}"
 
         # "doy" vars from hydrograph datasets
         if var in ["doy_min", "doy_mean", "doy_max"]:
@@ -710,7 +710,7 @@ def run_get_arctic_hydrology_stats_data(stream_id):
     # validate get request query parameters
     source = request.args.get("source", None)
     if source is None:
-        source = "gcm_diff_applied_to_cheng"
+        source = "gcm_diff_applied_to_blaskey"
 
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
@@ -787,7 +787,7 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
     # validate get request query parameters
     source = request.args.get("source", None)
     if source is None:
-        source = "gcm_diff_applied_to_cheng"
+        source = "gcm_diff_applied_to_blaskey"
     elif source == "gcm_diff":
         return render_template("400/bad_request.html"), 400
 
@@ -837,11 +837,11 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
             except Exception:
                 return render_template("500/server_error.html"), 500
 
-        # apply GCM-projected changes to Cheng climatology if source is "gcm_diff_applied_to_cheng"
+        # apply GCM-projected changes to Blaskey climatology if source is "gcm_diff_applied_to_blaskey"
         # PGW models without a 1990-2021 historical era are silently absent from this source;
         # they are only available via source=original_gcm.
-        if source == "gcm_diff_applied_to_cheng":
-            data_dict["data"] = calculate_and_apply_gcm_diffs_to_cheng_climatology(
+        if source == "gcm_diff_applied_to_blaskey":
+            data_dict["data"] = calculate_and_apply_gcm_diffs_to_blaskey_climatology(
                 data_dict["data"]
             )
 
@@ -865,7 +865,7 @@ def run_get_arctic_hydrology_wt_stats_data(stream_id):
     """
     source = request.args.get("source", None)
     if source is None:
-        source = "gcm_diff_applied_to_cheng"
+        source = "gcm_diff_applied_to_blaskey"
 
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
@@ -933,7 +933,7 @@ def run_get_arctic_hydrology_wt_modeled_climatology(stream_id):
     """
     source = request.args.get("source", None)
     if source is None:
-        source = "gcm_diff_applied_to_cheng"
+        source = "gcm_diff_applied_to_blaskey"
     elif source == "gcm_diff":
         return render_template("400/bad_request.html"), 400
 
@@ -980,8 +980,8 @@ def run_get_arctic_hydrology_wt_modeled_climatology(stream_id):
             except Exception:
                 return render_template("500/server_error.html"), 500
 
-        if source == "gcm_diff_applied_to_cheng":
-            data_dict["data"] = calculate_and_apply_gcm_diffs_to_cheng_wt_climatology(
+        if source == "gcm_diff_applied_to_blaskey":
+            data_dict["data"] = calculate_and_apply_gcm_diffs_to_blaskey_wt_climatology(
                 data_dict["data"]
             )
 
@@ -1019,7 +1019,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
     chart_era = "2034-2065"
     historical_era = "1990-2021"
 
-    # fetch stats with default source (gcm_diff_applied_to_cheng)
+    # fetch stats with default source (gcm_diff_applied_to_blaskey)
     stats_response = run_get_arctic_hydrology_stats_data(stream_id)
     if isinstance(stats_response, tuple):
         return stats_response
@@ -1027,7 +1027,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
     try:
         stats = stats_response.get_json()
 
-        # Fetch original_gcm stats to get PGW models (absent from gcm_diff_applied_to_cheng).
+        # Fetch original_gcm stats to get PGW models (absent from gcm_diff_applied_to_blaskey).
         # The describe call is a duplicate of what run_get_arctic_hydrology_stats_data already did,
         # but keeping the fetch inline here avoids a larger refactor of the route function.
         stats_decode_dict = asyncio.run(
@@ -1051,7 +1051,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
             if chart_era not in stats["data"].get(model, {}):
                 stats["data"][model] = model_data
 
-        # Fetch and decode climatology once; compute both Cheng-adjusted and original_gcm
+        # Fetch and decode climatology once; compute both Blaskey-adjusted and original_gcm
         # versions in memory rather than making two network calls (the doy_climatology coverage
         # has no source dimension, so both versions start from the same raw data).
         datasets = asyncio.run(
@@ -1069,17 +1069,17 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
 
         raw_data_dict = package_hydrograph_data(stream_id, decoded_datasets)
 
-        # Build Cheng-adjusted version; PGW models missing a 1990-2021 era are silently skipped.
-        cheng_adjusted = calculate_and_apply_gcm_diffs_to_cheng_climatology(
+        # Build Blaskey-adjusted version; PGW models missing a 1990-2021 era are silently skipped.
+        blaskey_adjusted = calculate_and_apply_gcm_diffs_to_blaskey_climatology(
             copy.deepcopy(raw_data_dict["data"])
         )
 
-        # Fill in PGW models (absent from cheng_adjusted) using their original_gcm values.
+        # Fill in PGW models (absent from blaskey_adjusted) using their original_gcm values.
         for model, model_data in raw_data_dict["data"].items():
-            if model not in cheng_adjusted:
-                cheng_adjusted[model] = model_data
+            if model not in blaskey_adjusted:
+                blaskey_adjusted[model] = model_data
 
-        climatology_data = cheng_adjusted
+        climatology_data = blaskey_adjusted
 
         historical_climatology = climatology_data["historical"][historical_era]
         historical_stats = stats["data"]["historical"]

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -20,8 +20,8 @@ from flask import (
 from generate_requests import generate_conus_hydrology_wcs_str
 from generate_urls import (
     generate_wfs_conus_hydrology_url,
-    generate_usgs_gauge_daily_streamflow_data_url,
-    generate_usgs_gauge_metadata_url,
+    generate_usgs_gage_daily_streamflow_data_url,
+    generate_usgs_gage_metadata_url,
 )
 from fetch_data import fetch_data, fetch_layer_data, describe_via_wcps
 from validate_request import get_axis_encodings
@@ -113,10 +113,10 @@ async def get_features(stream_id):
         return render_template("400/bad_request.html"), 400
 
 
-async def get_usgs_gauge_data(gauge_id):
+async def get_usgs_gage_data(gage_id):
 
-    gauge_data_dict = {
-        "id": gauge_id,
+    gage_data_dict = {
+        "id": gage_id,
         "name": None,
         "latitude": None,
         "longitude": None,
@@ -128,27 +128,27 @@ async def get_usgs_gauge_data(gauge_id):
     end_date = "2005-09-30"
 
     try:
-        metadata_url = generate_usgs_gauge_metadata_url(gauge_id)
-        data_url = generate_usgs_gauge_daily_streamflow_data_url(
-            gauge_id, start_date, end_date
+        metadata_url = generate_usgs_gage_metadata_url(gage_id)
+        data_url = generate_usgs_gage_daily_streamflow_data_url(
+            gage_id, start_date, end_date
         )
         async with ClientSession() as session:
-            gauge_metadata = await fetch_layer_data(metadata_url, session)
-            gauge_data = await fetch_layer_data(data_url, session)
+            gage_metadata = await fetch_layer_data(metadata_url, session)
+            gage_data = await fetch_layer_data(data_url, session)
     except:
         return render_template("400/bad_request.html"), 400
 
     # get metadata from JSON and populate dict
 
-    metadata_features = gauge_metadata.get("features")
+    metadata_features = gage_metadata.get("features")
     if not metadata_features:
         return render_template("400/bad_request.html"), 400
 
     metadata_feature = metadata_features[0]
-    gauge_data_dict["name"] = metadata_feature["properties"]["monitoring_location_name"]
+    gage_data_dict["name"] = metadata_feature["properties"]["monitoring_location_name"]
     coordinates = metadata_feature["geometry"]["coordinates"]
-    gauge_data_dict["longitude"] = round(float(coordinates[0]), 4)
-    gauge_data_dict["latitude"] = round(float(coordinates[1]), 4)
+    gage_data_dict["longitude"] = round(float(coordinates[0]), 4)
+    gage_data_dict["latitude"] = round(float(coordinates[1]), 4)
 
     # get streamflow data from JSON into dataframe
     date_range = pd.date_range(start_date, end=end_date, freq="D")
@@ -156,7 +156,7 @@ async def get_usgs_gauge_data(gauge_id):
     df.set_index("date", inplace=True)
     df["discharge_cfs"] = float("nan")
 
-    data_features = gauge_data.get("features")
+    data_features = gage_data.get("features")
     if not data_features:
         return render_template("400/bad_request.html"), 400
 
@@ -199,20 +199,20 @@ async def get_usgs_gauge_data(gauge_id):
     for row in rows:
         row["water_year_index"] = convert_doy_to_water_year_index(row["doy"])
 
-    gauge_data_dict["data"]["actual"] = {}
-    gauge_data_dict["data"]["actual"]["usgs"] = {}
-    gauge_data_dict["data"]["actual"]["usgs"]["observed"] = {}
-    gauge_data_dict["data"]["actual"]["usgs"]["observed"]["1976-2005"] = rows
+    gage_data_dict["data"]["actual"] = {}
+    gage_data_dict["data"]["actual"]["usgs"] = {}
+    gage_data_dict["data"]["actual"]["usgs"]["observed"] = {}
+    gage_data_dict["data"]["actual"]["usgs"]["observed"]["1976-2005"] = rows
 
     # populate metadata
     current_year = datetime.now().year
     current_date = datetime.now().strftime("%Y-%m-%d")
 
-    gauge_data_dict["metadata"]["source"] = {}
-    gauge_data_dict["metadata"]["source"][
+    gage_data_dict["metadata"]["source"] = {}
+    gage_data_dict["metadata"]["source"][
         "citation"
     ] = f"U.S. Geological Survey, {current_year}, U.S. Geological Survey National Water Information System database, accessed {current_date}, at https://doi.org/10.5066/F7P55KJN. Data download directly accessible at {data_url}"
-    gauge_data_dict["metadata"]["variables"] = {
+    gage_data_dict["metadata"]["variables"] = {
         "water_year_index": {
             "description": "Water year day index (1-366), where the water year starts on October 1 (DOY 275) and ends on September 30 (DOY 274).",
             "units": "dimensionless",
@@ -230,9 +230,9 @@ async def get_usgs_gauge_data(gauge_id):
             "units": "cfs",
         },
     }
-    gauge_data_dict["metadata"]["percent_complete"] = round(pct_complete, 2)
+    gage_data_dict["metadata"]["percent_complete"] = round(pct_complete, 2)
 
-    return gauge_data_dict
+    return gage_data_dict
 
 
 def package_stats_data(stream_id, ds):
@@ -995,18 +995,18 @@ def run_get_conus_hydrology_modeled_climatology(stream_id):
 
 
 @routes.route("/conus_hydrology/observed_climatology/<stream_id>")
-def run_get_conus_hydrology_gauge_data(stream_id):
+def run_get_conus_hydrology_gage_data(stream_id):
     """
-    Function to fetch USGS stream gauge data associated with a single stream ID.
+    Function to fetch USGS stream gage data associated with a single stream ID.
     Example URL: http://localhost:5000/conus_hydrology/observed_climatology/50563
-    (should fetch associated gauge: USGS-12039500, QUINAULT RIVER AT QUINAULT LAKE, WA)
+    (should fetch associated gage: USGS-12039500, QUINAULT RIVER AT QUINAULT LAKE, WA)
     Args:
         stream_id (str): Stream ID for the hydrology data
     Returns:
-        JSON response with USGS stream gauge data associated with the requested stream ID.
+        JSON response with USGS stream gage data associated with the requested stream ID.
         Results are an observed daily climatology for the period 1976-2005, packaged identically to
         the modeled daily climatology data.
-        If no gauge is associated with the stream ID, a 404 response is returned.
+        If no gage is associated with the stream ID, a 404 response is returned.
     """
     if not stream_id.isdigit():
         return render_template("400/bad_request.html"), 400
@@ -1016,25 +1016,25 @@ def run_get_conus_hydrology_gauge_data(stream_id):
         return gdf  # return 400 if gdf is a tuple
 
     try:
-        gauge_id = gdf.loc[0].GAUGE_ID
-        if gauge_id is None or gauge_id == "NA":
+        gage_id = gdf.loc[0].GAGE_ID
+        if gage_id is None or gage_id == "NA":
             return render_template("404/no_data.html"), 404
 
-        gauge_data_dict = asyncio.run(get_usgs_gauge_data(gauge_id))
-        if isinstance(gauge_data_dict, tuple):
-            return gauge_data_dict  # return 400 if gauge_data_dict is a tuple
+        gage_data_dict = asyncio.run(get_usgs_gage_data(gage_id))
+        if isinstance(gage_data_dict, tuple):
+            return gage_data_dict  # return 400 if gage_data_dict is a tuple
 
         if request.args.get("format") == "csv":
             try:
                 return create_csv(
-                    data=gauge_data_dict,
+                    data=gage_data_dict,
                     endpoint="conus_hydrology",
                     filename_prefix="Observed Daily Climatology",
-                    place_id=stream_id + " (" + gauge_id + ")",
-                    lat=str(gauge_data_dict["latitude"]),
-                    lon=str(gauge_data_dict["longitude"]),
+                    place_id=stream_id + " (" + gage_id + ")",
+                    lat=str(gage_data_dict["latitude"]),
+                    lon=str(gage_data_dict["longitude"]),
                     source_metadata={
-                        "percent_complete": gauge_data_dict["metadata"][
+                        "percent_complete": gage_data_dict["metadata"][
                             "percent_complete"
                         ]
                     },
@@ -1043,7 +1043,7 @@ def run_get_conus_hydrology_gauge_data(stream_id):
             except Exception as exc:
                 return render_template("500/server_error.html"), 500
 
-        return jsonify(gauge_data_dict)
+        return jsonify(gage_data_dict)
 
     except Exception as exc:
         if hasattr(exc, "status") and exc.status == 404:
@@ -1051,31 +1051,31 @@ def run_get_conus_hydrology_gauge_data(stream_id):
         return render_template("500/server_error.html"), 500
 
 
-@routes.route("/conus_hydrology/gauge_info")
-def run_get_conus_hydrology_gauge_info():
+@routes.route("/conus_hydrology/gage_info")
+def run_get_conus_hydrology_gage_info():
     """
-    Function to fetch all stream segment attributes and create a reference to associate USGS stream gauges.
-    Example URL: http://localhost:5000/conus_hydrology/gauge_info
+    Function to fetch all stream segment attributes and create a reference to associate USGS stream gages.
+    Example URL: http://localhost:5000/conus_hydrology/gage_info
     Args:
         None
     Returns:
-        JSON response that lists all stream IDs with associated gauges. Each stream ID key
-        maps to a list of dictionaries with the gauge name and USGS gauge ID. A small number of
-        stream IDs are associated with more than one gauge. If a stream has no associated gauges,
+        JSON response that lists all stream IDs with associated gages. Each stream ID key
+        maps to a list of dictionaries with the gage name and USGS gage ID. A small number of
+        stream IDs are associated with more than one gage. If a stream has no associated gages,
         it is not included in the response.
     """
     try:
         gdf = asyncio.run(get_features(""))  # omit ID to fetch all stream attributes
         if isinstance(gdf, tuple):
             return gdf  # return 400 if gdf is a tuple
-        gauges_gdf = gdf[gdf["GAUGE_ID"].notnull() & (gdf["GAUGE_ID"] != "NA")]
+        gages_gdf = gdf[gdf["GAGE_ID"].notnull() & (gdf["GAGE_ID"] != "NA")]
         result = (
-            gauges_gdf[["seg_id_nat", "GNIS_NAME", "GAUGE_ID"]]
-            .rename(columns={"GNIS_NAME": "name", "GAUGE_ID": "usgs_gauge_id"})
+            gages_gdf[["seg_id_nat", "GNIS_NAME", "GAGE_ID"]]
+            .rename(columns={"GNIS_NAME": "name", "GAGE_ID": "usgs_gage_id"})
             .groupby("seg_id_nat")
             .apply(
                 lambda x: x.drop(columns="seg_id_nat").to_dict(orient="records")
-            )  # allows for >1 gauge per stream, e.g. stream ID 29526
+            )  # allows for >1 gage per stream, e.g. stream ID 29526
             .to_dict()
         )
         return jsonify(result)
@@ -1318,7 +1318,7 @@ def fetch_all_hydroviz_route(stream_id):
                             "max": round(max(values), 3),
                         }
 
-        gauge_id = None
+        gage_id = None
         h8_outlet = False
         huc8 = None
 
@@ -1326,12 +1326,12 @@ def fetch_all_hydroviz_route(stream_id):
         if not isinstance(gdf, tuple):
             if gdf.loc[0].h8_outlet == 1:
                 h8_outlet = True
-            if gdf.loc[0].GAUGE_ID != "NA":
-                gauge_id = gdf.loc[0].GAUGE_ID
+            if gdf.loc[0].GAGE_ID != "NA":
+                gage_id = gdf.loc[0].GAGE_ID
             huc8 = gdf.loc[0].huc8
 
         response = {
-            "gauge_id": gauge_id,
+            "gage_id": gage_id,
             "h8_outlet": h8_outlet,
             "huc8": huc8,
             "hydrograph": hydrograph,

--- a/templates/documentation/arctic_hydrology.html
+++ b/templates/documentation/arctic_hydrology.html
@@ -11,7 +11,7 @@
   climate data using the SSP3-7.0 scenario. Four Community Earth System Model 2
   (CESM2) runs are included, as well as two pseudo-global warming (PGW) runs
   based on the CESM2 Large Ensemble using the SSP2-4.5 scenario. A dynamically
-  downscaled ERA5 baseline (Cheng) is available for the historical period.
+  downscaled ERA5 baseline (Blaskey) is available for the historical period.
 </p>
 
 <!-- TODO: create a way for users to find the stream IDs for streams of interest, and reference it here -->
@@ -59,8 +59,8 @@
         parameter. Accepted values are:
         <ul>
           <li>
-            <code>gcm_diff_applied_to_cheng</code> (default) &mdash;
-            GCM-projected changes applied to the historical Cheng baseline. PGW
+            <code>gcm_diff_applied_to_blaskey</code> (default) &mdash;
+            GCM-projected changes applied to the historical Blaskey baseline. PGW
             models are not included.
           </li>
           <li>
@@ -116,8 +116,8 @@
         parameter. Accepted values are:
         <ul>
           <li>
-            <code>gcm_diff_applied_to_cheng</code> (default) &mdash;
-            GCM-projected changes applied to the historical Cheng baseline. PGW
+            <code>gcm_diff_applied_to_blaskey</code> (default) &mdash;
+            GCM-projected changes applied to the historical Blaskey baseline. PGW
             models are not included.
           </li>
           <li>
@@ -167,8 +167,8 @@
         parameter. Accepted values are:
         <ul>
           <li>
-            <code>gcm_diff_applied_to_cheng</code> (default) &mdash;
-            GCM-projected changes applied to the historical Cheng baseline. PGW
+            <code>gcm_diff_applied_to_blaskey</code> (default) &mdash;
+            GCM-projected changes applied to the historical Blaskey baseline. PGW
             models are not included.
           </li>
           <li>
@@ -224,8 +224,8 @@
         parameter. Accepted values are:
         <ul>
           <li>
-            <code>gcm_diff_applied_to_cheng</code> (default) &mdash;
-            GCM-projected changes applied to the historical Cheng baseline. PGW
+            <code>gcm_diff_applied_to_blaskey</code> (default) &mdash;
+            GCM-projected changes applied to the historical Blaskey baseline. PGW
             models are not included.
           </li>
           <li>

--- a/templates/documentation/conus_hydrology.html
+++ b/templates/documentation/conus_hydrology.html
@@ -21,11 +21,11 @@
 
 <p>
   We also include endpoints to access daily streamflow climatologies from
-  associated USGS stream gauge data collected over the 1976&ndash;2005
+  associated USGS stream gage data collected over the 1976&ndash;2005
   historical period, for use in comparing with the modeled data. Note that not
-  all modeled stream segments have associated gauge data. See the
-  <a href="/conus_hydrology/gauge_info">/conus_hydrology/gauge_info</a> endpoint
-  for a list of all stream IDs with gauge data.
+  all modeled stream segments have associated gage data. See the
+  <a href="/conus_hydrology/gage_info">/conus_hydrology/gage_info</a> endpoint
+  for a list of all stream IDs with gage data.
 </p>
 
 <h3>Service endpoints</h3>
@@ -137,7 +137,7 @@
 <h4>Observed daily streamflow climatologies by stream ID</h4>
 
 <p>
-  Query daily streamflow climatologies computed from observed USGS stream gauge
+  Query daily streamflow climatologies computed from observed USGS stream gage
   data. Useful for constructing hydrographs. Minimum, maximum, and mean values
   for each day of year are computed over the 1976&ndash;2005 historical era.
 </p>
@@ -165,8 +165,8 @@
         CSV output is also available by appending <code>?format=csv</code> to
         the URL. <br />
         See
-        <a href="/conus_hydrology/gauge_info">/conus_hydrology/gauge_info</a>
-        for a list of all stream IDs with gauge data.
+        <a href="/conus_hydrology/gage_info">/conus_hydrology/gage_info</a>
+        for a list of all stream IDs with gage data.
       </td>
     </tr>
   </tfoot>
@@ -479,8 +479,8 @@
 
 <p>
   Note that the latitude and longitude values represent the location of the
-  stream gauge. Also note that the climatology is constructed from all available
-  data from 1976&ndash;2005, but some gauges may not have a complete record for
+  stream gage. Also note that the climatology is constructed from all available
+  data from 1976&ndash;2005, but some gages may not have a complete record for
   this time period. Use the <code>percent_complete</code> value to assess the
   data completeness. The above output is structured like this:
 </p>
@@ -506,9 +506,9 @@
       ...
     },
   },
-  "id": &lt;USGS stream gauge ID&gt;,
-  "latitude": &lt;latitude of stream gauge&gt;,
-  "longitude": &lt;longitude of stream gauge&gt;,
+  "id": &lt;USGS stream gage ID&gt;,
+  "latitude": &lt;latitude of stream gage&gt;,
+  "longitude": &lt;longitude of stream gage&gt;,
   "metadata": {
     "percent_complete": &lt;percent of data available for period&gt;,
     "source": {
@@ -521,7 +521,7 @@
       },
     },
   }
-  "name": &lt;name of stream gauge&gt;
+  "name": &lt;name of stream gage&gt;
 }
 </pre>
 


### PR DESCRIPTION
Xref: https://github.com/ua-snap/hydroviz/issues/210
Xref: https://github.com/ua-snap/hydroviz/pull/246

This PR updates hydroviz-related endpoints to use the latest GeoServer layers, which have updated the word "Gauge" to its proper USGS spelling, "Gage", throughout. All references to "gauge" have been updated to "gage" in the Data API code also.

This PR also incorporates work from a branch Josh put together a few weeks back, which corrects all references from "Cheng" to "Blaskey" throughout the code to correct our citation for the Arctic Rivers dataset.

To test, point the `gage_not_gauge` branch of the hydroviz webapp against this `gage_not_gauge` branch of the Data API and confirm that everything still works as expected by loading some Alaska stream segments.