### PR TITLE
Fix arctic_hydrology climatology Blaskey-adjusted JSON vs. original GCM CSV  discrepancies

### DIFF
--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -823,6 +823,14 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
         data_dict = populate_feature_attributes(data_dict, gdf)
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
+        # apply GCM-projected changes to Blaskey climatology if source is "gcm_diff_applied_to_blaskey"
+        # PGW models without a 1990-2021 historical era are silently absent from this source;
+        # they are only available via source=original_gcm.
+        if source == "gcm_diff_applied_to_blaskey":
+            data_dict["data"] = calculate_and_apply_gcm_diffs_to_blaskey_climatology(
+                data_dict["data"]
+            )
+
         if request.args.get("format") == "csv":
             try:
                 return create_csv(
@@ -836,14 +844,6 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
                 )
             except Exception:
                 return render_template("500/server_error.html"), 500
-
-        # apply GCM-projected changes to Blaskey climatology if source is "gcm_diff_applied_to_blaskey"
-        # PGW models without a 1990-2021 historical era are silently absent from this source;
-        # they are only available via source=original_gcm.
-        if source == "gcm_diff_applied_to_blaskey":
-            data_dict["data"] = calculate_and_apply_gcm_diffs_to_blaskey_climatology(
-                data_dict["data"]
-            )
 
         return jsonify(data_dict)
 
@@ -966,6 +966,11 @@ def run_get_arctic_hydrology_wt_modeled_climatology(stream_id):
         data_dict = populate_feature_attributes(data_dict, gdf)
         data_dict = prune_nulls_with_max_intensity(data_dict)
 
+        if source == "gcm_diff_applied_to_blaskey":
+            data_dict["data"] = calculate_and_apply_gcm_diffs_to_blaskey_wt_climatology(
+                data_dict["data"]
+            )
+
         if request.args.get("format") == "csv":
             try:
                 return create_csv(
@@ -979,11 +984,6 @@ def run_get_arctic_hydrology_wt_modeled_climatology(stream_id):
                 )
             except Exception:
                 return render_template("500/server_error.html"), 500
-
-        if source == "gcm_diff_applied_to_blaskey":
-            data_dict["data"] = calculate_and_apply_gcm_diffs_to_blaskey_wt_climatology(
-                data_dict["data"]
-            )
 
         return jsonify(data_dict)
 

--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -400,6 +400,10 @@ def package_stats_data(stream_id, ds):
                 if not np.isnan(v)
             }
 
+    # Move the historical model above the rest.
+    historical_data = stats_dict["data"].pop("historical")
+    stats_dict["data"] = {"historical": historical_data, **stats_dict["data"]}
+
     return stats_dict
 
 
@@ -466,6 +470,10 @@ def package_hydrograph_data(stream_id, datasets):
                     rows.append(entry)
 
                 model_dict[era] = rows
+
+    # Move the historical model above the rest.
+    historical_data = hydrograph_dict["data"].pop("historical")
+    hydrograph_dict["data"] = {"historical": historical_data, **hydrograph_dict["data"]}
 
     return hydrograph_dict
 


### PR DESCRIPTION
This PR fixes the discrepancy in values between outputs of these two URLs (for example):

http://localhost:5000/arctic_hydrology/modeled_climatology/81009008
http://localhost:5000/arctic_hydrology/modeled_climatology/81009008?format=csv

The problem was that the `gcm_diff_applied_to_blaskey` adjustment was being done after the CSV export code, not before, for both the `modeled_climatology` and `wt_modeled_climatology` endpoints.

I've also added a couple chunks of code to move the "historical" model above the projected models in the CSVs to make them more intuitive and consistent with our other CSVs.

To test, I pointed the hydroviz webapp at this `json_csv_discrepancy` Data API branch and disabled LOWESS smoothing + enabled hovermode to cross reference values from the hydrographs & water temperature hydrographs with their corresponding CSVs to make sure that the same values appear on the same dates. I also cross-referenced a handful of flow & temperature stat table values against their corresponding CSVs. Everything is as expected!