### PR TITLE
Remove unused stats table data from CONUS and Alaska hydroviz endpoints

### DIFF
--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -1227,9 +1227,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
 
         for stat, values in stat_arrays.items():
             table_stats["projected"][chart_era][stat] = {
-                "min": round(min(values), 3),
                 "median": round(statistics.median(values), 3),
-                "max": round(max(values), 3),
             }
 
         ########## Populate arrays for water temperature hydrograph. ##########
@@ -1343,9 +1341,7 @@ def run_get_arctic_hydrology_hydroviz(stream_id):
 
         for stat, values in wt_stat_arrays.items():
             wt_table_stats["projected"][chart_era][stat] = {
-                "min": round(min(values), 3),
                 "median": round(statistics.median(values), 3),
-                "max": round(max(values), 3),
             }
 
         response = {

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -1295,12 +1295,6 @@ def fetch_all_hydroviz_route(stream_id):
                             model_stats[scenario][era][stat]
                         )
 
-        aggregation_stats = {
-            "rcp45": "min",
-            "rcp60": "median",
-            "rcp85": "max"
-        }
-
         for scenario in scenario_stat_arrays.keys():
             for era in scenario_stat_arrays[scenario].keys():
                 if era not in table_stats["projected"]:
@@ -1310,18 +1304,12 @@ def fetch_all_hydroviz_route(stream_id):
                 for stat in scenario_stat_arrays[scenario][era].keys():
                     table_stats["projected"][era][scenario][stat] = {}
                     values = scenario_stat_arrays[scenario][era][stat]
-                    aggr_stat = aggregation_stats[scenario]
                     if all(v is None for v in values):
-                        table_stats["projected"][era][scenario][stat][aggr_stat] = None
+                        table_stats["projected"][era][scenario][stat]["median"] = None
                         continue
                     values = [v for v in values if v is not None]
-                    if scenario == "rcp45":
-                        aggr_value = round(min(values), 3)
-                    elif scenario == "rcp60":
-                        aggr_value = round(statistics.median(values), 3)
-                    elif scenario == "rcp85":
-                        aggr_value = round(max(values), 3)
-                    table_stats["projected"][era][scenario][stat][aggr_stat] = aggr_value
+                    median_value = round(statistics.median(values), 3)
+                    table_stats["projected"][era][scenario][stat]["median"] = median_value
 
         gage_id = None
         h8_outlet = False

--- a/routes/conus_hydrology.py
+++ b/routes/conus_hydrology.py
@@ -1295,6 +1295,12 @@ def fetch_all_hydroviz_route(stream_id):
                             model_stats[scenario][era][stat]
                         )
 
+        aggregation_stats = {
+            "rcp45": "min",
+            "rcp60": "median",
+            "rcp85": "max"
+        }
+
         for scenario in scenario_stat_arrays.keys():
             for era in scenario_stat_arrays[scenario].keys():
                 if era not in table_stats["projected"]:
@@ -1302,21 +1308,20 @@ def fetch_all_hydroviz_route(stream_id):
                 if scenario not in table_stats["projected"][era]:
                     table_stats["projected"][era][scenario] = {}
                 for stat in scenario_stat_arrays[scenario][era].keys():
+                    table_stats["projected"][era][scenario][stat] = {}
                     values = scenario_stat_arrays[scenario][era][stat]
+                    aggr_stat = aggregation_stats[scenario]
                     if all(v is None for v in values):
-                        table_stats["projected"][era][scenario][stat] = {
-                            "min": None,
-                            "median": None,
-                            "max": None,
-                        }
-                    else:
-                        # If values are not all None, calculate min/median/max using non-None values.
-                        values = [v for v in values if v is not None]
-                        table_stats["projected"][era][scenario][stat] = {
-                            "min": round(min(values), 3),
-                            "median": round(statistics.median(values), 3),
-                            "max": round(max(values), 3),
-                        }
+                        table_stats["projected"][era][scenario][stat][aggr_stat] = None
+                        continue
+                    values = [v for v in values if v is not None]
+                    if scenario == "rcp45":
+                        aggr_value = round(min(values), 3)
+                    elif scenario == "rcp60":
+                        aggr_value = round(statistics.median(values), 3)
+                    elif scenario == "rcp85":
+                        aggr_value = round(max(values), 3)
+                    table_stats["projected"][era][scenario][stat][aggr_stat] = aggr_value
 
         gage_id = None
         h8_outlet = False


### PR DESCRIPTION
Closes https://github.com/ua-snap/data-api/issues/733

Before this PR, min/median/max values were included for every scenario in the CONUS and Alaska stats table data. We ended up using only the median values across the board in the hydroviz webapp. So, this PR removes all min & max data to reduce unnecessary computation and make the data response a bit smaller.

To test, run the hydroviz webapp against this `unused_hydroviz_data` Data API branch and verify that CONUS and Alaska stats tables are still populating without errors.