### PR TITLE
Don't cache error responses, and return accurate error codes from Arctic hydrology endpoints

### DIFF
--- a/application.py
+++ b/application.py
@@ -200,8 +200,14 @@ def validate_get_params():
 
 @app.after_request
 def add_cache_control(response):
-    # Set cache control headers here
-    response.cache_control.max_age = 7776000
+    if response.status_code == 200:
+        response.cache_control.max_age = 7776000
+    else:
+        # Errors are often transient (upstream hiccups), so keep them out of
+        # long-lived caches: a cached error would otherwise be served for the
+        # full max-age even after the upstream recovered. The short TTL still
+        # shields upstreams from request storms during a real outage.
+        response.cache_control.max_age = 60
     return response
 
 

--- a/routes/arctic_hydrology.py
+++ b/routes/arctic_hydrology.py
@@ -96,18 +96,26 @@ async def get_features(stream_id):
     Args:
         stream_id (str): Stream ID for the hydrology data
     Returns:
-        geopandas GeoDataFrame with the vector features, or 400."""
+        geopandas GeoDataFrame with the vector features, or an error response
+        tuple: 502 if the WFS fetch fails, 404 if the stream ID has no
+        features."""
     try:
         url = generate_wfs_arctic_hydrology_url(stream_id)
 
         async with ClientSession() as session:
             layer_data = await fetch_layer_data(url, session)
-        gdf = gpd.GeoDataFrame.from_features(layer_data["features"], crs="EPSG:3338")
-        gdf["geometry"] = gdf["geometry"].make_valid()
-
-        return gdf
     except Exception:
-        return render_template("400/bad_request.html"), 400
+        # WFS/upstream failure - a server-side problem, not a bad request.
+        return render_template("502/upstream_unreachable.html"), 502
+
+    if not layer_data.get("features"):
+        # Valid query, but no such stream ID.
+        return render_template("404/no_data.html"), 404
+
+    gdf = gpd.GeoDataFrame.from_features(layer_data["features"], crs="EPSG:3338")
+    gdf["geometry"] = gdf["geometry"].make_valid()
+
+    return gdf
 
 
 async def get_stats_features(stream_id):
@@ -717,7 +725,7 @@ def run_get_arctic_hydrology_stats_data(stream_id):
 
     gdf = asyncio.run(get_features(stream_id))
     if isinstance(gdf, tuple):
-        return gdf  # return 400 if gdf is a tuple
+        return gdf  # error response (502/404) if gdf is a tuple
 
     stats_gdf = asyncio.run(get_stats_features(stream_id))
 
@@ -796,7 +804,7 @@ def run_get_arctic_hydrology_modeled_climatology(stream_id):
 
     gdf = asyncio.run(get_features(stream_id))
     if isinstance(gdf, tuple):
-        return gdf  # return 400 if gdf is a tuple
+        return gdf  # error response (502/404) if gdf is a tuple
 
     try:
         # fetch data and metadata


### PR DESCRIPTION
> [!NOTE]
> This PR was AI-generated (Claude Code) and human-reviewed before submission.

## Summary

Two related fixes around error handling:

- **Error responses are no longer cached for 90 days.** The `after_request` hook set `Cache-Control: max-age=7776000` on every response, including errors. A transient upstream hiccup could therefore be served from cache for months after the upstream recovered. Now only 200 responses get the 90-day max-age; everything else gets a 60-second max-age — short enough to recover quickly, long enough to shield upstreams from request storms during a real outage.
- **Arctic hydrology endpoints return accurate error codes.** `get_features()` in `routes/arctic_hydrology.py` returned `400 Bad Request` for every failure, whether the WFS fetch to GeoServer failed or the stream ID simply had no features. It now returns **502 Upstream Data Unreachable** for fetch failures and **404 No Data** for unknown stream IDs (both using existing templates). The two `isinstance(gdf, tuple)` early-return comments in the stats and modeled-climatology routes are updated to match.

## Manual testing

1. Run the API locally:
   ```
   micromamba activate api-env
   export FLASK_APP=application.py
   export FLASK_DEBUG=True
   flask run
   ```
2. **200 + long cache:** `curl -sI http://localhost:5000/arctic_hydrology/stats/81000004` — expect `200` and `Cache-Control: max-age=7776000`.
3. **404 + short cache:** `curl -sI http://localhost:5000/arctic_hydrology/stats/1` (a stream ID with no features) — expect `404` and `Cache-Control: max-age=60`, and the "No data" page in a browser.
4. **502 + short cache:** restart Flask with GeoServer pointed somewhere unreachable, e.g. `export API_GS_BASE_URL=http://localhost:9999/`, then repeat the request from step 2 — expect `502` and `Cache-Control: max-age=60`, and the "Upstream Data Unreachable" page in a browser. Unset `API_GS_BASE_URL` afterwards.
5. Spot-check that an unrelated non-hydrology endpoint still returns `Cache-Control: max-age=7776000` on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)